### PR TITLE
Undefined names: Add missing imports

### DIFF
--- a/mindsdb/proxies/mysql/data_types/mysql_packets/eof_packet.py
+++ b/mindsdb/proxies/mysql/data_types/mysql_packets/eof_packet.py
@@ -9,6 +9,8 @@
  *******************************************************
 """
 
+from mindsdb.libs.helpers.logging import logging
+from mindsdb.proxies.mysql.data_types.mysql_datum import Datum
 from mindsdb.mindsdb_server.proxies.mysql.data_types.mysql_packet import Packet
 
 

--- a/mindsdb/proxies/mysql/data_types/mysql_packets/err_packet.py
+++ b/mindsdb/proxies/mysql/data_types/mysql_packets/err_packet.py
@@ -9,6 +9,8 @@
  *******************************************************
 """
 
+from mindsdb.libs.helpers.logging import logging
+from mindsdb.proxies.mysql.data_types.mysql_datum import Datum
 from mindsdb.mindsdb_server.proxies.mysql.data_types.mysql_packet import Packet
 
 

--- a/mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py
+++ b/mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py
@@ -9,6 +9,12 @@
  *******************************************************
 """
 
+from mindsdb.libs.constants import (DEFAULT_CAPABILITIES,
+                                    DEFAULT_COALLITION_ID,
+                                    FILLER_FOR_WIRESHARK_DUMP,
+                                    SERVER_STATUS_AUTOCOMMIT)
+from mindsdb.libs.helpers.logging import logging
+from mindsdb.proxies.mysql.data_types.mysql_datum import Datum
 from mindsdb.mindsdb_server.proxies.mysql.data_types.mysql_packet import Packet
 
 

--- a/mindsdb/proxies/mysql/data_types/mysql_packets/handshake_response_packet.py
+++ b/mindsdb/proxies/mysql/data_types/mysql_packets/handshake_response_packet.py
@@ -12,6 +12,8 @@
 import traceback
 from pprint import pformat
 
+from mindsdb.libs.helpers.logging import logging
+from mindsdb.proxies.mysql.data_types.mysql_datum import Datum
 from mindsdb.mindsdb_server.proxies.mysql.data_types.mysql_packet import Packet
 
 from external_libs.mysql_scramble import scramble, scramble_323

--- a/mindsdb/proxies/mysql/data_types/mysql_packets/ok_packet.py
+++ b/mindsdb/proxies/mysql/data_types/mysql_packets/ok_packet.py
@@ -9,6 +9,8 @@
  *******************************************************
 """
 
+from mindsdb.libs.helpers.logging import logging
+from mindsdb.proxies.mysql.data_types.mysql_datum import Datum
 from mindsdb.mindsdb_server.proxies.mysql.data_types.mysql_packet import Packet
 
 

--- a/mindsdb/proxies/mysql/data_types/mysql_packets/switch_auth_packet.py
+++ b/mindsdb/proxies/mysql/data_types/mysql_packets/switch_auth_packet.py
@@ -9,6 +9,8 @@
  *******************************************************
 """
 
+from mindsdb.libs.helpers.logging import logging
+from mindsdb.proxies.mysql.data_types.mysql_datum import Datum
 from mindsdb.mindsdb_server.proxies.mysql.data_types.mysql_packet import Packet
 
 
@@ -52,6 +54,3 @@ class SwitchOutPacket(Packet):
 # only run the test if this file is called from debugger
 if __name__ == "__main__":
     SwitchOutPacket.test()
-
-
-


### PR DESCRIPTION
_Undefined names_ have the potential to raise __NameError__ at runtime.  Could not discover where in this repo __MAX_LENGTH__ is defined .  The undefined names in __mysql_scramble.py__ occur because the Python porting best practice [use feature detection instead of version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection) was not followed.  Wildcard (*) imports are probably masking other _undefined names_.

[flake8](http://flake8.pycqa.org) testing of https://github.com/mindsdb/mindsdb on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./mindsdb/libs/ml_models/pytorch/encoders/rnn/decoder_rnn.py:10:76: F821 undefined name 'MAX_LENGTH'
    def __init__(self, hidden_size, output_size, dropout_p=0.1, max_length=MAX_LENGTH):
                                                                           ^
./mindsdb/external_libs/mysql_scramble.py:39:18: F821 undefined name 'xrange'
    range_type = xrange
                 ^
./mindsdb/external_libs/mysql_scramble.py:40:17: F821 undefined name 'unicode'
    text_type = unicode
                ^
./mindsdb/external_libs/mysql_scramble.py:41:17: F821 undefined name 'long'
    long_type = long
                ^
./mindsdb/external_libs/mysql_scramble.py:42:16: F821 undefined name 'basestring'
    str_type = basestring
               ^
./mindsdb/proxies/mysql/data_types/mysql_packets/ok_packet.py:39:26: F821 undefined name 'Datum'
        self.ok_header = Datum('int<1>', 0)
                         ^
./mindsdb/proxies/mysql/data_types/mysql_packets/ok_packet.py:40:30: F821 undefined name 'Datum'
        self.affected_rows = Datum('int<lenenc>', 0)
                             ^
./mindsdb/proxies/mysql/data_types/mysql_packets/ok_packet.py:41:31: F821 undefined name 'Datum'
        self.last_insert_id = Datum('int<lenenc>', 0)
                              ^
./mindsdb/proxies/mysql/data_types/mysql_packets/ok_packet.py:42:30: F821 undefined name 'Datum'
        self.server_status = Datum('int<2>', 0)
                             ^
./mindsdb/proxies/mysql/data_types/mysql_packets/ok_packet.py:43:30: F821 undefined name 'Datum'
        self.warning_count = Datum('int<2>', 0)
                             ^
./mindsdb/proxies/mysql/data_types/mysql_packets/ok_packet.py:44:21: F821 undefined name 'Datum'
        self.info = Datum('string<EOF>')
                    ^
./mindsdb/proxies/mysql/data_types/mysql_packets/ok_packet.py:71:9: F821 undefined name 'logging'
        logging.basicConfig(level=10)
        ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_response_packet.py:47:29: F821 undefined name 'Datum'
        self.capabilities = Datum('int<4>')
                            ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_response_packet.py:48:25: F821 undefined name 'Datum'
        self.reserved = Datum(reserved_type)
                        ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_response_packet.py:49:25: F821 undefined name 'Datum'
        self.username = Datum('string<NUL>')
                        ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_response_packet.py:50:29: F821 undefined name 'Datum'
        self.enc_password = Datum(enc_pass_type)
                            ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_response_packet.py:51:25: F821 undefined name 'Datum'
        self.database = Datum('string<NUL>')
                        ^
./mindsdb/proxies/mysql/data_types/mysql_packets/err_packet.py:31:27: F821 undefined name 'Datum'
        self.err_header = Datum('int<1>', 255)
                          ^
./mindsdb/proxies/mysql/data_types/mysql_packets/err_packet.py:32:25: F821 undefined name 'Datum'
        self.err_code = Datum('int<2>',err_code)
                        ^
./mindsdb/proxies/mysql/data_types/mysql_packets/err_packet.py:33:20: F821 undefined name 'Datum'
        self.msg = Datum('string<EOF>', msg)
                   ^
./mindsdb/proxies/mysql/data_types/mysql_packets/err_packet.py:55:9: F821 undefined name 'logging'
        logging.basicConfig(level=10)
        ^
./mindsdb/proxies/mysql/data_types/mysql_packets/switch_auth_packet.py:25:27: F821 undefined name 'Datum'
        self.eof_header = Datum('int<1>', int('0xfe',0))
                          ^
./mindsdb/proxies/mysql/data_types/mysql_packets/switch_auth_packet.py:26:43: F821 undefined name 'Datum'
        self.authentication_plugin_name = Datum('string<NUL>', 'mysql_native_password')
                                          ^
./mindsdb/proxies/mysql/data_types/mysql_packets/switch_auth_packet.py:27:21: F821 undefined name 'Datum'
        self.seed = Datum('string<NUL>', seed)
                    ^
./mindsdb/proxies/mysql/data_types/mysql_packets/switch_auth_packet.py:48:9: F821 undefined name 'logging'
        logging.basicConfig(level=10)
        ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:24:33: F821 undefined name 'Datum'
        self.protocol_version = Datum('int<1>', 10)
                                ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:25:31: F821 undefined name 'Datum'
        self.server_version = Datum('string<NUL>', '5.7.1-MindsDB-1.0')
                              ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:26:30: F821 undefined name 'Datum'
        self.connection_id = Datum('int<4>', self.proxy.connection_id)
                             ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:27:34: F821 undefined name 'Datum'
        self.scramble_1st_part = Datum('string<8>', self.proxy.salt[:8])
                                 ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:28:30: F821 undefined name 'Datum'
        self.reserved_byte = Datum('string<1>', '')
                             ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:29:45: F821 undefined name 'Datum'
        self.server_capabilities_1st_part = Datum(
                                            ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:30:23: F821 undefined name 'DEFAULT_CAPABILITIES'
            'int<2>', DEFAULT_CAPABILITIES)
                      ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:31:41: F821 undefined name 'Datum'
        self.server_default_collation = Datum('int<1>', DEFAULT_COALLITION_ID)
                                        ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:31:57: F821 undefined name 'DEFAULT_COALLITION_ID'
        self.server_default_collation = Datum('int<1>', DEFAULT_COALLITION_ID)
                                                        ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:32:29: F821 undefined name 'Datum'
        self.status_flags = Datum('int<2>', SERVER_STATUS_AUTOCOMMIT)
                            ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:32:45: F821 undefined name 'SERVER_STATUS_AUTOCOMMIT'
        self.status_flags = Datum('int<2>', SERVER_STATUS_AUTOCOMMIT)
                                            ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:33:45: F821 undefined name 'Datum'
        self.server_capabilities_2nd_part = Datum(
                                            ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:34:23: F821 undefined name 'DEFAULT_CAPABILITIES'
            'int<2>', DEFAULT_CAPABILITIES >> 16)
                      ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:35:33: F821 undefined name 'Datum'
        self.wireshark_filler = Datum('int<1>', FILLER_FOR_WIRESHARK_DUMP)
                                ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:35:49: F821 undefined name 'FILLER_FOR_WIRESHARK_DUMP'
        self.wireshark_filler = Datum('int<1>', FILLER_FOR_WIRESHARK_DUMP)
                                                ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:36:33: F821 undefined name 'Datum'
        self.reserved_filler1 = Datum('string<6>', '')
                                ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:37:33: F821 undefined name 'Datum'
        self.reserved_filler2 = Datum('string<4>', '')
                                ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:38:34: F821 undefined name 'Datum'
        self.scramble_2nd_part = Datum('string<NUL>', self.proxy.salt[8:])
                                 ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:39:27: F821 undefined name 'Datum'
        self.null_close = Datum('string<NUL>', 'mysql_native_password')
                          ^
./mindsdb/proxies/mysql/data_types/mysql_packets/handshake_packet.py:70:9: F821 undefined name 'logging'
        logging.basicConfig(level=10)
        ^
./mindsdb/proxies/mysql/data_types/mysql_packets/eof_packet.py:24:27: F821 undefined name 'Datum'
        self.eof_header = Datum('int<1>', int('0xfe',0))
                          ^
./mindsdb/proxies/mysql/data_types/mysql_packets/eof_packet.py:25:30: F821 undefined name 'Datum'
        self.warning_count = Datum('int<2>', 0)
                             ^
./mindsdb/proxies/mysql/data_types/mysql_packets/eof_packet.py:26:30: F821 undefined name 'Datum'
        self.server_status = Datum('int<2>', status)
                             ^
./mindsdb/proxies/mysql/data_types/mysql_packets/eof_packet.py:47:9: F821 undefined name 'logging'
        logging.basicConfig(level=10)
        ^
49    F821 undefined name 'xrange'
49
```