### PR TITLE
Fix undefined names in mysql_scramble.py

### DIFF
--- a/mindsdb/external_libs/mysql_scramble.py
+++ b/mindsdb/external_libs/mysql_scramble.py
@@ -28,20 +28,18 @@ import struct
 import io
 import sys
 
-PY2 = sys.version_info[0] == 2
 PYPY = hasattr(sys, 'pypy_translation_info')
 JYTHON = sys.platform.startswith('java')
 IRONPYTHON = sys.platform == 'cli'
 CPYTHON = not PYPY and not JYTHON and not IRONPYTHON
 
-if PY2:
-    import __builtin__
+try:
     range_type = xrange
     text_type = unicode
     long_type = long
     str_type = basestring
-    unichr = __builtin__.unichr
-else:
+    unichr = unichr
+except NameError:
     range_type = range
     text_type = str
     long_type = int
@@ -139,6 +137,3 @@ def join_bytes(bs):
         for b in bs[1:]:
             rv += b
         return rv
-
-
-


### PR DESCRIPTION
_Undefined names_ have the potential to raise __NameError__ at runtime.  Could not discover where in this repo __MAX_LENGTH__ is defined .  Follows the Python porting best practice [use feature detection instead of version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).

[flake8](http://flake8.pycqa.org) testing of https://github.com/mindsdb/mindsdb on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./mindsdb/libs/ml_models/pytorch/encoders/rnn/decoder_rnn.py:10:76: F821 undefined name 'MAX_LENGTH'
    def __init__(self, hidden_size, output_size, dropout_p=0.1, max_length=MAX_LENGTH):
                                                                           ^
./mindsdb/external_libs/mysql_scramble.py:39:18: F821 undefined name 'xrange'
    range_type = xrange
                 ^
./mindsdb/external_libs/mysql_scramble.py:40:17: F821 undefined name 'unicode'
    text_type = unicode
                ^
./mindsdb/external_libs/mysql_scramble.py:41:17: F821 undefined name 'long'
    long_type = long
                ^
./mindsdb/external_libs/mysql_scramble.py:42:16: F821 undefined name 'basestring'
    str_type = basestring
               ^
```