### PR TITLE
current data type default to TEXT in order to avoid null data types

### DIFF
--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -85,7 +85,7 @@ class StatsGenerator(BaseModule):
             else:
                 type_dist[currentGuess] += 1
 
-        curr_data_type = None
+        curr_data_type = DATA_TYPES.TEXT
         max_data_type = 0
 
         for data_type in type_dist:
@@ -455,4 +455,3 @@ def test():
 # only run the test if this file is called from debugger
 if __name__ == "__main__":
     test()
-


### PR DESCRIPTION
The data type for a column remained `None` if a specific column had only null (empty) values.

This caused issues later on the chain.

A better fix might be to:

a) Crash if a column has only null values

b) Ignore the column

c) Deal with data type `None` in the `norm` function or later down the chain

For now, this is a very easy way to fixes #64
And it shouldn't affect behavior in any way.