### PR TITLE
Titanic fix

### DIFF
--- a/integration_testing/run_a_file.py
+++ b/integration_testing/run_a_file.py
@@ -1,18 +1,7 @@
-import mindsdb
+from mindsdb import *
 
-
-mdb = mindsdb.MindsDB(send_logs=False)
-
-mdb.learn(
-        from_data='marvel_wiki.csv',
-    predict='FIRST_APPEARANCE',
-    model_name='run_a_file'
+MindsDB().learn(
+    from_data="train.csv",
+    predict='Survived',
+    model_name='titanic_model'
 )
-print('!-------------  Learning ran successfully  -------------!')
-
-''':
-features = {}
-result = mdb.predict(when=features, model_name='run_a_file')
-print(result)
-'''
-print('!-------------  Prediction from file ran successfully  -------------!')

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -304,6 +304,7 @@ class StatsGenerator(BaseModule):
         if stats[col_name][KEYS.DATA_TYPE] != DATA_TYPES.NUMERIC:
             return {}
 
+        print(col_name, len(columns[col_name]))
         z_scores = list(map(abs,(st.zscore(columns[col_name]))))
         threshold = 3
         z_score_outlier_indexes = [i for i in range(len(z_scores)) if z_scores[i] > threshold]
@@ -527,6 +528,7 @@ class StatsGenerator(BaseModule):
                 column_count[column] += 1
         stats = {}
 
+        col_data_dict = {}
         for i, col_name in enumerate(non_null_data):
             col_data = non_null_data[col_name] # all rows in just one column
             full_col_data = all_sampled_data[col_name]
@@ -562,9 +564,6 @@ class StatsGenerator(BaseModule):
                     if value != '' and value != '\r' and value != '\n':
                         newData.append(value)
 
-                if col_name == 'Ticket':
-                    print(col_name, data_type, data_type_dist)
-                    exit()
                 col_data = [clean_float(i) for i in newData if str(i) not in ['', str(None), str(False), str(np.nan), 'NaN', 'nan', 'NA']]
 
                 y, x = np.histogram(col_data, 50, density=False)
@@ -677,15 +676,15 @@ class StatsGenerator(BaseModule):
             stats[col_name]['column'] = col_name
             stats[col_name]['empty_cells'] = empty_count[col_name]
             stats[col_name]['empty_percentage'] = empty_count[col_name] * 100 / column_count[col_name]
-
+            col_data_dict[col_name] = col_data
 
         for i, col_name in enumerate(all_sampled_data):
             stats[col_name].update(self._compute_duplicates_score(stats, all_sampled_data, col_name))
             stats[col_name].update(self._compute_empty_cells_score(stats, all_sampled_data, col_name))
             stats[col_name].update(self._compute_clf_based_correlation_score(stats, all_sampled_data, col_name))
             stats[col_name].update(self._compute_data_type_dist_score(stats, all_sampled_data, col_name))
-            stats[col_name].update(self._compute_z_score(stats, all_sampled_data, col_name))
-            stats[col_name].update(self._compute_lof_score(stats, all_sampled_data, col_name))
+            stats[col_name].update(self._compute_z_score(stats, col_data_dict, col_name))
+            stats[col_name].update(self._compute_lof_score(stats, col_data_dict, col_name))
             stats[col_name].update(self._compute_similariy_score(stats, all_sampled_data, col_name))
             stats[col_name].update(self._compute_value_distribution_score(stats, all_sampled_data, col_name))
 

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -127,6 +127,12 @@ class StatsGenerator(BaseModule):
 
         # assume that the type is the one with the most prevelant type_dist
         for data_type in type_dist:
+            # If any of the members are text, use that data type, since otherwise the model will crash when casting
+            if data_type == DATA_TYPES.TEXT:
+                pass
+                curr_data_type = DATA_TYPES.TEXT
+                print(curr_data_type)
+                break
             if type_dist[data_type] > max_data_type:
                 curr_data_type = data_type
                 max_data_type = type_dist[data_type]
@@ -556,7 +562,9 @@ class StatsGenerator(BaseModule):
                     if value != '' and value != '\r' and value != '\n':
                         newData.append(value)
 
-
+                if col_name == 'Ticket':
+                    print(col_name, data_type, data_type_dist)
+                    exit()
                 col_data = [clean_float(i) for i in newData if str(i) not in ['', str(None), str(False), str(np.nan), 'NaN', 'nan', 'NA']]
 
                 y, x = np.histogram(col_data, 50, density=False)


### PR DESCRIPTION
Fixes #84 by defaulting to the `TEXT` data type if any of the values are Text in a column that's predominantly numerical.

Also fixes the way some of the score in the stats generator are computed, since some of the scores didn't behave well when given `None` values, so we have to use them on the cleaned up column data rather than the raw column data.