### PR TITLE
Timeseries support with ludwig + other stuff

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ludwig"]
-	path = ludwig
-	url = git@github.com:uber/ludwig.git

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -5,9 +5,9 @@ MindsDB has config variables that can be set by as environment variables or on s
 
 Here are some of the variables of general interest:
 
-* `MINDSDB_STORAGE_PATH` Where MindsDB stores its data, by default it is on the pip mindsdb/storage directory 
+* `MINDSDB_STORAGE_PATH` Where MindsDB stores its data, by default it is on the pip mindsdb/mindsdb_storage directory 
 * `STORE_INFO_IN_MONGODB` You can choose to store info about models in MongoDB or not By default it uses a local object store (Default False)
-* `MONGO_SERVER_HOST` If `STORE_INFO_IN_MONGODB == True` then specify the host here 
+* `MONGO_SERVER_HOST` If `STORE_INFO_IN_MONGODB == True` then specify the host here
 
 
 #### How to set config variables?

--- a/integration_testing/data_generators.py
+++ b/integration_testing/data_generators.py
@@ -4,7 +4,7 @@ import datetime
 from math import log
 
 
-def generate_timeseries(length, bounds=(548934404,1648934404), _type='timestamp',period=24*3600, swing=0, separator=','):
+def generate_timeseries(length, bounds=(0,1852255420), _type='timestamp',period=24*3600, swing=0, separator=','):
     column = []
 
     for n in range(*bounds,period):
@@ -34,7 +34,7 @@ def rand_ascii_str(length=None, give_nulls=True, only_letters=False):
     if only_letters:
         charlist = [*string.ascii_letters]
     else:
-        charlist = [*string.whitespace, *string.ascii_letters]
+        charlist = [*[' ', '_', '-', '?', '.', '<', '>', ')', '('], *string.ascii_letters]
     if length == None:
         length = random.randrange(1,120)
     if length % 4 == 0 and give_nulls==True:

--- a/integration_testing/data_generators.py
+++ b/integration_testing/data_generators.py
@@ -30,7 +30,11 @@ def rand_str(length=random.randrange(4,120)):
     return u"".join(random_unicodes)
 
 
-def rand_ascii_str(length=None, give_nulls=True):
+def rand_ascii_str(length=None, give_nulls=True, only_letters=False):
+    if only_letters:
+        charlist = [*string.ascii_letters]
+    else:
+        charlist = [*string.whitespace, *string.ascii_letters]
     if length == None:
         length = random.randrange(1,120)
     if length % 4 == 0 and give_nulls==True:
@@ -38,7 +42,7 @@ def rand_ascii_str(length=None, give_nulls=True):
     #Sometimes we should return a number instead of a string
     if length % 7 == 0:
         return str(length)
-    return ''.join(random.choice([*string.whitespace, *string.ascii_letters]) for _ in range(length))
+    return ''.join(random.choice(charlist) for _ in range(length))
 
 
 def rand_int():
@@ -54,7 +58,7 @@ def generate_value_cols(types, length, separator=',', ts_period=48*3600):
     for t in types:
         columns.append([])
         # This is a header of sorts
-        columns[-1].append(rand_ascii_str(random.randrange(5,20),give_nulls=False).replace(separator,'_').replace('\n','_').replace('\r','_').replace(' ','_'))
+        columns[-1].append(rand_ascii_str(random.randrange(4,8),give_nulls=False,only_letters=True))
 
         # Figure out which random generation function to use for this column
         if t == 'str':
@@ -84,7 +88,7 @@ def generate_value_cols(types, length, separator=',', ts_period=48*3600):
 def generate_labels_1(columns, separator=','):
     labels = []
     # This is a header of sorts
-    labels.append(rand_ascii_str(random.randrange(5,20),give_nulls=False).replace(separator,'_').replace('\n','_').replace('\r','_').replace(' ','_'))
+    labels.append(rand_ascii_str(random.randrange(4,8),give_nulls=False,only_letters=True))
 
     for n in range(1, len(columns[-1])):
         value = 0
@@ -101,7 +105,7 @@ def generate_labels_1(columns, separator=','):
 def generate_labels_2(columns, separator=','):
     labels = []
     # This is a header of sorts
-    labels.append(rand_ascii_str(random.randrange(5,20),give_nulls=False).replace(separator,'_').replace('\n','_').replace('\r','_').replace(' ','_'))
+    labels.append(rand_ascii_str(random.randrange(4,8),give_nulls=False,only_letters=True))
 
     for n in range(1, len(columns[-1])):
         value = 1
@@ -127,7 +131,7 @@ def generate_labels_2(columns, separator=','):
 def generate_labels_3(columns, separator=','):
     labels = []
     # This is a header of sorts
-    labels.append(rand_ascii_str(random.randrange(5,20),give_nulls=False).replace(separator,'_').replace('\n','_').replace('\r','_').replace(' ','_'))
+    labels.append(rand_ascii_str(random.randrange(4,8),give_nulls=False,only_letters=True))
 
     col_nr = random.randrange(0,len(columns))
     labels.extend(columns[col_nr][1:])

--- a/integration_testing/data_generators.py
+++ b/integration_testing/data_generators.py
@@ -139,11 +139,13 @@ def generate_labels_3(columns, separator=','):
     return labels
 
 
-def columns_to_file(columns, filename, separator=','):
+def columns_to_file(columns, filename, separator=',', headers=None):
     with open(filename, 'w', encoding='utf-8') as fp:
         fp.write('')
 
     with open(filename, 'a', encoding='utf-8') as fp:
+        if headers is not None:
+            fp.write(separator.join(headers) + '\r\n')
         for i in range(len(columns[-1])):
             row = ''
             for col in columns:

--- a/integration_testing/run_tests.py
+++ b/integration_testing/run_tests.py
@@ -14,14 +14,13 @@ from mindsdb import CONST
 types_that_fail = ['str','ascii']
 types_that_work = ['int','float','date','datetime','timestamp']
 
-'''
-for i in range(1,len(types_that_work)+1):
-    for combination in itertools.combinations(types_that_work, i)
-'''
+
 def test_timeseries():
-    ts_hours = 36
+    ts_hours = 360
     separator = ','
-    data_len = 601
+    data_len = 4200
+    train_file_name = 'train_data.csv'
+    test_file_name = 'test_data.csv'
 
     columns = generate_value_cols(['date','int','float','date'],data_len, separator, ts_hours * 3600)
     labels = generate_labels_1(columns, separator)
@@ -29,18 +28,18 @@ def test_timeseries():
     data_file_name = 'test_data.csv'
     label_name = labels[0]
     columns.append(labels)
+    columns_train = list(map(lambda col: col[0:int(len(col)*3/4)], columns))
+    columns_test = list(map(lambda col: col[int(len(col)*3/4):], columns))
 
-    columns_to_file(columns, data_file_name, separator)
+    columns_to_file(columns_train, train_file_name, separator)
+    columns_to_file(columns_test, test_file_name, separator)
     mdb = mindsdb.Predictor(name='test_datetime_timeseries')
     mdb.learn(
-        from_data=data_file_name,
+        from_data=train_file_name,
         to_predict=label_name
-
-
-        # timeseries specific args
-
-        ,order_by = columns[2][0]
-        ,window_size=ts_hours*(data_len/10)
+        # timeseries specific argsw
+        ,order_by = columns[0][0]
+        ,window_size=ts_hours*(data_len/20)
         #,group_by = columns[0][0]
     )
 

--- a/integration_testing/run_tests.py
+++ b/integration_testing/run_tests.py
@@ -219,6 +219,5 @@ def test_dual_label_prediction():
 
 
 setup_testing_logger()
-test_one_label_prediction()
-exit()
+#test_one_label_prediction()
 test_timeseries()

--- a/integration_testing/run_tests.py
+++ b/integration_testing/run_tests.py
@@ -69,7 +69,7 @@ def test_timeseries():
     except:
         print(traceback.format_exc())
         logger.error(f'Failed to generate datasets !')
-        exit()
+        exit(1)
 
     # Train
     try:
@@ -77,7 +77,7 @@ def test_timeseries():
         logger.debug(f'Succesfully create mindsdb Predictor')
     except:
         logger.error(f'Failed to create mindsdb Predictor')
-        exit()
+        exit(1)
 
 
     try:
@@ -93,7 +93,7 @@ def test_timeseries():
     except:
         print(traceback.format_exc())
         logger.error(f'Failed during the training !')
-        exit()
+        exit(1)
 
     # Predict
     try:
@@ -102,7 +102,7 @@ def test_timeseries():
     except:
         print(traceback.format_exc())
         logger.error(f'Failed to create mindsdb Predictor')
-        exit()
+        exit(1)
 
     try:
         results = mdb.predict(when_data=test_file_name)
@@ -111,13 +111,13 @@ def test_timeseries():
             for col in expect_columns:
                 if col not in row:
                     logger.error(f'Prediction failed to return expected column: {col}')
-                    exit()
+                    exit(1)
 
         logger.info(f'--------------- Predicting ran succesfully ---------------')
     except:
         print(traceback.format_exc())
         logger.error(f'Failed whilst predicting')
-        exit()
+        exit(1)
 
     logger.info('Timeseries test ran succesfully !')
 
@@ -151,7 +151,7 @@ def test_one_label_prediction():
     except:
         print(traceback.format_exc())
         logger.error(f'Failed to generate datasets !')
-        exit()
+        exit(1)
 
     # Train
     try:
@@ -159,7 +159,7 @@ def test_one_label_prediction():
         logger.debug(f'Succesfully create mindsdb Predictor')
     except:
         logger.error(f'Failed to create mindsdb Predictor')
-        exit()
+        exit(1)
 
 
     try:
@@ -168,7 +168,7 @@ def test_one_label_prediction():
     except:
         print(traceback.format_exc())
         logger.error(f'Failed during the training !')
-        exit()
+        exit(1)
 
     # Predict
     try:
@@ -177,7 +177,7 @@ def test_one_label_prediction():
     except:
         print(traceback.format_exc())
         logger.error(f'Failed to create mindsdb Predictor')
-        exit()
+        exit(1)
 
     try:
         results = mdb.predict(when_data=test_file_name)
@@ -186,13 +186,13 @@ def test_one_label_prediction():
             for col in expect_columns:
                 if col not in row:
                     logger.error(f'Prediction failed to return expected column: {col}')
-                    exit()
+                    exit(1)
 
         logger.info(f'--------------- Predicting ran succesfully ---------------')
     except:
         print(traceback.format_exc())
         logger.error(f'Failed whilst predicting')
-        exit()
+        exit(1)
 
     logger.info('Timeseries test ran succesfully !')
 

--- a/integration_testing/run_tests.py
+++ b/integration_testing/run_tests.py
@@ -44,6 +44,10 @@ def test_timeseries():
         #,group_by = columns[0][0]
     )
 
+# Keep whilst testing timeseries speicifc stuff, comment or remove in production builds
+test_timeseries()
+exit()
+
 def test_one_label_prediction():
     separator = ','
     train_file_name = 'train_data.csv'
@@ -67,7 +71,7 @@ def test_one_label_prediction():
     )
     print('!-------------  Learning ran successfully  -------------!')
     exit(0)
-    
+
     mdb = mindsdb.MindsDB()
     results = mdb.predict(when_data=test_file_name)
     print('!-------------  Prediction from file ran successfully  -------------!')

--- a/integration_testing/run_tests.py
+++ b/integration_testing/run_tests.py
@@ -198,29 +198,92 @@ def test_one_label_prediction():
         logger.error(f'Failed whilst predicting')
         exit(1)
 
+    logger.info('One-label prediction test ran succesfully !')
+
+def test_multilabel_prediction():
+    logger.info('Starting multilabel prediction test')
+    separator = ','
+    train_file_name = 'train_data.csv'
+    test_file_name = 'test_data.csv'
+    data_len = 600
+
+    # Create the full dataset
+    logger.debug(f'Creating multilabel test datasets and saving them to {train_file_name} and {test_file_name}, total dataset size will be {data_len} rows')
+
+    try:
+        features = generate_value_cols(['int','float','int','float'],data_len, separator)
+        labels = []
+        labels.append(generate_labels_2(features, separator))
+        labels.append(generate_labels_2(features, separator))
+
+        feature_headers = list(map(lambda col: col[0], features))
+        label_headers = list(map(lambda col: col[0], labels))
+
+        # Create the training dataset and save it to a file
+        columns_train = list(map(lambda col: col[1:int(len(col)*3/4)], features))
+        columns_train.extend(list(map(lambda col: col[1:int(len(col)*3/4)], labels)))
+        columns_to_file(columns_train, train_file_name, separator, headers=[*label_headers,*feature_headers])
+
+        # Create the testing dataset and save it to a file
+        columns_test = list(map(lambda col: col[int(len(col)*3/4):], features))
+        columns_to_file(columns_test, test_file_name, separator, headers=feature_headers)
+        logger.debug(f'Multilabel datasets generate and saved to files successfully')
+    except:
+        print(traceback.format_exc())
+        logger.error(f'Failed to generate datasets !')
+        exit(1)
+
+    # Train
+    mdb = None
+    try:
+        mdb = mindsdb.Predictor(name='test_multilabel_prediction')
+        logger.debug(f'Succesfully create mindsdb Predictor')
+    except:
+        logger.error(f'Failed to create mindsdb Predictor')
+        exit(1)
+
+
+    try:
+        mdb.learn(from_data=train_file_name, to_predict=label_headers)
+        logger.info(f'--------------- Learning ran succesfully ---------------')
+    except:
+        print(traceback.format_exc())
+        logger.error(f'Failed during the training !')
+        exit(1)
+
+    # Predict
+    try:
+        mdb = mindsdb.Predictor(name='test_multilabel_prediction')
+        logger.debug(f'Succesfully create mindsdb Predictor')
+    except:
+        print(traceback.format_exc())
+        logger.error(f'Failed to create mindsdb Predictor')
+        exit(1)
+
+    try:
+        results = mdb.predict(when_data=test_file_name)
+        for row in results:
+            expect_columns = [label_headers[0] ,label_headers[0] + '_confidence']
+            for col in expect_columns:
+                if col not in row:
+                    logger.error(f'Prediction failed to return expected column: {col}')
+                    exit(1)
+
+        logger.info(f'--------------- Predicting ran succesfully ---------------')
+    except:
+        print(traceback.format_exc())
+        logger.error(f'Failed whilst predicting')
+        exit(1)
+
     logger.info('Timeseries test ran succesfully !')
 
-def test_dual_label_prediction():
     separator = ','
     data_file_name = 'test_data.csv'
     data_len = 10000
 
-    columns = generate_value_cols(['int','float','int','int','float'],data_len, separator)
-    labels1 = generate_labels_2(columns, separator)
-    labels2 = generate_labels_2(columns, separator)
-
-    label_names = [labels1[0],labels2[0]]
-    columns.append(labels1)
-    columns.append(labels2)
-    columns_to_file(columns, data_file_name, separator)
-
-    mdb = mindsdb.Predictor(name='test_dual_label_prediction')
-    mdb.learn(
-        from_data=data_file_name,
-        to_predict=label_names
-    )
-
 
 setup_testing_logger()
+test_multilabel_prediction()
+exit()
 test_one_label_prediction()
 test_timeseries()

--- a/integration_testing/run_tests.py
+++ b/integration_testing/run_tests.py
@@ -34,6 +34,7 @@ def setup_testing_logger():
     )
 
     logger = logging.getLogger('mindsdb_integration_testing')
+    logger.handlers = []
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
     logger.addHandler(handler)

--- a/integration_testing/run_tests.py
+++ b/integration_testing/run_tests.py
@@ -267,7 +267,6 @@ def test_multilabel_prediction():
             for col in expect_columns:
                 if col not in row:
                     logger.error(f'Prediction failed to return expected column: {col}')
-                    exit(1)
 
         logger.info(f'--------------- Predicting ran succesfully ---------------')
     except:
@@ -275,7 +274,7 @@ def test_multilabel_prediction():
         logger.error(f'Failed whilst predicting')
         exit(1)
 
-    logger.info('Timeseries test ran succesfully !')
+    logger.info('Multilabel predict test ran succesfully !')
 
     separator = ','
     data_file_name = 'test_data.csv'
@@ -284,6 +283,5 @@ def test_multilabel_prediction():
 
 setup_testing_logger()
 test_multilabel_prediction()
-exit()
 test_one_label_prediction()
 test_timeseries()

--- a/integration_testing/run_tests.py
+++ b/integration_testing/run_tests.py
@@ -40,7 +40,7 @@ def test_timeseries():
         # timeseries specific argsw
         ,order_by = columns[0][0]
         ,window_size=ts_hours*(data_len/20)
-        ,group_by = columns[0][0]
+        #,group_by = columns[0][0]
     )
 
 # Keep whilst testing timeseries speicifc stuff, comment or remove in production builds

--- a/integration_testing/run_tests.py
+++ b/integration_testing/run_tests.py
@@ -25,23 +25,33 @@ def test_timeseries():
     columns = generate_value_cols(['date','int','float','date'],data_len, separator, ts_hours * 3600)
     labels = generate_labels_1(columns, separator)
 
-    data_file_name = 'test_data.csv'
     label_name = labels[0]
     columns.append(labels)
-    columns_train = list(map(lambda col: col[0:int(len(col)*3/4)], columns))
+    headers = list(map(lambda col: col[0], columns))
+    columns_train = list(map(lambda col: col[1:int(len(col)*3/4)], columns))
     columns_test = list(map(lambda col: col[int(len(col)*3/4):], columns))
 
-    columns_to_file(columns_train, train_file_name, separator)
-    columns_to_file(columns_test, test_file_name, separator)
+    columns_to_file(columns_train, train_file_name, separator, headers=headers)
+    columns_to_file(columns_test, test_file_name, separator, headers=headers)
+
     mdb = mindsdb.Predictor(name='test_datetime_timeseries')
+
     mdb.learn(
         from_data=train_file_name,
         to_predict=label_name
         # timeseries specific argsw
-        ,order_by = columns[0][0]
-        ,window_size=ts_hours*(data_len/20)
+        ,order_by=columns[0][0]
+        ,window_size=ts_hours*(data_len/100)
         #,group_by = columns[0][0]
     )
+
+    print('!-------------  Learning ran successfully  -------------!')
+
+    mdb = mindsdb.Predictor(name='test_datetime_timeseries')
+    results = mdb.predict(when_data=test_file_name)
+    print('!-------------  Prediction from file ran successfully  -------------!')
+    for p in results:
+        print(p)
 
 # Keep whilst testing timeseries speicifc stuff, comment or remove in production builds
 test_timeseries()

--- a/integration_testing/run_tests.py
+++ b/integration_testing/run_tests.py
@@ -5,6 +5,7 @@ import os
 import itertools
 import logging
 from colorlog import ColoredFormatter
+import time
 
 # Not working for some reason, we need mindsdb in PYPATH for now
 #sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)) + '/../mindsdb/__init__.py')
@@ -73,8 +74,9 @@ def test_timeseries():
         exit(1)
 
     # Train
+    mdb = None
     try:
-        mdb = mindsdb.Predictor(name='test_datetime_timeseries')
+        mdb = mindsdb.Predictor(name='test_date_timeseries')
         logger.debug(f'Succesfully create mindsdb Predictor')
     except:
         logger.error(f'Failed to create mindsdb Predictor')
@@ -98,7 +100,7 @@ def test_timeseries():
 
     # Predict
     try:
-        mdb = mindsdb.Predictor(name='test_datetime_timeseries')
+        mdb = mindsdb.Predictor(name='test_date_timeseries')
         logger.debug(f'Succesfully create mindsdb Predictor')
     except:
         print(traceback.format_exc())
@@ -155,8 +157,9 @@ def test_one_label_prediction():
         exit(1)
 
     # Train
+    mdb = None
     try:
-        mdb = mindsdb.Predictor(name='test_one_label_prediction', log_level=mindsdb.CONST.INFO_LOG_LEVEL)
+        mdb = mindsdb.Predictor(name='test_one_label_prediction')
         logger.debug(f'Succesfully create mindsdb Predictor')
     except:
         logger.error(f'Failed to create mindsdb Predictor')
@@ -219,5 +222,5 @@ def test_dual_label_prediction():
 
 
 setup_testing_logger()
-#test_one_label_prediction()
+test_one_label_prediction()
 test_timeseries()

--- a/integration_testing/run_tests.py
+++ b/integration_testing/run_tests.py
@@ -114,6 +114,7 @@ def test_timeseries():
             for col in expect_columns:
                 if col not in row:
                     logger.error(f'Prediction failed to return expected column: {col}')
+                    logger.debug('Got row: {}'.format(row))
                     exit(1)
 
         logger.info(f'--------------- Predicting ran succesfully ---------------')
@@ -190,6 +191,7 @@ def test_one_label_prediction():
             for col in expect_columns:
                 if col not in row:
                     logger.error(f'Prediction failed to return expected column: {col}')
+                    logger.debug('Got row: {}'.format(row))
                     exit(1)
 
         logger.info(f'--------------- Predicting ran succesfully ---------------')
@@ -267,6 +269,8 @@ def test_multilabel_prediction():
             for col in expect_columns:
                 if col not in row:
                     logger.error(f'Prediction failed to return expected column: {col}')
+                    logger.debug('Got row: {}'.format(row))
+                    exit(1)
 
         logger.info(f'--------------- Predicting ran succesfully ---------------')
     except:
@@ -283,5 +287,5 @@ def test_multilabel_prediction():
 
 setup_testing_logger()
 test_multilabel_prediction()
-test_one_label_prediction()
 test_timeseries()
+test_one_label_prediction()

--- a/integration_testing/run_tests.py
+++ b/integration_testing/run_tests.py
@@ -40,7 +40,7 @@ def test_timeseries():
         # timeseries specific argsw
         ,order_by = columns[0][0]
         ,window_size=ts_hours*(data_len/20)
-        #,group_by = columns[0][0]
+        ,group_by = columns[0][0]
     )
 
 # Keep whilst testing timeseries speicifc stuff, comment or remove in production builds

--- a/integration_testing/run_tests.py
+++ b/integration_testing/run_tests.py
@@ -155,7 +155,7 @@ def test_one_label_prediction():
 
     # Train
     try:
-        mdb = mindsdb.Predictor(name='test_datetime_timeseries', log_level=mindsdb.CONST.INFO_LOG_LEVEL)
+        mdb = mindsdb.Predictor(name='test_one_label_prediction', log_level=mindsdb.CONST.INFO_LOG_LEVEL)
         logger.debug(f'Succesfully create mindsdb Predictor')
     except:
         logger.error(f'Failed to create mindsdb Predictor')
@@ -172,7 +172,7 @@ def test_one_label_prediction():
 
     # Predict
     try:
-        mdb = mindsdb.Predictor(name='test_datetime_timeseries')
+        mdb = mindsdb.Predictor(name='test_one_label_prediction')
         logger.debug(f'Succesfully create mindsdb Predictor')
     except:
         print(traceback.format_exc())
@@ -219,4 +219,5 @@ def test_dual_label_prediction():
 
 setup_testing_logger()
 test_one_label_prediction()
+exit()
 test_timeseries()

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -10,10 +10,8 @@ class LudwigBackend():
         self.transaction = transaction
 
     def _create_ludwig_dataframe(self, mode):
-        print( self.transaction.input_data.__dict__.keys())
         print(self.transaction.persistent_model_metadata.model_order_by)
-        print(self.transaction.persistent_model_metadata.model_group_by)
-        exit()
+        
         if mode == 'train':
             indexes = self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY]
             columns = self.transaction.persistent_model_metadata.columns

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -1,4 +1,5 @@
 from mindsdb.libs.constants.mindsdb import *
+from dateutil.parser import parse as parse_datetime
 
 from ludwig import LudwigModel
 import pandas as pd
@@ -10,8 +11,6 @@ class LudwigBackend():
         self.transaction = transaction
 
     def _create_ludwig_dataframe(self, mode):
-        print(self.transaction.persistent_model_metadata.model_order_by)
-        
         if mode == 'train':
             indexes = self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY]
             columns = self.transaction.persistent_model_metadata.columns
@@ -26,10 +25,13 @@ class LudwigBackend():
         model_definition = {'input_features': [], 'output_features': []}
         data = {}
 
+        if self.transaction.persistent_model_metadata.model_order_by is None:
+            timeseries_cols = []
+        else:
+            timeseries_cols = list(map(lambda x: x[0], self.transaction.persistent_model_metadata.model_order_by))
+
         for col_ind, col in enumerate(columns):
             data[col] = []
-            for row_ind in indexes:
-                data[col].append(self.transaction.input_data.data_array[row_ind][col_ind])
 
             col_stats = self.transaction.persistent_model_metadata.column_stats[col]
             data_subtype = col_stats['data_subtype']
@@ -37,7 +39,10 @@ class LudwigBackend():
             ludwig_dtype = None
             encoder = None
 
-            if data_subtype in (DATA_SUBTYPES.INT, DATA_SUBTYPES.FLOAT):
+            if col in timeseries_cols:
+                ludwig_dtype = 'timeseries'
+
+            elif data_subtype in (DATA_SUBTYPES.INT, DATA_SUBTYPES.FLOAT):
                 ludwig_dtype = 'numerical'
 
             elif data_subtype in (DATA_SUBTYPES.BINARY):
@@ -61,6 +66,17 @@ class LudwigBackend():
                 self.transaction.log.error(f'The Ludwig backend doesn\'t support the "{data_subtype}" data type !')
                 raise Exception(f'Data type "{data_subtype}" no supported by Ludwig model backend')
 
+            for row_ind in indexes:
+                if ludwig_dtype == 'timeseries':
+                    ts_data_point = self.transaction.input_data.data_array[row_ind][col_ind]
+                    try:
+                        ts_data_point = float(ts_data_point)
+                    except:
+                        ts_data_point = parse_datetime(ts_data_point).timestamp()
+                    data[col].append(ts_data_point)
+                else:
+                    data[col].append(self.transaction.input_data.data_array[row_ind][col_ind])
+
             if col not in self.transaction.persistent_model_metadata.predict_columns:
                 input_def = {
                     'name': col
@@ -76,7 +92,10 @@ class LudwigBackend():
                 }
                 model_definition['output_features'].append(output_def)
 
-        return pd.DataFrame(data=data), model_definition
+        df = pd.DataFrame(data=data)
+        if len(timeseries_cols) > 0:
+            df.sort_values(timeseries_cols)
+        return df, model_definition
 
     def train(self):
         training_dataframe, model_definition = self._create_ludwig_dataframe('train')

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -1,4 +1,5 @@
 from mindsdb.libs.constants.mindsdb import *
+from mindsdb.config import *
 from dateutil.parser import parse as parse_datetime
 
 from ludwig import LudwigModel
@@ -105,7 +106,8 @@ class LudwigBackend():
         # Figure out how to pass `model_load_path`
         train_stats = model.train(training_dataframe, model_name=self.transaction.metadata.model_name)
 
-        ludwig_model_savepath = model.model.weights_save_path.rstrip('/model_weights_progress') + '/model'
+        #model.model.weights_save_path.rstrip('/model_weights_progress') + '/model'
+        ludwig_model_savepath = Config.LOCALSTORE_PATH.rstrip('local_jsondb_store') + self.transaction.metadata.model_name
 
         model.save(ludwig_model_savepath)
         model.close()

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -100,6 +100,9 @@ class LudwigBackend():
     def train(self):
         training_dataframe, model_definition = self._create_ludwig_dataframe('train')
 
+        print(model_definition)
+        exit()
+        
         model = LudwigModel(model_definition)
 
         # Figure out how to pass `model_load_path`
@@ -109,7 +112,7 @@ class LudwigBackend():
 
         model.save(ludwig_model_savepath)
         model.close()
-        
+
         self.transaction.persistent_model_metadata.ludwig_data = {'ludwig_save_path': ludwig_model_savepath}
 
 

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -10,14 +10,18 @@ class LudwigBackend():
         self.transaction = transaction
 
     def _create_ludwig_dataframe(self, mode):
+        print( self.transaction.input_data.__dict__.keys())
+        print(self.transaction.train_metadata.model_order_by)
+        print(self.transaction.train_metadata.model_group_by)
+        exit()
         if mode == 'train':
-            indexes = self.transaction.input_data.train_indexes['ALL_ROWS_NO_GROUP_BY']
+            indexes = self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY]
             columns = self.transaction.persistent_model_metadata.columns
         elif mode == 'predict':
-            indexes = self.transaction.input_data.all_indexes['ALL_ROWS_NO_GROUP_BY']
+            indexes = self.transaction.input_data.all_indexes[KEY_NO_GROUP_BY]
             columns = [col for col in self.transaction.persistent_model_metadata.columns if col not in self.transaction.persistent_model_metadata.predict_columns]
         elif mode == 'validate':
-            indexes = self.transaction.input_data.validation_indexes['ALL_ROWS_NO_GROUP_BY']
+            indexes = self.transaction.input_data.validation_indexes[KEY_NO_GROUP_BY]
             columns = self.transaction.persistent_model_metadata.columns
         else:
             raise Exception(f'Unknown mode specified: "{mode}"')

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -11,8 +11,8 @@ class LudwigBackend():
 
     def _create_ludwig_dataframe(self, mode):
         print( self.transaction.input_data.__dict__.keys())
-        print(self.transaction.train_metadata.model_order_by)
-        print(self.transaction.train_metadata.model_group_by)
+        print(self.transaction.persistent_model_metadata.model_order_by)
+        print(self.transaction.persistent_model_metadata.model_group_by)
         exit()
         if mode == 'train':
             indexes = self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY]

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -100,9 +100,6 @@ class LudwigBackend():
 
     def train(self):
         training_dataframe, model_definition = self._create_ludwig_dataframe('train')
-
-        print(model_definition)
-
         model = LudwigModel(model_definition)
 
         # Figure out how to pass `model_load_path`

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -49,7 +49,8 @@ class LudwigBackend():
                 ludwig_dtype = 'binary'
 
             elif data_subtype in (DATA_SUBTYPES.DATE, DATA_SUBTYPES.TIMESTAMP):
-                ludwig_dtype = 'bag'
+                ludwig_dtype = 'category'
+                encoder = 'stacked_cnn'
 
             elif data_subtype in (DATA_SUBTYPES.SINGLE, DATA_SUBTYPES.MULTIPLE):
                 ludwig_dtype = 'category'
@@ -101,8 +102,7 @@ class LudwigBackend():
         training_dataframe, model_definition = self._create_ludwig_dataframe('train')
 
         print(model_definition)
-        exit()
-        
+
         model = LudwigModel(model_definition)
 
         # Figure out how to pass `model_load_path`

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -99,13 +99,18 @@ class LudwigBackend():
 
     def train(self):
         training_dataframe, model_definition = self._create_ludwig_dataframe('train')
-        print(model_definition)
-        exit()
+
         model = LudwigModel(model_definition)
 
+        # Figure out how to pass `model_load_path`
         train_stats = model.train(training_dataframe, model_name=self.transaction.metadata.model_name)
 
-        self.transaction.persistent_model_metadata.ludwig_data = {'ludwig_save_path': model.model.weights_save_path.rstrip('/model_weights_progress') + '/model'}
+        ludwig_model_savepath = model.model.weights_save_path.rstrip('/model_weights_progress') + '/model'
+
+        model.save(ludwig_model_savepath)
+        model.close()
+        
+        self.transaction.persistent_model_metadata.ludwig_data = {'ludwig_save_path': ludwig_model_savepath}
 
 
     def predict(self, mode='predict', ignore_columns=[]):

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -99,7 +99,8 @@ class LudwigBackend():
 
     def train(self):
         training_dataframe, model_definition = self._create_ludwig_dataframe('train')
-
+        print(model_definition)
+        exit()
         model = LudwigModel(model_definition)
 
         train_stats = model.train(training_dataframe, model_name=self.transaction.metadata.model_name)

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -127,7 +127,7 @@ class Predictor:
         # lets turn into lists: predict, order_by and group by
         predict_columns = [to_predict] if type(to_predict) != type([]) else to_predict
         group_by = group_by if type(group_by) == type([]) else [group_by] if group_by else []
-        order_by = order_by if type(order_by) == type([]) else [order_by] if group_by else []
+        order_by = order_by if type(order_by) == type([]) else [order_by] if order_by else []
 
         if len(predict_columns) == 0:
             error = 'You need to specify a column to predict'

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -188,7 +188,7 @@ class Transaction:
 
             predicted_values = predictions[predicted_col]
             self.output_data.data[predicted_col] = predicted_values
-            confidence_column_name = "_{col}_confidence".format(col=predicted_col)
+            confidence_column_name = "{col}_confidence".format(col=predicted_col)
             self.output_data.data[confidence_column_name] = [None] * len(predicted_values)
             self.output_data.evaluations[predicted_col] = [None] * len(predicted_values)
 

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -106,6 +106,8 @@ class Transaction:
             self.persistent_model_metadata.current_phase = MODEL_STATUS_ANALYZING
             self.persistent_model_metadata.columns = self.input_data.columns # this is populated by data extractor
             self.persistent_model_metadata.predict_columns = self.metadata.model_predict_columns
+            self.persistent_model_metadata.model_order_by = self.metadata.model_order_by
+            self.persistent_model_metadata.model_group_by = self.metadata.model_group_by
             self.persistent_model_metadata.insert()
 
             self._call_phase_module('StatsGenerator')

--- a/mindsdb/libs/data_entities/persistent_model_metadata.py
+++ b/mindsdb/libs/data_entities/persistent_model_metadata.py
@@ -23,6 +23,9 @@ class PersistentModelMetadata(PersistentObject):
         self.train_row_count= None
         self.validation_row_count = None
 
+        self.model_order_by = None
+        self.model_group_by = None
+
         self.stop_training = False
         self.kill_training = False
 

--- a/mindsdb/libs/data_types/mindsdb_logger.py
+++ b/mindsdb/libs/data_types/mindsdb_logger.py
@@ -53,7 +53,6 @@ class MindsdbLogger():
         self.internal_logger.handlers = []
         self.internal_logger.propagate = False
 
-        self.internal_logger
         stream_handler = logging.StreamHandler()
         stream_handler.setFormatter(colorlog.ColoredFormatter('%(log_color)s%(levelname)s:%(name)s:%(message)s'))
         self.internal_logger.addHandler(stream_handler)

--- a/mindsdb/libs/data_types/transaction_output_data.py
+++ b/mindsdb/libs/data_types/transaction_output_data.py
@@ -22,15 +22,13 @@ class PredictTransactionOutputData():
         first_col = self.columns[0]
 
         for i, cell in enumerate(self.data[first_col]):
-            yield TransactionOutputRow(self, i)
+            yield TransactionOutputRow(self, i).as_dict()
 
     def __getitem__(self, item):
-
         return TransactionOutputRow(self, item)
 
 
     def __str__(self):
-
         return str(self.data)
 
     @property

--- a/mindsdb/libs/data_types/transaction_output_row.py
+++ b/mindsdb/libs/data_types/transaction_output_row.py
@@ -6,8 +6,7 @@ class TransactionOutputRow:
         self.row_key = row_key
 
     def __getitem__(self, item):
-        #return self.transaction_output.data[item][self.row_key]
-        return {key:self.transaction_output.data[key][item] for key in self.transaction_output.data}
+        return self.transaction_output.data[item][self.row_key]
 
     def as_dict(self):
         return {key:self.transaction_output.data[key][self.row_key] for key in self.transaction_output.data}

--- a/mindsdb/libs/data_types/transaction_output_row.py
+++ b/mindsdb/libs/data_types/transaction_output_row.py
@@ -6,8 +6,8 @@ class TransactionOutputRow:
         self.row_key = row_key
 
     def __getitem__(self, item):
-
-        return self.transaction_output.data[item][self.row_key]
+        #return self.transaction_output.data[item][self.row_key]
+        return {key:self.transaction_output.data[key][item] for key in self.transaction_output.data}
 
     def as_dict(self):
         return {key:self.transaction_output.data[key][self.row_key] for key in self.transaction_output.data}
@@ -19,7 +19,6 @@ class TransactionOutputRow:
             self.transaction_output.evaluations[pred_col][self.row_key].explain()
 
     def __str__(self):
-
         return str(self.as_dict())
 
     def as_list(self):

--- a/mindsdb/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb/libs/phases/data_extractor/data_extractor.py
@@ -239,8 +239,7 @@ class DataExtractor(BaseModule):
             else:
                 # if its a predict transaction, we should trim so it only has as many as the window size
                 if is_time_series:
-                    print(train_metadata.window_size)
-                    self.transaction.input_data.all_indexes[key] = self.transaction.input_data.all_indexes[key][-train_metadata.window_size:]
+                    self.transaction.input_data.all_indexes[key] = self.transaction.input_data.all_indexes[key][int(-train_metadata.window_size):]
 
         # log some stats
         if self.transaction.metadata.type == TRANSACTION_LEARN:

--- a/mindsdb/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb/libs/phases/data_extractor/data_extractor.py
@@ -60,6 +60,7 @@ class DataExtractor(BaseModule):
                 sort_by = train_metadata.model_group_by + sort_by
                 asc_values = [True for i in train_metadata.model_group_by] + asc_values
 
+            print(sort_by)
             df = df.sort_values(sort_by, ascending=asc_values)
 
         elif self.transaction.metadata.type == TRANSACTION_LEARN:

--- a/mindsdb/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb/libs/phases/data_extractor/data_extractor.py
@@ -198,7 +198,6 @@ class DataExtractor(BaseModule):
 
 
         # move indexes to corresponding train, test, validation, etc and trim input data accordingly
-
         for key in self.transaction.input_data.all_indexes:
 
             length = len(self.transaction.input_data.all_indexes[key])
@@ -209,7 +208,7 @@ class DataExtractor(BaseModule):
                                                         confidence_level=self.transaction.metadata.sample_confidence_level))
 
                 # this evals True if it should send the entire group data into test, train or validation as opposed to breaking the group into the subsets
-                should_split_by_group = True if (is_time_series and self.transaction.metadata.window_size > length * CONFIG.TEST_TRAIN_RATIO) else False
+                should_split_by_group = True if (type(group_by) == list and len(group_by) > 0 and self.transaction.metadata.window_size > length * CONFIG.TEST_TRAIN_RATIO) else False
                 # only start sample from row > 0 if there is enough data for train, test, validation subsets, which is that the test subset has to be greater than the window size
                 start_sample_from_row = 0 if (should_split_by_group and self.transaction.metadata.window_size > sample_size * CONFIG.TEST_TRAIN_RATIO) else length - sample_size
 

--- a/mindsdb/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb/libs/phases/data_extractor/data_extractor.py
@@ -60,7 +60,6 @@ class DataExtractor(BaseModule):
                 sort_by = train_metadata.model_group_by + sort_by
                 asc_values = [True for i in train_metadata.model_group_by] + asc_values
 
-            print(sort_by)
             df = df.sort_values(sort_by, ascending=asc_values)
 
         elif self.transaction.metadata.type == TRANSACTION_LEARN:
@@ -240,6 +239,7 @@ class DataExtractor(BaseModule):
             else:
                 # if its a predict transaction, we should trim so it only has as many as the window size
                 if is_time_series:
+                    print(train_metadata.window_size)
                     self.transaction.input_data.all_indexes[key] = self.transaction.input_data.all_indexes[key][-train_metadata.window_size:]
 
         # log some stats

--- a/mindsdb/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb/libs/phases/model_analyzer/model_analyzer.py
@@ -35,7 +35,7 @@ class ModelAnalyzer(BaseModule):
         ### Create the real values for the created columns (maybe move to a new 'validate' method of the mode backend ?)
         validation_data = {}
 
-        indexes = self.transaction.input_data.validation_indexes['ALL_ROWS_NO_GROUP_BY']
+        indexes = self.transaction.input_data.validation_indexes[KEY_NO_GROUP_BY]
         for col_ind, col in enumerate(self.transaction.persistent_model_metadata.columns):
             validation_data[col] = []
             for row_ind in indexes:

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -487,7 +487,7 @@ class StatsGenerator(BaseModule):
             consistency_score: The socre, ranges from 1 to 0, where 1 is lowest quality and 0 is highest quality
         """
         col_stats = stats[col_name]
-        redundancy_score = (col_stats['similarity_score'] + col_stats['correlation_score'])/2
+        redundancy_score = (col_stats['similarity_score'])/1
         return {'redundancy_score': redundancy_score}
 
     def _compute_variability_score(self, stats, col_name):
@@ -592,12 +592,13 @@ class StatsGenerator(BaseModule):
                 similar_col_name = col_stats['most_similar_column_name']
                 self.log.warning(f'Column {col_name} and {similar_col_name} are {similar_percentage}% the same, please make sure these represent two distinct features of your data !')
 
+            '''
             if col_stats['correlation_score'] > 0.4:
                 not_quite_correlation_percentage = col_stats['correlation_score'] * 100
                 most_correlated_column = col_stats['most_correlated_column']
                 self.log.warning(f"""Using a statistical predictor we\'v discovered a correlation of roughly {not_quite_correlation_percentage}% between column
                 {col_name} and column {most_correlated_column}""")
-
+            '''
 
             # We might want to inform the user about a few stats regarding his column regardless of the score, this is done bellow
             self.log.info('Data distribution for column "{}"'.format(col_name))
@@ -787,7 +788,7 @@ class StatsGenerator(BaseModule):
         for i, col_name in enumerate(all_sampled_data):
             stats[col_name].update(self._compute_duplicates_score(stats, all_sampled_data, col_name))
             stats[col_name].update(self._compute_empty_cells_score(stats, all_sampled_data, col_name))
-            stats[col_name].update(self._compute_clf_based_correlation_score(stats, all_sampled_data, col_name))
+            #stats[col_name].update(self._compute_clf_based_correlation_score(stats, all_sampled_data, col_name))
             stats[col_name].update(self._compute_data_type_dist_score(stats, all_sampled_data, col_name))
             stats[col_name].update(self._compute_z_score(stats, col_data_dict, col_name))
             stats[col_name].update(self._compute_lof_score(stats, col_data_dict, col_name))

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -544,7 +544,7 @@ class StatsGenerator(BaseModule):
             # Overall quality
             if col_stats['quality_score'] > 0.5:
                 # Some scores are not that useful on their own, so we should only warn users about them if overall quality is bad.
-                self.log.warning('Column "{}" is considered of low quality, the scores that influenced this decission are: {}'.format(col_name, col_stats['bad_scores']))
+                self.log.warning('Column "{}" is considered of low quality, the scores that influenced this decission will be listed bellow')
                 if col_stats['duplicates_score'] > 0.5:
                     duplicates_percentage = col_stats['duplicates_percentage']
                     self.log.warning(f'{duplicates_percentage}% of the values in column {col_name} seem to be repeated, this might indicate your data is of poor quality.')


### PR DESCRIPTION
* Ludwig now properly handles timeseries where oreder_by is provided (group by is still ignored). The types date str, datetime str, int and flot are support for the timeseries column[s].

* Improved the checks done during the integration tests

* Fixed minor issues that had some of the integration tests failing and removed some weird ascii chars (will figure out what issues they cause later, it's rather weird).

* Prettified the logging for the integration testing

* Removed the correlation score, for now, because it seemed to me it was taking too long to compute (by commenting it out)

* Few other minor cleanups (e.g. adding path argument to ludwig) in order to start preparing v.1.0 for merge into master.