### PR TITLE
Remove 3.5 Python version from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 matrix:
   include:
-    - python: 3.5
     - python: 3.6
     - python: 3.7
       dist: xenial


### PR DESCRIPTION
This PR removes Python 3.5 from Travis CI