### PR TITLE
Categorical improvements

### DIFF
--- a/integration_testing/data_generators.py
+++ b/integration_testing/data_generators.py
@@ -47,6 +47,9 @@ def rand_ascii_str(length=None, give_nulls=True, only_letters=False):
 def rand_int():
     return int(random.randrange(-pow(2,18), pow(2,18)))
 
+def rand_numerical_cat():
+    return int(random.randrange(-pow(2,3), pow(2,3)))
+
 
 def rand_float():
     return random.randrange(-pow(2,18), pow(2,18)) * random.random()
@@ -66,6 +69,8 @@ def generate_value_cols(types, length, separator=',', ts_period=48*3600):
             gen_fun = rand_ascii_str
         elif t == 'int':
             gen_fun = rand_int
+        elif t == 'nr_category':
+            gen_fun = rand_numerical_cat
         elif t == 'float':
             gen_fun = rand_float
         else:

--- a/integration_testing/run_tests.py
+++ b/integration_testing/run_tests.py
@@ -139,7 +139,7 @@ def test_one_label_prediction():
     logger.debug(f'Creating one-labe test datasets and saving them to {train_file_name} and {test_file_name}, total dataset size will be {data_len} rows')
 
     try:
-        features = generate_value_cols(['int','float','ascii','ascii'],data_len, separator)
+        features = generate_value_cols(['int','float','nr_category'],data_len, separator)
         labels = [generate_labels_2(features, separator)]
 
         feature_headers = list(map(lambda col: col[0], features))

--- a/mindsdb/libs/constants/mindsdb.py
+++ b/mindsdb/libs/constants/mindsdb.py
@@ -25,8 +25,8 @@ class DATA_SUBTYPES:
     TIMESTAMP = 'Timestamp' # YYYY-MM-DD hh:mm:ss or 1852362464
 
     # CATEGORICAL
-    SINGLE = 'Simple Category'
-    MULTIPLE = 'Complex Category' # Kind of unclear on the implementation
+    SINGLE = 'Binary Category'
+    MULTIPLE = 'Category' # Kind of unclear on the implementation
 
     # FILE_PATH
     IMAGE = 'Image'

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -118,7 +118,7 @@ class StatsGenerator(BaseModule):
             return DATA_TYPES.SEQUENTIAL, DATA_SUBTYPES.TEXT
 
 
-    def _get_column_data_type(self, data):
+    def _get_column_data_type(self, data, col_name):
         """
         Provided the column data, define it its numeric, data or class
 
@@ -219,6 +219,19 @@ class StatsGenerator(BaseModule):
             type_dist[curr_data_type] = type_dist.pop('Unknown')
             subtype_dist[curr_data_subtype] = subtype_dist.pop('Unknown')
 
+        all_values = []
+        for i in self.transaction.input_data.data_array:
+            all_values.append(self.transaction.input_data.data_array[i][col_name])
+
+        all_distinct_vals = set(all_values)
+        # Let's chose so random number
+        if all_distinct_vals < len(all_values)/200 or (all_distinct_vals < 120 and all_distinct_vals < len(all_values)/6):
+            curr_data_type = DATA_TYPES.CATEGORICAL
+            if len(all_distinct_vals) < 3:
+                curr_data_subtype = DATA_TYPES_SUBTYPES.SINGLE
+            else:
+                curr_data_subtype = DATA_TYPES_SUBTYPES.MULTIPLE
+                
         return curr_data_type, curr_data_subtype, type_dist, subtype_dist, additional_info
 
     def _get_words_dictionary(self, data, full_text = False):
@@ -648,8 +661,8 @@ class StatsGenerator(BaseModule):
         # we dont need to generate statistic over all of the data, so we subsample, based on our accepted margin of error
         population_size = len(self.transaction.input_data.data_array)
         sample_size = int(calculate_sample_size(population_size=population_size, margin_error=CONFIG.DEFAULT_MARGIN_OF_ERROR, confidence_level=CONFIG.DEFAULT_CONFIDENCE_LEVEL))
-        if sample_size > 800:
-            sample_size = 800
+        if sample_size > 3000 and sample_size > population_size/8:
+            sample_size = min(round(population_size/8),3000)
         # get the indexes of randomly selected rows given the population size
         input_data_sample_indexes = random.sample(range(population_size), sample_size)
         self.log.info('population_size={population_size},  sample_size={sample_size}  {percent:.2f}%'.format(population_size=population_size, sample_size=sample_size, percent=(sample_size/population_size)*100))
@@ -675,18 +688,7 @@ class StatsGenerator(BaseModule):
         for i, col_name in enumerate(non_null_data):
             col_data = non_null_data[col_name] # all rows in just one column
             full_col_data = all_sampled_data[col_name]
-            data_type, curr_data_subtype, data_type_dist, data_subtype_dist, additional_info = self._get_column_data_type(col_data)
-
-            # NOTE: Enable this if you want to assume that some numeric values can be text
-            # We noticed that by default this should not be the behavior
-            # TODO: Evaluate if we want to specify the problem type on predict statement as regression or classification
-            #
-            # if col_name in self.train_meta_data.model_predict_columns and data_type == DATA_TYPES.NUMERIC:
-            #     unique_count = len(set(col_data))
-            #     if unique_count <= CONFIG.ASSUME_NUMERIC_AS_TEXT_WHEN_UNIQUES_IS_LESS_THAN:
-            #         data_type = DATA_TYPES.CLASS
-
-            # Generic stats that can be generated for any data type
+            data_type, curr_data_subtype, data_type_dist, data_subtype_dist, additional_info = self._get_column_data_type(col_data, col_name)
 
 
             if data_type == DATA_TYPES.DATE:
@@ -767,8 +769,24 @@ class StatsGenerator(BaseModule):
                     },
                     "percentage_buckets": xp
                 }
-                stats[col_name] = col_stats
-            # else if its text
+            elif data_type == DATA_TYPES.CATEGORICAL:
+                all_values = []
+                for i in self.transaction.input_data.data_array:
+                    all_values.append(self.transaction.input_data.data_array[i][col_name])
+
+                histogram = Counter(all_values)
+                all_possible_values = histogram.keys()
+
+                col_stats = {
+                    'data_type': data_type,
+                    'data_subtype': curr_data_subtype,
+                    "histogram": {
+                        "x": histogram.keys(),
+                        "y": histogram.values()
+                    },
+                    "percentage_buckets": histogram.keys()
+                }
+
             # @TODO This is probably wrong, look into it a bit later
             else:
                 # see if its a sentence or a word

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -224,7 +224,7 @@ class StatsGenerator(BaseModule):
             all_values.append(row[col_index])
 
         all_distinct_vals = set(all_values)
-        
+
         # Let's chose so random number
         if (len(all_distinct_vals) < len(all_values)/200) or ( (len(all_distinct_vals) < 120) and (len(all_distinct_vals) < len(all_values)/6) ):
             curr_data_type = DATA_TYPES.CATEGORICAL
@@ -789,8 +789,8 @@ class StatsGenerator(BaseModule):
                     "histogram": {
                         "x": list(histogram.keys()),
                         "y": list(histogram.values())
-                    },
-                    "percentage_buckets": list(histogram.keys())
+                    }
+                    #"percentage_buckets": list(histogram.keys())
                 }
 
             # @TODO This is probably wrong, look into it a bit later


### PR DESCRIPTION
I forgot to make an issue for this, but it's been a change we needed for along time, so, I coded it today.

Essentially if a column has a lot of repeat values the stats generator will determine it's type as categorical. This is checked on the whole dataset, rather than only on the sample.

The formula at the moment is somewhat randomly chosen as:

`(len(all_distinct_vals) < len(all_values)/200) or ( (len(all_distinct_vals) < 120) and (len(all_distinct_vals) < len(all_values)/6) )`

Feel free to ask for other magic numbers if you wish

This happens regardless of the previously determined type of the column.

I've also changed a bit of the code around how categorical values are treated further down the line and added a new data generator to be able to generate numerical values within a very small range (i.e. numbers which should be viewed as a category).