### PR TITLE
Silence ludwig output

### DIFF
--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -362,20 +362,20 @@ class LudwigBackend():
             sys.stdout = devnull
             sys.stderr = devnull
 
-        try:
-            model = LudwigModel(model_definition)
+            try:
+                model = LudwigModel(model_definition)
 
-            # Figure out how to pass `model_load_path`
-            train_stats = model.train(data_df=training_dataframe, model_name=self.transaction.persistent_model_metadata.model_name)
+                # Figure out how to pass `model_load_path`
+                train_stats = model.train(data_df=training_dataframe, model_name=self.transaction.persistent_model_metadata.model_name)
 
-            #model.model.weights_save_path.rstrip('/model_weights_progress') + '/model'
-            ludwig_model_savepath = Config.LOCALSTORE_PATH.rstrip('local_jsondb_store') + self.transaction.persistent_model_metadata.model_name
+                #model.model.weights_save_path.rstrip('/model_weights_progress') + '/model'
+                ludwig_model_savepath = Config.LOCALSTORE_PATH.rstrip('local_jsondb_store') + self.transaction.persistent_model_metadata.model_name
 
-            model.save(ludwig_model_savepath)
-            model.close()
-        finally:
-            sys.stdout = old_stdout
-            sys.stderr = old_stderr
+                model.save(ludwig_model_savepath)
+                model.close()
+            finally:
+                sys.stdout = old_stdout
+                sys.stderr = old_stderr
 
         self.transaction.persistent_model_metadata.ludwig_data = {'ludwig_save_path': ludwig_model_savepath, 'model_definition': model_definition}
 

--- a/mindsdb/libs/helpers/general_helpers.py
+++ b/mindsdb/libs/helpers/general_helpers.py
@@ -5,6 +5,9 @@ import uuid
 from pathlib import Path
 import pickle
 import requests
+from contextlib import contextmanager
+import sys
+import os
 
 from mindsdb.__about__ import __version__
 from mindsdb.config import CONFIG
@@ -197,3 +200,17 @@ def evaluate_accuracy(predictions, real_values, col_stats, output_columns):
     if score == 0:
         score = 0.00000001
     return score
+
+
+@contextmanager
+def suppress_out():
+    with open(os.devnull, "w") as devnull:
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        sys.stdout = devnull
+        sys.stderr = devnull
+        try:
+            yield
+        finally:
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr

--- a/mindsdb/libs/helpers/general_helpers.py
+++ b/mindsdb/libs/helpers/general_helpers.py
@@ -229,6 +229,7 @@ class suppress_stdout_stderr(object):
             os.close(fd)
 
 @contextmanager
+# @TODO: Make it work with mindsdb logger/log levels... maybe
 def disable_ludwig_output():
     try:
         try:
@@ -236,6 +237,7 @@ def disable_ludwig_output():
         except:
             old_tf_loglevel = '2'
         os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
+        # Maybe get rid of this to not supress all errors and stdout
         with suppress_stdout_stderr():
             yield
     finally:

--- a/mindsdb/libs/helpers/general_helpers.py
+++ b/mindsdb/libs/helpers/general_helpers.py
@@ -5,9 +5,6 @@ import uuid
 from pathlib import Path
 import pickle
 import requests
-from contextlib import contextmanager
-import sys
-import os
 
 from mindsdb.__about__ import __version__
 from mindsdb.config import CONFIG
@@ -200,17 +197,3 @@ def evaluate_accuracy(predictions, real_values, col_stats, output_columns):
     if score == 0:
         score = 0.00000001
     return score
-
-
-@contextmanager
-def suppress_out():
-    with open(os.devnull, "w") as devnull:
-        old_stdout = sys.stdout
-        old_stderr = sys.stderr
-        sys.stdout = devnull
-        sys.stderr = devnull
-        try:
-            yield
-        finally:
-            sys.stdout = old_stdout
-            sys.stderr = old_stderr

--- a/test.log
+++ b/test.log
@@ -1,6 +1,0 @@
-/home/george/mindsdb/venv/lib/python3.7/site-packages/ludwig/features/numerical_feature.py:63: FutureWarning: Method .as_matrix will be removed in a future version. Use .values instead.
-  np.float32).as_matrix()
-INFO:mindsdb_integration_testing:--------------- Learning ran succesfully ---------------
-DEBUG:mindsdb_integration_testing:Succesfully create mindsdb Predictor
-INFO:mindsdb_integration_testing:--------------- Predicting ran succesfully ---------------
-INFO:mindsdb_integration_testing:Travis CLI Tests ran succesfully !

--- a/test.log
+++ b/test.log
@@ -1,0 +1,6 @@
+/home/george/mindsdb/venv/lib/python3.7/site-packages/ludwig/features/numerical_feature.py:63: FutureWarning: Method .as_matrix will be removed in a future version. Use .values instead.
+  np.float32).as_matrix()
+INFO:mindsdb_integration_testing:--------------- Learning ran succesfully ---------------
+DEBUG:mindsdb_integration_testing:Succesfully create mindsdb Predictor
+INFO:mindsdb_integration_testing:--------------- Predicting ran succesfully ---------------
+INFO:mindsdb_integration_testing:Travis CLI Tests ran succesfully !


### PR DESCRIPTION
This *should* resolve #155 .

It's not the prettiest solution, but, for the moment, it's the most non-invasive way I've found of doing it that should work on all platforms. There's some weirdness around ludwig logging that I don't quite understand which gets in the way of a more "standard" fix.

The lines related to disabling TF logging could be removed and it would work as intended on all platforms (I think). But, ideally, once a few ludwig changes are made, we can actually keep only the TF related lines and remove the stderr and stdout supression (which isn't exactly a "best practice"), so I'll keep that code in for now.