### PR TITLE
Lmd adaptor

### DIFF
--- a/integration_testing/run_tests.py
+++ b/integration_testing/run_tests.py
@@ -113,6 +113,8 @@ def test_timeseries():
 
     try:
         results = mdb.predict(when_data=test_file_name)
+        models = mdb.get_models()
+        get_model_data(models[0])
         for row in results:
             expect_columns = [label_headers[0] ,label_headers[0] + '_confidence']
             for col in expect_columns:
@@ -191,6 +193,8 @@ def test_one_label_prediction():
 
     try:
         results = mdb.predict(when_data=test_file_name)
+        models = mdb.get_models()
+        get_model_data(models[0])
         for row in results:
             expect_columns = [label_headers[0] ,label_headers[0] + '_confidence']
             for col in expect_columns:
@@ -267,6 +271,8 @@ def test_one_label_prediction_wo_strings():
 
     try:
         results = mdb.predict(when_data=test_file_name)
+        models = mdb.get_models()
+        get_model_data(models[0])
         for row in results:
             expect_columns = [label_headers[0] ,label_headers[0] + '_confidence']
             for col in expect_columns:
@@ -346,6 +352,8 @@ def test_multilabel_prediction():
 
     try:
         results = mdb.predict(when_data=test_file_name)
+        models = mdb.get_models()
+        get_model_data(models[0])
         for i in range(len(results)):
             row = results[i]
             expect_columns = [label_headers[0] ,label_headers[0] + '_confidence']

--- a/integration_testing/run_tests.py
+++ b/integration_testing/run_tests.py
@@ -114,7 +114,7 @@ def test_timeseries():
     try:
         results = mdb.predict(when_data=test_file_name)
         models = mdb.get_models()
-        mdb.get_model_data(models[0])
+        mdb.get_model_data(models[0]['name'])
         for row in results:
             expect_columns = [label_headers[0] ,label_headers[0] + '_confidence']
             for col in expect_columns:
@@ -194,7 +194,7 @@ def test_one_label_prediction():
     try:
         results = mdb.predict(when_data=test_file_name)
         models = mdb.get_models()
-        mdb.get_model_data(models[0])
+        mdb.get_model_data(models[0]['name'])
         for row in results:
             expect_columns = [label_headers[0] ,label_headers[0] + '_confidence']
             for col in expect_columns:
@@ -272,7 +272,7 @@ def test_one_label_prediction_wo_strings():
     try:
         results = mdb.predict(when_data=test_file_name)
         models = mdb.get_models()
-        mdb.get_model_data(models[0])
+        mdb.get_model_data(models[0]['name'])
         for row in results:
             expect_columns = [label_headers[0] ,label_headers[0] + '_confidence']
             for col in expect_columns:
@@ -353,7 +353,7 @@ def test_multilabel_prediction():
     try:
         results = mdb.predict(when_data=test_file_name)
         models = mdb.get_models()
-        mdb.get_model_data(models[0])
+        mdb.get_model_data(models[0]['name'])
         for i in range(len(results)):
             row = results[i]
             expect_columns = [label_headers[0] ,label_headers[0] + '_confidence']

--- a/integration_testing/run_tests.py
+++ b/integration_testing/run_tests.py
@@ -114,7 +114,7 @@ def test_timeseries():
     try:
         results = mdb.predict(when_data=test_file_name)
         models = mdb.get_models()
-        get_model_data(models[0])
+        mdb.get_model_data(models[0])
         for row in results:
             expect_columns = [label_headers[0] ,label_headers[0] + '_confidence']
             for col in expect_columns:
@@ -194,7 +194,7 @@ def test_one_label_prediction():
     try:
         results = mdb.predict(when_data=test_file_name)
         models = mdb.get_models()
-        get_model_data(models[0])
+        mdb.get_model_data(models[0])
         for row in results:
             expect_columns = [label_headers[0] ,label_headers[0] + '_confidence']
             for col in expect_columns:
@@ -272,7 +272,7 @@ def test_one_label_prediction_wo_strings():
     try:
         results = mdb.predict(when_data=test_file_name)
         models = mdb.get_models()
-        get_model_data(models[0])
+        mdb.get_model_data(models[0])
         for row in results:
             expect_columns = [label_headers[0] ,label_headers[0] + '_confidence']
             for col in expect_columns:
@@ -353,7 +353,7 @@ def test_multilabel_prediction():
     try:
         results = mdb.predict(when_data=test_file_name)
         models = mdb.get_models()
-        get_model_data(models[0])
+        mdb.get_model_data(models[0])
         for i in range(len(results)):
             row = results[i]
             expect_columns = [label_headers[0] ,label_headers[0] + '_confidence']

--- a/integration_testing/run_travis_tests.py
+++ b/integration_testing/run_travis_tests.py
@@ -109,10 +109,7 @@ def run_tests():
         '''
         # Print statements are in for debugging, remove later, but keep the funcion calls to make sure the interface is working
         models = mdb.get_models()
-        print(models)
-
         lmd = mdb.get_model_data(models[0]['name'])
-        print(lmd)
 
     except:
         print(traceback.format_exc())

--- a/integration_testing/run_travis_tests.py
+++ b/integration_testing/run_travis_tests.py
@@ -78,7 +78,7 @@ def run_tests():
 
 
     try:
-        #mdb.learn(from_data=train_file_name, to_predict=label_headers)
+        mdb.learn(from_data=train_file_name, to_predict=label_headers)
         logger.info(f'--------------- Learning ran succesfully ---------------')
     except:
         print(traceback.format_exc())
@@ -95,7 +95,7 @@ def run_tests():
         exit(1)
 
     try:
-        '''
+
         results = mdb.predict(when_data=test_file_name)
         for row in results:
             expect_columns = [label_headers[0] ,label_headers[0] + '_confidence']
@@ -106,7 +106,7 @@ def run_tests():
                     exit(1)
 
         logger.info(f'--------------- Predicting ran succesfully ---------------')
-        '''
+
         # Print statements are in for debugging, remove later, but keep the funcion calls to make sure the interface is working
         models = mdb.get_models()
         lmd = mdb.get_model_data(models[0]['name'])

--- a/integration_testing/run_travis_tests.py
+++ b/integration_testing/run_travis_tests.py
@@ -78,7 +78,7 @@ def run_tests():
 
 
     try:
-        mdb.learn(from_data=train_file_name, to_predict=label_headers)
+        #mdb.learn(from_data=train_file_name, to_predict=label_headers)
         logger.info(f'--------------- Learning ran succesfully ---------------')
     except:
         print(traceback.format_exc())
@@ -95,6 +95,7 @@ def run_tests():
         exit(1)
 
     try:
+        '''
         results = mdb.predict(when_data=test_file_name)
         for row in results:
             expect_columns = [label_headers[0] ,label_headers[0] + '_confidence']
@@ -105,9 +106,14 @@ def run_tests():
                     exit(1)
 
         logger.info(f'--------------- Predicting ran succesfully ---------------')
-
+        '''
+        # Print statements are in for debugging, remove later, but keep the funcion calls to make sure the interface is working
         models = mdb.get_models()
         print(models)
+
+        lmd = mdb.get_model_data(models[0]['name'])
+        print(lmd)
+
     except:
         print(traceback.format_exc())
         logger.error(f'Failed whilst predicting')

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -193,7 +193,7 @@ class Predictor:
             lmd = pickle.load(fp)
         # ADAPTOR CODE
         amd = {}
-        for k in lmd: print(k)
+
         # Shared keys
         for k in ['name', 'version', 'is_active', 'data_source', 'predict', 'accuracy',
         'status', 'train_end_at', 'updated_at', 'created_at','data_preparation']:

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -109,9 +109,12 @@ class Predictor:
                 amd[k] = None
                 print(f'Key {k} not found in the light model metadata !')
 
-        amd['data_analysis'] = {}
-        amd['data_analysis']['target_columns_metadata'] = []
-        for col in lmd['predict_columns']:
+        amd['data_analysis'] = {
+            ,'target_columns_metadata': []
+            ,'input_columns_metadata': []
+        }
+        
+        for col in lmd['model_columns_map'].keys():
             icm = {}
             icm['column_name'] = col
             icm['importance_score'] = 0 #lmd['column_importances'][col]
@@ -206,19 +209,10 @@ class Predictor:
                     ,"description": "Scores have no descriptions yet"
                 }
 
-
-            amd['data_analysis']['target_columns_metadata'].append(icm)
-
-        amd['data_analysis']['input_columns_metadata'] = []
-        for col in lmd['model_columns_map'].keys():
-            if col not in lmd['predict_columns']:
-                icm = {}
-                icm['column_name'] = col
-                icm['importance_score'] = lmd['column_importances'][col]
-                icm['data_type'] = lmd['column_stats'][col]['data_type']
-                icm['data_subtype'] = lmd['column_stats'][col]['data_subtype']
-
-                #amd['data_analysis']['input_columns_metadata'].append(icm)
+            if col in lmd['predict_columns']:
+                amd['data_analysis']['target_columns_metadata'].append(icm)
+            else:
+                amd['data_analysis']['input_columns_metadata'].append(icm)
 
 
         # ADAPTOR CODE

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -110,14 +110,15 @@ class Predictor:
                 print(f'Key {k} not found in the light model metadata !')
 
         amd['data_analysis'] = {
-            ,'target_columns_metadata': []
+            'target_columns_metadata': []
             ,'input_columns_metadata': []
         }
-        
+
+        amd['model_analysis'] = []
+
         for col in lmd['model_columns_map'].keys():
             icm = {}
             icm['column_name'] = col
-            icm['importance_score'] = 0 #lmd['column_importances'][col]
             icm['data_type'] = lmd['column_stats'][col]['data_type']
             icm['data_subtype'] = lmd['column_stats'][col]['data_subtype']
 
@@ -210,9 +211,42 @@ class Predictor:
                 }
 
             if col in lmd['predict_columns']:
+                icm['importance_score'] = None
                 amd['data_analysis']['target_columns_metadata'].append(icm)
+
+                # Model analysis building for each of the predict columns
+                mao = {
+                    'column_name': col
+                    ,'overall_input_importance': {
+                        "type": "categorical"
+                        ,"x": []
+                        ,"y": []
+                    }
+                  ,"train_accuracy_over_time": {
+                    "type": "categorical",
+                    "x": [0],
+                    "y": [0]
+                  }
+                  ,"test_accuracy_over_time": {
+                    "type": "categorical",
+                    "x": [0],
+                    "y": [0]
+                  }
+                  ,"accuracy_histogram": {
+                    
+                  }
+                }
+
+                for icol in lmd['model_columns_map'].keys():
+                    if icol not in lmd['predict_columns']:
+                        mao['overall_input_importance']['x'].append(icol)
+                        mao['overall_input_importance']['y'].append(lmd['column_importances'][icol])
+
+                amd['model_analysis'].append(mao)
             else:
+                icm['importance_score'] = lmd['column_importances'][col]
                 amd['data_analysis']['input_columns_metadata'].append(icm)
+
 
 
         # ADAPTOR CODE

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -186,6 +186,8 @@ class Predictor:
                 ,"description": "Scores have no descriptions yet"
             }
 
+            return icm
+
     def get_model_data(self, model_name):
         with open(CONFIG.MINDSDB_STORAGE_PATH + f'/{model_name}_light_model_metadata.pickle', 'rb') as fp:
             lmd = pickle.load(fp)
@@ -214,7 +216,7 @@ class Predictor:
             icm = self._adapt_column(lmd['column_stats'][col],col)
 
             if col in lmd['predict_columns']:
-                
+
                 icm['importance_score'] = None
                 amd['data_analysis']['target_columns_metadata'].append(icm)
 


### PR DESCRIPTION
Finished the two functions for the mindsdb server:

`get_model_data(model_name)` which returns a json to be used by the frontend for plots

and

`get_models()` to be used by the mindsdb server to get a list of all the modules

Loads of the data is incomplete because... well, we don't generate said data yet, I'll make some issues around that.

Hopefully the schema is ok, some things may have to change because I might have missed something, but overall it seems fine. Will start integrating this with the server tomorrow.

Oh, I think we might also want to close  (#154) for now, since the difference between what the server expects and the actual light metadata were so big we had to write the adapter.

It might be nice to get a separate schema for the light metadata in the future, but for now there's not enough time for that. As for the schema for the adapted metadata we send to the server, the one currently in the mindsdb-server should do.