### PR TITLE
Ludwig online train

### DIFF
--- a/integration_testing/run_travis_tests.py
+++ b/integration_testing/run_travis_tests.py
@@ -110,8 +110,8 @@ def run_tests():
         # Print statements are in for debugging, remove later, but keep the funcion calls to make sure the interface is working
         models = mdb.get_models()
         lmd = mdb.get_model_data(models[0]['name'])
-        print(lmd)
-        
+        #print(lmd)
+
     except:
         print(traceback.format_exc())
         logger.error(f'Failed whilst predicting')

--- a/integration_testing/run_travis_tests.py
+++ b/integration_testing/run_travis_tests.py
@@ -80,6 +80,8 @@ def run_tests():
     try:
         mdb.learn(from_data=train_file_name, to_predict=label_headers)
         logger.info(f'--------------- Learning ran succesfully ---------------')
+        mdb.learn(from_data=train_file_name, to_predict=label_headers, rebuild_model=False)
+        logger.info(f'--------------- Additional learning ran succesfully ---------------')
     except:
         print(traceback.format_exc())
         logger.error(f'Failed during the training !')

--- a/integration_testing/run_travis_tests.py
+++ b/integration_testing/run_travis_tests.py
@@ -110,7 +110,8 @@ def run_tests():
         # Print statements are in for debugging, remove later, but keep the funcion calls to make sure the interface is working
         models = mdb.get_models()
         lmd = mdb.get_model_data(models[0]['name'])
-
+        print(lmd)
+        
     except:
         print(traceback.format_exc())
         logger.error(f'Failed whilst predicting')

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -377,8 +377,6 @@ class LudwigBackend():
                 else:
                     self.transaction.lmd['model_accuracy']['train'][k].extend(train_stats['train'][k]['accuracy'])
                     self.transaction.lmd['model_accuracy']['test'][k].extend(train_stats['test'][k]['accuracy'])
-                    
-            exit()
 
         else:
             model = LudwigModel.load(self.transaction.lmd['ludwig_data']['ludwig_save_path'])

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -356,32 +356,32 @@ class LudwigBackend():
         if len(timeseries_cols) > 0:
             training_dataframe, model_definition =  self._translate_df_to_timeseries_format(training_dataframe, model_definition, timeseries_cols, 'train')
 
-        #with disable_ludwig_output():
+        with disable_ludwig_output():
 
-        if self.transaction.lmd['rebuild_model'] is True:
-            model = LudwigModel(model_definition)
+            if self.transaction.lmd['rebuild_model'] is True:
+                model = LudwigModel(model_definition)
 
-            # <---- Ludwig currently broken, since mode can't be initialized without train_set_metadata and train_set_metadata can't be obtained without running train... see this issue for any updates on the matter: https://github.com/uber/ludwig/issues/295
-            #model.initialize_model(train_set_metadata={})
-            #train_stats = model.train_online(data_df=training_dataframe) # ??Where to add model_name?? ----> model_name=self.transaction.lmd['name']
+                # <---- Ludwig currently broken, since mode can't be initialized without train_set_metadata and train_set_metadata can't be obtained without running train... see this issue for any updates on the matter: https://github.com/uber/ludwig/issues/295
+                #model.initialize_model(train_set_metadata={})
+                #train_stats = model.train_online(data_df=training_dataframe) # ??Where to add model_name?? ----> model_name=self.transaction.lmd['name']
 
-            train_stats = model.train(data_df=training_dataframe, model_name=self.transaction.lmd['name'], skip_save_model=True)
+                train_stats = model.train(data_df=training_dataframe, model_name=self.transaction.lmd['name'], skip_save_model=True)
 
-            for k in train_stats['train']:
-                if k not in self.transaction.lmd['model_accuracy']['train']:
-                    self.transaction.lmd['model_accuracy']['train'][k] = []
-                    self.transaction.lmd['model_accuracy']['test'][k] = []
-                elif k is not 'combined':
-                    # We should be adding the accuracy here but we only have it for combined, so, for now use that, will only affect multi-output scenarios anyway
-                    pass
-                else:
-                    self.transaction.lmd['model_accuracy']['train'][k].extend(train_stats['train'][k]['accuracy'])
-                    self.transaction.lmd['model_accuracy']['test'][k].extend(train_stats['test'][k]['accuracy'])
+                for k in train_stats['train']:
+                    if k not in self.transaction.lmd['model_accuracy']['train']:
+                        self.transaction.lmd['model_accuracy']['train'][k] = []
+                        self.transaction.lmd['model_accuracy']['test'][k] = []
+                    elif k is not 'combined':
+                        # We should be adding the accuracy here but we only have it for combined, so, for now use that, will only affect multi-output scenarios anyway
+                        pass
+                    else:
+                        self.transaction.lmd['model_accuracy']['train'][k].extend(train_stats['train'][k]['accuracy'])
+                        self.transaction.lmd['model_accuracy']['test'][k].extend(train_stats['test'][k]['accuracy'])
 
-        else:
-            model = LudwigModel.load(self.transaction.lmd['ludwig_data']['ludwig_save_path'])
-            for i in range(0,100):
-                train_stats = model.train_online(data_df=training_dataframe)
+            else:
+                model = LudwigModel.load(self.transaction.lmd['ludwig_data']['ludwig_save_path'])
+                for i in range(0,100):
+                    train_stats = model.train_online(data_df=training_dataframe)
 
         ludwig_model_savepath = Config.LOCALSTORE_PATH.rstrip('local_jsondb_store') + self.transaction.lmd['name']
 

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -357,14 +357,23 @@ class LudwigBackend():
             training_dataframe, model_definition =  self._translate_df_to_timeseries_format(training_dataframe, model_definition, timeseries_cols, 'train')
 
         #with disable_ludwig_output():
-        model = LudwigModel(model_definition)
 
-        # <---- Ludwig currently broken, since mode can't be initialized without train_set_metadata and train_set_metadata can't be obtained without running train...
-        #model.initialize_model(train_set_metadata={})
-        #train_stats = model.train_online(data_df=training_dataframe) #, model_name=self.transaction.lmd['name']
+        if lmd['rebuild_model'] == True:
+            model = LudwigModel.load(self.transaction.lmd['ludwig_data']['ludwig_save_path'])
+            for i in range(0,100):
+                train_stats = model.train_online(data_df=training_dataframe)
+        else:
+            model = LudwigModel(model_definition)
 
-        train_stats = model.train(data_df=training_dataframe, model_name=self.transaction.lmd['name'], skip_save_model=True)
-        print(train_stats)
+            # <---- Ludwig currently broken, since mode can't be initialized without train_set_metadata and train_set_metadata can't be obtained without running train...
+            #model.initialize_model(train_set_metadata={})
+            #train_stats = model.train_online(data_df=training_dataframe) # ??Where to add model_name?? ----> model_name=self.transaction.lmd['name']
+
+            train_stats = model.train(data_df=training_dataframe, model_name=self.transaction.lmd['name'], skip_save_model=True)
+            #print(train_stats)
+            for k in train_stats['train']:
+                print(k)
+            exit()
 
         ludwig_model_savepath = Config.LOCALSTORE_PATH.rstrip('local_jsondb_store') + self.transaction.lmd['name']
 

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -356,13 +356,16 @@ class LudwigBackend():
         if len(timeseries_cols) > 0:
             training_dataframe, model_definition =  self._translate_df_to_timeseries_format(training_dataframe, model_definition, timeseries_cols, 'train')
 
-        with disable_ludwig_output():
-            model = LudwigModel(model_definition)
+        #with disable_ludwig_output():
+        model = LudwigModel(model_definition)
 
-            # Figure out how to pass `model_load_path`
-            train_stats = model.train(data_df=training_dataframe, model_name=self.transaction.lmd['name'])
+        # <---- Ludwig currently broken, since mode can't be initialized without train_set_metadata and train_set_metadata can't be obtained without running train...
+        #model.initialize_model(train_set_metadata={})
+        #train_stats = model.train_online(data_df=training_dataframe) #, model_name=self.transaction.lmd['name']
 
-        #model.model.weights_save_path.rstrip('/model_weights_progress') + '/model'
+        train_stats = model.train(data_df=training_dataframe, model_name=self.transaction.lmd['name'], skip_save_model=True)
+        print(train_stats)
+
         ludwig_model_savepath = Config.LOCALSTORE_PATH.rstrip('local_jsondb_store') + self.transaction.lmd['name']
 
         model.save(ludwig_model_savepath)

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -358,30 +358,36 @@ class LudwigBackend():
 
         with disable_ludwig_output():
 
+            model = LudwigModel(model_definition)
+
+            # <---- Ludwig currently broken, since mode can't be initialized without train_set_metadata and train_set_metadata can't be obtained without running train... see this issue for any updates on the matter: https://github.com/uber/ludwig/issues/295
+            #model.initialize_model(train_set_metadata={})
+            #train_stats = model.train_online(data_df=training_dataframe) # ??Where to add model_name?? ----> model_name=self.transaction.lmd['name']
+
             if self.transaction.lmd['rebuild_model'] is True:
-                model = LudwigModel(model_definition)
-
-                # <---- Ludwig currently broken, since mode can't be initialized without train_set_metadata and train_set_metadata can't be obtained without running train... see this issue for any updates on the matter: https://github.com/uber/ludwig/issues/295
-                #model.initialize_model(train_set_metadata={})
-                #train_stats = model.train_online(data_df=training_dataframe) # ??Where to add model_name?? ----> model_name=self.transaction.lmd['name']
-
                 train_stats = model.train(data_df=training_dataframe, model_name=self.transaction.lmd['name'], skip_save_model=True)
-
-                for k in train_stats['train']:
-                    if k not in self.transaction.lmd['model_accuracy']['train']:
-                        self.transaction.lmd['model_accuracy']['train'][k] = []
-                        self.transaction.lmd['model_accuracy']['test'][k] = []
-                    elif k is not 'combined':
-                        # We should be adding the accuracy here but we only have it for combined, so, for now use that, will only affect multi-output scenarios anyway
-                        pass
-                    else:
-                        self.transaction.lmd['model_accuracy']['train'][k].extend(train_stats['train'][k]['accuracy'])
-                        self.transaction.lmd['model_accuracy']['test'][k].extend(train_stats['test'][k]['accuracy'])
-
             else:
+                train_stats = model.train(data_df=training_dataframe, model_name=self.transaction.lmd['name'], skip_save_model=True,
+                model_load_path=self.transaction.lmd['ludwig_data']['ludwig_save_path'])
+
+            for k in train_stats['train']:
+                if k not in self.transaction.lmd['model_accuracy']['train']:
+                    self.transaction.lmd['model_accuracy']['train'][k] = []
+                    self.transaction.lmd['model_accuracy']['test'][k] = []
+                elif k is not 'combined':
+                    # We should be adding the accuracy here but we only have it for combined, so, for now use that, will only affect multi-output scenarios anyway
+                    pass
+                else:
+                    self.transaction.lmd['model_accuracy']['train'][k].extend(train_stats['train'][k]['accuracy'])
+                    self.transaction.lmd['model_accuracy']['test'][k].extend(train_stats['test'][k]['accuracy'])
+
+                '''
+                @ TRAIN ONLINE BIT That's not working
                 model = LudwigModel.load(self.transaction.lmd['ludwig_data']['ludwig_save_path'])
                 for i in range(0,100):
                     train_stats = model.train_online(data_df=training_dataframe)
+                    # The resulting train_stats are "None"... wonderful -_-
+                '''
 
         ludwig_model_savepath = Config.LOCALSTORE_PATH.rstrip('local_jsondb_store') + self.transaction.lmd['name']
 

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -361,7 +361,7 @@ class LudwigBackend():
         if self.transaction.lmd['rebuild_model'] is True:
             model = LudwigModel(model_definition)
 
-            # <---- Ludwig currently broken, since mode can't be initialized without train_set_metadata and train_set_metadata can't be obtained without running train...
+            # <---- Ludwig currently broken, since mode can't be initialized without train_set_metadata and train_set_metadata can't be obtained without running train... see this issue for any updates on the matter: https://github.com/uber/ludwig/issues/295
             #model.initialize_model(train_set_metadata={})
             #train_stats = model.train_online(data_df=training_dataframe) # ??Where to add model_name?? ----> model_name=self.transaction.lmd['name']
 

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -384,6 +384,25 @@ class Predictor:
         light_transaction_metadata['rebuild_model'] = rebuild_model
         light_transaction_metadata['model_accuracy'] = {'train': {}, 'test': {}}
 
+        if rebuild_model is False:
+            old_lmd = {}
+            for k in light_transaction_metadata: old_lmd[k] = light_transaction_metadata[k]
+
+            old_hmd = {}
+            for k in heavy_transaction_metadata: old_hmd[k] = heavy_transaction_metadata[k]
+
+            with open(CONFIG.MINDSDB_STORAGE_PATH + '/' + light_transaction_metadata['name'] + '_light_model_metadata.pickle', 'rb') as fp:
+                light_transaction_metadata = pickle.load(fp)
+
+            with open(CONFIG.MINDSDB_STORAGE_PATH + '/' +heavy_transaction_metadata['name'] + '_heavy_model_metadata.pickle', 'rb') as fp:
+                heavy_transaction_metadata= pickle.load(fp)
+
+            for k in ['data_preparation']:
+                if old_lmd[k] is not None: light_transaction_metadata[k] = old_lmd[k]
+
+            for k in ['from_data', 'test_from_data']:
+                if old_hmd[k] is not None: heavy_transaction_metadata[k] = old_hmd[k]
+
         Transaction(session=self, light_transaction_metadata=light_transaction_metadata, heavy_transaction_metadata=heavy_transaction_metadata, logger=self.log, breakpoint=breakpoint)
 
 

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -279,7 +279,7 @@ class Predictor:
 
     def learn(self, to_predict, from_data = None, test_from_data=None, group_by = None, window_size_samples = None, window_size_seconds = None,
     window_size = None, order_by = [], sample_margin_of_error = CONFIG.DEFAULT_MARGIN_OF_ERROR, ignore_columns = [], rename_strange_columns = False,
-    stop_training_in_x_seconds = None, stop_training_in_accuracy = None,  send_logs=CONFIG.SEND_LOGS, backend='ludwig'):
+    stop_training_in_x_seconds = None, stop_training_in_accuracy = None,  send_logs=CONFIG.SEND_LOGS, backend='ludwig', rebuild_model=True):
         """
         Tells the mind to learn to predict a column or columns from the data in 'from_data'
 
@@ -370,6 +370,7 @@ class Predictor:
         light_transaction_metadata['sample_confidence_level'] = sample_confidence_level
         light_transaction_metadata['stop_training_in_x_seconds'] = stop_training_in_x_seconds
         light_transaction_metadata['stop_training_in_accuracy'] = stop_training_in_accuracy
+        light_transaction_metadata['rebuild_model'] = rebuild_model
 
         Transaction(session=self, light_transaction_metadata=light_transaction_metadata, heavy_transaction_metadata=heavy_transaction_metadata, logger=self.log, breakpoint=breakpoint)
 

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -397,7 +397,7 @@ class Predictor:
             with open(CONFIG.MINDSDB_STORAGE_PATH + '/' +heavy_transaction_metadata['name'] + '_heavy_model_metadata.pickle', 'rb') as fp:
                 heavy_transaction_metadata= pickle.load(fp)
 
-            for k in ['data_preparation']:
+            for k in ['data_preparation', 'rebuild_model']:
                 if old_lmd[k] is not None: light_transaction_metadata[k] = old_lmd[k]
 
             for k in ['from_data', 'test_from_data']:

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -99,7 +99,7 @@ class Predictor:
         icm['data_subtype'] = col_stats['data_subtype']
 
         icm['data_type_distribution'] = {
-            'type': col_stats['data_type']
+            'type': "categorical"
             ,'x': []
             ,'y': []
         }
@@ -108,7 +108,7 @@ class Predictor:
             icm['data_type_distribution']['y'].append(col_stats['data_type_dist'][k])
 
         icm['data_subtype_distribution'] = {
-            'type': col_stats['data_subtype']
+            'type': "categorical"
             ,'x': []
             ,'y': []
         }
@@ -118,7 +118,7 @@ class Predictor:
 
         icm['data_distribution'] = {}
         icm['data_distribution']['data_histogram'] = {
-            "type": col_stats['data_type'],
+            "type": "categorical",
             'x': [],
             'y': []
         }

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -245,8 +245,8 @@ class Predictor:
                   }
                 }
 
-                train_acc = self.lmd['model_accuracy']['train']['combined']
-                test_acc = self.lmd['model_accuracy']['test']['combined']
+                train_acc = lmd['model_accuracy']['train']['combined']
+                test_acc = lmd['model_accuracy']['test']['combined']
 
                 for i in range(0,len(train_acc)):
                     mao['train_accuracy_over_time']['x'] = i

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -397,7 +397,7 @@ class Predictor:
             with open(CONFIG.MINDSDB_STORAGE_PATH + '/' +heavy_transaction_metadata['name'] + '_heavy_model_metadata.pickle', 'rb') as fp:
                 heavy_transaction_metadata= pickle.load(fp)
 
-            for k in ['data_preparation', 'rebuild_model']:
+            for k in ['data_preparation', 'rebuild_model', 'data_source', 'type', 'ignore_columns', 'sample_margin_of_error', 'sample_confidence_level', 'stop_training_in_x_seconds', 'stop_training_in_accuracy']:
                 if old_lmd[k] is not None: light_transaction_metadata[k] = old_lmd[k]
 
             for k in ['from_data', 'test_from_data']:

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -245,6 +245,17 @@ class Predictor:
                   }
                 }
 
+                train_acc = self.lmd['model_accuracy']['train']['combined']
+                test_acc = self.lmd['model_accuracy']['test']['combined']
+
+                for i in range(0,len(train_acc)):
+                    mao['train_accuracy_over_time']['x'] = i
+                    mao['train_accuracy_over_time']['y'] = train_acc[i]
+
+                for i in range(0,len(test_acc)):
+                    mao['test_accuracy_over_time']['x'] = i
+                    mao['test_accuracy_over_time']['y'] = test_acc[i]
+
                 for sub_group in mao['accuracy_histogram']['x']:
                     sub_group_stats = {} # Something like: `self._adapt_column(lmd['subgroup_stats'][col][sub_group],col) ``... once we actually implement the subgroup stats
                     # TEMP PLACEHOLDER
@@ -371,6 +382,7 @@ class Predictor:
         light_transaction_metadata['stop_training_in_x_seconds'] = stop_training_in_x_seconds
         light_transaction_metadata['stop_training_in_accuracy'] = stop_training_in_accuracy
         light_transaction_metadata['rebuild_model'] = rebuild_model
+        light_transaction_metadata['model_accuracy'] = {'train': {}, 'test': {}}
 
         Transaction(session=self, light_transaction_metadata=light_transaction_metadata, heavy_transaction_metadata=heavy_transaction_metadata, logger=self.log, breakpoint=breakpoint)
 

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -230,13 +230,13 @@ class Predictor:
                     }
                   ,"train_accuracy_over_time": {
                     "type": "categorical",
-                    "x": [0],
-                    "y": [0]
+                    "x": [],
+                    "y": []
                   }
                   ,"test_accuracy_over_time": {
                     "type": "categorical",
-                    "x": [0],
-                    "y": [0]
+                    "x": [],
+                    "y": []
                   }
                   ,"accuracy_histogram": {
                         "x": []
@@ -249,12 +249,12 @@ class Predictor:
                 test_acc = lmd['model_accuracy']['test']['combined']
 
                 for i in range(0,len(train_acc)):
-                    mao['train_accuracy_over_time']['x'] = i
-                    mao['train_accuracy_over_time']['y'] = train_acc[i]
+                    mao['train_accuracy_over_time']['x'].append(i)
+                    mao['train_accuracy_over_time']['y'].append(train_acc[i])
 
                 for i in range(0,len(test_acc)):
-                    mao['test_accuracy_over_time']['x'] = i
-                    mao['test_accuracy_over_time']['y'] = test_acc[i]
+                    mao['test_accuracy_over_time']['x'].append(i)
+                    mao['test_accuracy_over_time']['y'].append([i])
 
                 for sub_group in mao['accuracy_histogram']['x']:
                     sub_group_stats = {} # Something like: `self._adapt_column(lmd['subgroup_stats'][col][sub_group],col) ``... once we actually implement the subgroup stats

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -220,7 +220,6 @@ class Transaction:
             # Don't save data for now
             pickle.dump(self.hmd, fp)
 
-        print(self.lmd)
         return
 
 


### PR DESCRIPTION
* Sourcing training stats (accuracy) from ludwig
* Allow models to be trained further by adding the `rebuild_model=False` argument to the `learn` method of the Preidctor

Initially the intention was to switch to using ludwig's `online_train`, but it's apparently garbage in many ways (see comments in the ludwig code and issue https://github.com/uber/ludwig/issues/295), so for now we stuck with `train`.

sadly enough, this means we can't really control how long training takes or the number of epochs or gather our own information about the model whilst it's being trained :(

