### PR TITLE
Stats generator review and improvements

### DIFF
--- a/docs/website/docs/ColumnMetrics.md
+++ b/docs/website/docs/ColumnMetrics.md
@@ -1,0 +1,159 @@
+---
+id: column_metrics
+title: Column metrics
+---
+
+Mindsdb generate some metrics (we call them "scores") for each of the columns it processes in order to determine the quality.
+
+This document contains information on each of these scores, as well as an outline for how mindsdb computes and uses them.
+
+# The Scores
+
+## Value Distribution Score
+
+Warning if: > 0.8
+
+Reliability: Average
+
+The duplicates score represents how biased the data is towards a certain value.
+
+We compute this as one minus the number of time the most common value occurs over the mean of the nr of occurrences for all values.
+
+This score can indicate either biasing towards one specific value of a column or a large number of outliers. So it is a reliable quality indicator but we aren’t always sure “why” that is (as in, it can fall into 2 buckets).
+
+
+
+We might want to give different warnings based on the value of the z score and the lof score.
+
+If this score is especially high > 0.8 (meaning a value is present 5x times more than the mean), then we will warn the user and inform him what said most common value is.  
+
+
+## Duplicates Score
+
+Warning if: > 0.5 AND overall quality is low
+
+Reliability: Poor
+
+As it stands, duplicates score consists in the % of duplicate values / 100. So, it can range from 0 (no duplicates) to 1 (all the values have one or more duplicates).
+
+This score is always 0 if the data type is categorical or date. Since duplicates in those cases are to be expected.
+
+It’s also not necessarily “bad” if this score is large, for example, a text column consisting of: [‘house’, ‘apartment’, ‘house’, ‘apartment’, ‘duplex’, ‘house’, ‘apartment’, ‘duplex’], maybe not be interpreted as “categorical” by our data type generator and will have a duplicate score of 1.
+
+Thus, we should give a warning about this score if it’s above 0.5, but ONLY if the overall quality of the data is bad overall.
+
+
+## Empty cells score
+
+Warning if: > 0.2
+
+Reliability: Good
+
+This score is computed as the % of empty values / 100. It’s very reliable on its own, since empty values in a column are never a good sign.
+
+If more than 20% of a column is empty, the user should be warned about it, since that column will likely introduce some unreliability within the model itself.
+
+
+## Data type distribution score
+
+Warning if: > 0.2
+
+Reliability: Average
+
+This score indicates the % of data that are not of the same data type as the principal column type / 100.
+
+Realistically speaking, it’s unlikely this score will often be close to 1, so we should give a warning at a rather low value (I’ve chosen 0.2).
+
+
+## Z Test based outlier score
+
+Warning if: > 0.3
+
+Reliability: Average
+
+This score indicates the % of data that are 3 STDs or more away from the mean.
+
+ \
+There are various types of data where this can be the case, but usually it might indicate the data has too much noise.
+
+We should warn the user if this value is above 0.3 (over 30% of the data are considered outliers based on the test).
+
+
+## Local outlier factor score
+
+Warning if: > 0.2
+
+Reliability: Average
+
+The LOF algorithm from sklearn, which is a knn based approach using the 20th nearest neighbours to classify a data point.
+
+Data points are clusters and an outlier score is given to each data point (1 is an inliner, -1 is an outlier).
+
+We consider every point with an LOF score < 0.8 to be an outlier and compute the lof outlier score as the nr of these outliers / 100.
+
+LOF is fairly proven on real datasets at discovering outliers, but less intuitive (we currently treat it as a blackbox) than something like the z score, so we should be careful on relying too much on it.
+
+Since obtaining a score of < 0.8 based on LOF is rather difficult, we should be worries with the overall number of outliers is > 20% (score > 0.2), which is a significant amount of data that doesn’t fit closely in any cluster.
+
+
+## Similarity score
+
+Warning if: > 0.5
+
+Reliability: Good (When high)
+
+This score is simply a matthews correlation applied between this column and all other column.
+
+The score * 100 is the number of values which are similar in the column that is most similar to the scored column.
+
+If this score is > 0.5 that means half the values are similar (in the same position) in two columns, we should warn the user about this by information him of which two columns are correlated.
+
+
+## Correlation score
+
+Warning if: > 0.4
+
+Reliability: Average
+
+This score uses a classifier (in this case a decision tree) and tries to predict the value in one column based on the values in all the other column (the classifier is pre-fit on the data it tries to predict, so we essentially just look at the features biasing inside the classifier by running a predict).
+
+If the prediction is highly accurate and one column in particular is most important in making the prediction, this score will be bad. We compute it as the highest correlated column (from 0 to 1) times the accuracy of the prediction (using sklearn’s score function, at most this value is 1).
+
+If this score is above 0.4, we should warn the user that one of his column is heavily correlated with this.
+
+
+# Derived scores
+
+
+## Consistency score
+
+Warning if: > 0.2
+
+Reliability: Average
+
+The data consistency score is mainly based upon the **Data Type Distribution Score** and the **Empty Cells Score**, the **Duplicates Score** is also taken into account if present but with a smaller (2x smaller) bias.
+
+If this score is > 0.2 we should warn the user about the data in his column being inconsistent (as in, incomplete and/or vague)
+
+
+## Redundancy score
+
+Warning if: > 0.45
+
+Reliability: Average
+
+The value is based in equal part on the **Similarity Score** and the **Correlation Score**.
+
+If this score is > 0.45 we should warn the user about the data in his column being possibly redundant, that means any insights implied by this column are already present in the data from other columns).
+
+Variability/Randomness score
+
+Warning if: > 0.5
+
+Reliability: Average
+
+The value is based in equal part on the **Z Test based outliers score**, the **LOG based outlier score** and the **Value Distribution Score**.
+
+In certain cases, only the **Value Distribution Score **can be computed for the column. Then, we reduce the relevance of this score by dividing it by 2 (possibly not the best approach).
+
+If this score is > 0.5 we should warn the user that there’s too much randomness/noise in this data.

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -134,18 +134,21 @@ class Predictor:
                 metrics.append({
                       "type": "score",
                       "score": col_stats['data_type_distribution_score'],
-                      "description": "Scores have no descriptions yet"
+                      "description": col_stats['data_type_distribution_description'],
+                      "warning": col_stats['data_type_distribution_warning']
                 })
                 metrics.append({
                       "type": "score",
                       "score": col_stats['empty_cells_score'],
-                      "description": "Scores have no descriptions yet"
+                      "description": col_stats['empty_cells_score_description'],
+                      "warning": col_stats['empty_cells_score_warning']
                 })
                 if 'duplicates_score' in col_stats:
                     metrics.append({
                           "type": "score",
                           "score": col_stats['duplicates_score'],
-                          "description": "Scores have no descriptions yet"
+                          "description": col_stats['duplicates_score_description'],
+                          "warning": col_stats['duplicates_score_warning']
                     })
 
             if score == 'variability_score':
@@ -153,30 +156,35 @@ class Predictor:
                     metrics.append({
                           "type": "score",
                           "score": col_stats['lof_based_outlier_score'],
-                          "description": "Scores have no descriptions yet"
+                          "description": col_stats['lof_based_outlier_score_description'],
+                          "warning": col_stats['lof_based_outlier_score_warning']
                     })
                     metrics.append({
                           "type": "score",
                           "score": col_stats['z_test_based_outlier_score'],
-                          "description": "Scores have no descriptions yet"
+                          "description": col_stats['z_test_based_outlier_score_description'],
+                          "warning": col_stats['z_test_based_outlier_score_warning']
                     })
                     metrics.append({
                           "type": "score",
                           "score": col_stats['value_distribution_score'],
-                          "description": "Scores have no descriptions yet"
+                          "description": col_stats['value_distribution_score_description'],
+                          "warning": col_stats['value_distribution_score_warning']
                     })
                 else:
                     metrics.append({
                           "type": "score",
                           "score": col_stats['value_distribution_score'],
-                          "description": "Scores have no descriptions yet"
+                          "description": col_stats['value_distribution_score_description'],
+                          "warning": col_stats['value_distribution_score_warning']
                     })
 
             if score == 'redundancy_score':
                 metrics.append({
                       "type": "score",
                       "score": col_stats['similarity_score'],
-                      "description": "Scores have no descriptions yet"
+                          "description": col_stats['similarity_score_description'],
+                          "warning": col_stats['similarity_score_warning']
                 })
 
 

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -183,15 +183,16 @@ class Predictor:
                 metrics.append({
                       "type": "score",
                       "score": col_stats['similarity_score'],
-                          "description": col_stats['similarity_score_description'],
-                          "warning": col_stats['similarity_score_warning']
+                      "description": col_stats['similarity_score_description'],
+                      "warning": col_stats['similarity_score_warning']
                 })
 
 
             icm[score.replace('','_score')] = {
                 'score': col_stats[score],
                 'metrics': metrics
-                ,"description": "Scores have no descriptions yet"
+                "description": col_stats[f'{score}_description'],
+                "warning": col_stats[f'{score}_warning']
             }
 
             return icm

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -134,8 +134,8 @@ class Predictor:
                 metrics.append({
                       "type": "score",
                       "score": col_stats['data_type_distribution_score'],
-                      "description": col_stats['data_type_distribution_description'],
-                      "warning": col_stats['data_type_distribution_warning']
+                      "description": col_stats['data_type_distribution_score_description'],
+                      "warning": col_stats['data_type_distribution_score_warning']
                 })
                 metrics.append({
                       "type": "score",

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -190,7 +190,7 @@ class Predictor:
 
             icm[score.replace('','_score')] = {
                 'score': col_stats[score],
-                'metrics': metrics
+                'metrics': metrics,
                 "description": col_stats[f'{score}_description'],
                 "warning": col_stats[f'{score}_warning']
             }

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -631,17 +631,22 @@ class StatsGenerator(BaseModule):
                 w = f'The values in column {col_name} rate poorly in terms of consistency. This means the data has too many empty values, values with a hard to determine type and duplicate values. Please see the detailed logs bellow for more info'
                 self.log.warning(w)
                 col_stats['consistency_score_warning'] = w
+            else:
+                col_stats['consistency_score_warning'] = None
 
             if col_stats['redundancy_score'] > 0.45:
                 w = f'The data in the column {col_name} is likely somewhat redundant, any insight it can give us can already by deduced from your other columns. Please see the detailed logs bellow for more info'
                 self.log.warning(w)
                 col_stats['redundancy_score_warning'] = w
+            else:
+                col_stats['redundancy_score_warning'] = None
 
             if col_stats['variability_score'] > 0.5:
                 w = f'The data in the column {col_name} seems to have too contain too much noise/randomness based on the value variability. That is too say, the data is too unevenly distributed and has too many outliers. Please see the detailed logs bellow for more info.'
                 self.log.warning(w)
                 col_stats['variability_score_warning'] = w
-
+            else:
+                col_stats['variability_score_warning'] = None
 
             # Some scores are meaningful on their own, and the user should be warnned if they fall bellow a certain threshold
             if col_stats['empty_cells_score'] > 0.2:
@@ -649,6 +654,8 @@ class StatsGenerator(BaseModule):
                 w = f'{empty_cells_percentage}% of the values in column {col_name} are empty, this might indicate your data is of poor quality.'
                 self.log.warning(w)
                 col_stats['empty_cells_score_warning'] = w
+            else:
+                col_stats['empty_cells_score_warning'] = None
 
             if col_stats['data_type_distribution_score'] > 0.2:
                 #self.log.infoChart(stats[col_name]['data_type_dist'], type='list', uid='Dubious Data Type Distribution for column "{}"'.format(col_name))
@@ -657,6 +664,8 @@ class StatsGenerator(BaseModule):
                 w = f'{percentage_of_data_not_of_principal_type}% of your data is not of type {principal_data_type}, which was detected to be the data type for column {col_name}, this might indicate your data is of poor quality.'
                 self.log.warning(w)
                 col_stats['data_type_distribution_score_warning'] = w
+            else:
+                col_stats['data_type_distribution_score_warning'] = None
 
             if 'z_test_based_outlier_score' in col_stats and col_stats['z_test_based_outlier_score'] > 0.3:
                 percentage_of_outliers = col_stats['z_test_based_outlier_score']*100
@@ -664,6 +673,8 @@ class StatsGenerator(BaseModule):
                 be too much randomness in this column for us to make an accurate prediction based on it."""
                 self.log.warning(w)
                 col_stats['z_test_based_outlier_score_warning'] = w
+            else:
+                col_stats['z_test_based_outlier_score_warning'] = None
 
             if 'lof_based_outlier_score' in col_stats and col_stats['lof_based_outlier_score'] > 0.3:
                 percentage_of_outliers = col_stats['percentage_of_log_based_outliers']
@@ -671,13 +682,16 @@ class StatsGenerator(BaseModule):
                 be too much randomness in this column for us to make an accurate prediction based on it."""
                 self.log.warning(w)
                 col_stats['lof_based_outlier_score_warning'] = w
+            else:
+                col_stats['lof_based_outlier_score_warning'] = None
 
             if col_stats['value_distribution_score'] > 0.8:
                 max_probability_key = col_stats['max_probability_key']
                 w = f"""Column {col_name} is very biased towards the value {max_probability_key}, please make sure that the data in this column is correct !"""
                 self.log.warning(w)
                 col_stats['lvalue_distribution_score_warning'] = w
-
+            else:
+                col_stats['value_distribution_score_warning'] = None
 
             if col_stats['similarity_score'] > 0.5:
                 similar_percentage = col_stats['similarity_score'] * 100
@@ -685,7 +699,8 @@ class StatsGenerator(BaseModule):
                 w = f'Column {col_name} and {similar_col_name} are {similar_percentage}% the same, please make sure these represent two distinct features of your data !'
                 self.log.warning(w)
                 col_stats['lof_based_outlier_score_warning'] = w
-
+            else:
+                col_stats['similarity_score_warning'] = None
 
             '''
             if col_stats['correlation_score'] > 0.4:

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -623,8 +623,11 @@ class StatsGenerator(BaseModule):
                 self.log.warning('Column "{}" is considered of low quality, the scores that influenced this decission will be listed bellow')
                 if col_stats['duplicates_score'] > 0.5:
                     duplicates_percentage = col_stats['duplicates_percentage']
-                    self.log.warning(f'{duplicates_percentage}% of the values in column {col_name} seem to be repeated, this might indicate your data is of poor quality.')
-
+                    w = f'{duplicates_percentage}% of the values in column {col_name} seem to be repeated, this might indicate your data is of poor quality.'
+                    self.log.warning(w)
+                    col_stats['duplicates_score_warning'] = w
+                else:
+                    col_stats['duplicates_score_warning'] = None
 
             #Compound scores
             if col_stats['consistency_score'] > 0.25:

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -630,44 +630,62 @@ class StatsGenerator(BaseModule):
             if col_stats['consistency_score'] > 0.25:
                 w = f'The values in column {col_name} rate poorly in terms of consistency. This means the data has too many empty values, values with a hard to determine type and duplicate values. Please see the detailed logs bellow for more info'
                 self.log.warning(w)
+                col_stats['consistency_score_warning'] = w
 
             if col_stats['redundancy_score'] > 0.45:
-                self.log.warning(f'The data in the column {col_name} is likely somewhat redundant, any insight it can give us can already by deduced from your other columns. Please see the detailed logs bellow for more info')
+                w = f'The data in the column {col_name} is likely somewhat redundant, any insight it can give us can already by deduced from your other columns. Please see the detailed logs bellow for more info'
+                self.log.warning(w)
+                col_stats['redundancy_score_warning'] = w
 
             if col_stats['variability_score'] > 0.5:
-                self.log.warning(f'The data in the column {col_name} seems to have too contain too much noise/randomness based on the value variability. That is too say, the data is too unevenly distributed and has too many outliers. Please see the detailed logs bellow for more info.')
-
+                w = f'The data in the column {col_name} seems to have too contain too much noise/randomness based on the value variability. That is too say, the data is too unevenly distributed and has too many outliers. Please see the detailed logs bellow for more info.'
+                self.log.warning(w)
+                col_stats['variability_score_warning'] = w
 
 
             # Some scores are meaningful on their own, and the user should be warnned if they fall bellow a certain threshold
             if col_stats['empty_cells_score'] > 0.2:
                 empty_cells_percentage = col_stats['empty_percentage']
-                self.log.warning(f'{empty_cells_percentage}% of the values in column {col_name} are empty, this might indicate your data is of poor quality.')
+                w = f'{empty_cells_percentage}% of the values in column {col_name} are empty, this might indicate your data is of poor quality.'
+                self.log.warning(w)
+                col_stats['empty_cells_score_warning'] = w
 
             if col_stats['data_type_distribution_score'] > 0.2:
                 #self.log.infoChart(stats[col_name]['data_type_dist'], type='list', uid='Dubious Data Type Distribution for column "{}"'.format(col_name))
                 percentage_of_data_not_of_principal_type = col_stats['data_type_distribution_score'] * 100
                 principal_data_type = col_stats['data_type']
-                self.log.warning(f'{percentage_of_data_not_of_principal_type}% of your data is not of type {principal_data_type}, which was detected to be the data type for column {col_name}, this might indicate your data is of poor quality.')
+                w = f'{percentage_of_data_not_of_principal_type}% of your data is not of type {principal_data_type}, which was detected to be the data type for column {col_name}, this might indicate your data is of poor quality.'
+                self.log.warning(w)
+                col_stats['data_type_distribution_score_warning'] = w
 
             if 'z_test_based_outlier_score' in col_stats and col_stats['z_test_based_outlier_score'] > 0.3:
                 percentage_of_outliers = col_stats['z_test_based_outlier_score']*100
-                self.log.warning(f"""Column {col_name} has a very high amount of outliers, {percentage_of_outliers}% of your data is more than 3 standard deviations away from the mean, this means there might
-                be too much randomness in this column for us to make an accurate prediction based on it.""")
+                w = f"""Column {col_name} has a very high amount of outliers, {percentage_of_outliers}% of your data is more than 3 standard deviations away from the mean, this means there might
+                be too much randomness in this column for us to make an accurate prediction based on it."""
+                self.log.warning(w)
+                col_stats['z_test_based_outlier_score_warning'] = w
 
             if 'lof_based_outlier_score' in col_stats and col_stats['lof_based_outlier_score'] > 0.3:
                 percentage_of_outliers = col_stats['percentage_of_log_based_outliers']
-                self.log.warning(f"""Column {col_name} has a very high amount of outliers, {percentage_of_outliers}% of your data doesn't fit closely in any cluster using the KNN algorithm (20n) to cluster your data, this means there might
-                be too much randomness in this column for us to make an accurate prediction based on it.""")
+                w = f"""Column {col_name} has a very high amount of outliers, {percentage_of_outliers}% of your data doesn't fit closely in any cluster using the KNN algorithm (20n) to cluster your data, this means there might
+                be too much randomness in this column for us to make an accurate prediction based on it."""
+                self.log.warning(w)
+                col_stats['lof_based_outlier_score_warning'] = w
 
             if col_stats['value_distribution_score'] > 0.8:
                 max_probability_key = col_stats['max_probability_key']
-                self.log.warning(f"""Column {col_name} is very biased towards the value {max_probability_key}, please make sure that the data in this column is correct !""")
+                w = f"""Column {col_name} is very biased towards the value {max_probability_key}, please make sure that the data in this column is correct !"""
+                self.log.warning(w)
+                col_stats['lvalue_distribution_score_warning'] = w
+
 
             if col_stats['similarity_score'] > 0.5:
                 similar_percentage = col_stats['similarity_score'] * 100
                 similar_col_name = col_stats['most_similar_column_name']
-                self.log.warning(f'Column {col_name} and {similar_col_name} are {similar_percentage}% the same, please make sure these represent two distinct features of your data !')
+                w = f'Column {col_name} and {similar_col_name} are {similar_percentage}% the same, please make sure these represent two distinct features of your data !'
+                self.log.warning(w)
+                col_stats['lof_based_outlier_score_warning'] = w
+
 
             '''
             if col_stats['correlation_score'] > 0.4:

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -628,7 +628,9 @@ class StatsGenerator(BaseModule):
                     col_stats['duplicates_score_warning'] = w
                 else:
                     col_stats['duplicates_score_warning'] = None
-
+            else:
+                col_stats['duplicates_score_warning'] = None
+                
             #Compound scores
             if col_stats['consistency_score'] > 0.25:
                 w = f'The values in column {col_name} rate poorly in terms of consistency. This means the data has too many empty values, values with a hard to determine type and duplicate values. Please see the detailed logs bellow for more info'


### PR DESCRIPTION
* Added a `description` and `warning` for each of the scores computed by the stats generator. The description is a simplified description of what the score is, the warning is a string representing the warning we logged to the user regarding the score or `None` if we considered the value of the score to be low enough to warrant no notice.

* These 2 new fields are now being written into the object associated with each of the scores in the adapted light metadata.

* Added documentation (based on the internal google doc) for each of the scores inside the website docs directory. This Resolves #111 .

Note: The scores are called "metrics" in the adapted metadata if they are used to compute a derived score and are found under the object named after said derived score inside the `model_columns_map` key of the adapted metadata.