### PR TITLE
Generic stats generation

### DIFF
--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -265,15 +265,25 @@ class Predictor:
                     mao['test_accuracy_over_time']['x'].append(i)
                     mao['test_accuracy_over_time']['y'].append([i])
 
-                for sub_group in mao['accuracy_histogram']['x']:
-                    sub_group_stats = {} # Something like: `self._adapt_column(lmd['subgroup_stats'][col][sub_group],col) ``... once we actually implement the subgroup stats
+                bucket_importance_keys = list(lmd['unusual_columns_buckets_importances'].keys())
+                for incol in lmd['column_importance_dict']:
+                    incol_bucket_importance_keys = list(filter(lambda x: incol in x, bucket_importance_keys))
+
+                    if len(incol_bucket_importance_keys) > 0:
+                        sub_group_stats = self._adapt_column(lmd['unusual_columns_buckets_importances'][f'{incol}_bucket_{vb}'], f'{incol}_bucket_{vb}')
+                    else:
+                        sub_group_stats = [None]
+                    sub_group_stats = {} # Something like: `
                     # TEMP PLACEHOLDER
                     sub_group_stats = self._adapt_column(lmd['column_stats'][col],col)
                     # TEMP PLACEHOLDER
-                    mao['accuracy_histogram'].append(sub_group_stats)
+                    mao['accuracy_histogram']['x_explained'].append(sub_group_stats)
 
                 for icol in lmd['model_columns_map'].keys():
                     if icol not in lmd['predict_columns']:
+
+
+
                         mao['overall_input_importance']['x'].append(icol)
                         mao['overall_input_importance']['y'].append(lmd['column_importances'][icol])
 

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -266,17 +266,16 @@ class Predictor:
                     mao['test_accuracy_over_time']['y'].append([i])
 
                 bucket_importance_keys = list(lmd['unusual_columns_buckets_importances'].keys())
-                for incol in lmd['column_importance_dict']:
+                for incol in lmd['column_importances']:
                     incol_bucket_importance_keys = list(filter(lambda x: incol in x, bucket_importance_keys))
+
+                    mao['accuracy_histogram']['x'] = incol
+                    mao['accuracy_histogram']['y'] = lmd['column_importances'][incol]
 
                     if len(incol_bucket_importance_keys) > 0:
                         sub_group_stats = self._adapt_column(lmd['unusual_columns_buckets_importances'][f'{incol}_bucket_{vb}'], f'{incol}_bucket_{vb}')
                     else:
                         sub_group_stats = [None]
-                    sub_group_stats = {} # Something like: `
-                    # TEMP PLACEHOLDER
-                    sub_group_stats = self._adapt_column(lmd['column_stats'][col],col)
-                    # TEMP PLACEHOLDER
                     mao['accuracy_histogram']['x_explained'].append(sub_group_stats)
 
                 for icol in lmd['model_columns_map'].keys():
@@ -402,6 +401,8 @@ class Predictor:
         light_transaction_metadata['stop_training_in_accuracy'] = stop_training_in_accuracy
         light_transaction_metadata['rebuild_model'] = rebuild_model
         light_transaction_metadata['model_accuracy'] = {'train': {}, 'test': {}}
+        light_transaction_metadata['column_importances'] = None
+        light_transaction_metadata['unusual_columns_buckets_importances'] = None
 
         if rebuild_model is False:
             old_lmd = {}

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -95,7 +95,7 @@ class Transaction:
             self.lmd['current_phase'] = MODEL_STATUS_ANALYZING
             self.lmd['columns'] = self.input_data.columns # this is populated by data extractor
 
-            self._call_phase_module('StatsGenerator', columns=self.input_data.columns)
+            self._call_phase_module('StatsGenerator', columns=self.input_data.columns, data_array=self.input_data, modify_light_metadata=True)
             self.lmd['current_phase'] = MODEL_STATUS_TRAINING
 
             if self.lmd['model_backend'] == 'ludwig':

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -53,7 +53,7 @@ class Transaction:
         self.run()
 
 
-    def _call_phase_module(self, module_name):
+    def _call_phase_module(self, module_name, **kwargs):
         """
         Loads the module and runs it
 
@@ -67,7 +67,7 @@ class Transaction:
         try:
             main_module = importlib.import_module(module_full_path)
             module = getattr(main_module, module_name)
-            return module(self.session, self)()
+            return module(self.session, self)(**kwargs)
         except:
             error = 'Could not load module {module_name}'.format(module_name=module_name)
             self.log.error('Could not load module {module_name}'.format(module_name=module_name))
@@ -95,7 +95,7 @@ class Transaction:
             self.lmd['current_phase'] = MODEL_STATUS_ANALYZING
             self.lmd['columns'] = self.input_data.columns # this is populated by data extractor
 
-            self._call_phase_module('StatsGenerator')
+            self._call_phase_module('StatsGenerator', columns=self.input_data.columns)
             self.lmd['current_phase'] = MODEL_STATUS_TRAINING
 
             if self.lmd['model_backend'] == 'ludwig':

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -95,7 +95,7 @@ class Transaction:
             self.lmd['current_phase'] = MODEL_STATUS_ANALYZING
             self.lmd['columns'] = self.input_data.columns # this is populated by data extractor
 
-            self._call_phase_module('StatsGenerator', columns=self.input_data.columns, data_array=self.input_data, modify_light_metadata=True)
+            self._call_phase_module('StatsGenerator', input_data=self.input_data, modify_light_metadata=True)
             self.lmd['current_phase'] = MODEL_STATUS_TRAINING
 
             if self.lmd['model_backend'] == 'ludwig':

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -147,7 +147,6 @@ class Transaction:
 
     def _execute_predict(self):
         """
-
         :return:
         """
         old_lmd = {}

--- a/mindsdb/libs/helpers/general_helpers.py
+++ b/mindsdb/libs/helpers/general_helpers.py
@@ -167,6 +167,9 @@ def get_value_bucket(value, buckets, col_stats):
     """
     :return: The bucket in the `histogram` in which our `value` falls
     """
+    if buckets is None:
+        return None
+        
     if col_stats['data_subtype'] in (DATA_SUBTYPES.SINGLE, DATA_SUBTYPES.MULTIPLE):
         if value in buckets:
             bucket = buckets.index(value)

--- a/mindsdb/libs/model_examination/column_evaluator.py
+++ b/mindsdb/libs/model_examination/column_evaluator.py
@@ -1,5 +1,5 @@
-from mindsdb.libs.helpers.general_helpers import evaluate_accuracy
-
+from mindsdb.libs.helpers.general_helpers import evaluate_accuracy, get_value_bucket
+from mindsdb.libs.phases.stats_generator import StatsGenerator
 
 class ColumnEvaluator():
     """
@@ -18,12 +18,29 @@ class ColumnEvaluator():
         normal_accuracy = evaluate_accuracy(self.normal_predictions, full_dataset, stats, output_columns)
 
         column_importance_dict = {}
+        col_buckets_stats = {}
 
         for input_column in input_columns:
             # See what happens with the accuracy of the outputs if only this column is present
             ignore_columns = [col for col in input_columns if col != input_column ]
             col_only_predictions = model.predict('validate', ignore_columns)
             col_only_accuracy = evaluate_accuracy(self.normal_predictions, full_dataset, stats, output_columns)
+
+            if col_only_accuracy > normal_accuracy*0.75:
+                split_data = {}
+                #columns = [[col, col_ind] for col_ind, col in enumerate(self.transaction.lmd['columns'])]
+                for value in full_dataset[input_column]:
+
+                    if 'percentage_buckets' in stats[input_column]:
+                        bucket = stats[input_column]['percentage_buckets']
+                    else:
+                        bucket = None
+
+                    vb = get_value_bucket(value, bucket, stats[input_column])
+                    split_data[vb] =
+
+                print(f'\n\n\n\n--------------------!!!!!!!!!!!!    {input_column}   !!!!!!!!!!!!--------------------\n\n\n\n')
+
             col_only_normalized_accuracy = col_only_accuracy/normal_accuracy
 
             # See what happens with the accuracy if all columns but this one are present
@@ -33,6 +50,10 @@ class ColumnEvaluator():
             self.columnless_predictions[input_column] = col_missing_predictions
 
             col_missing_accuracy = evaluate_accuracy(self.normal_predictions, full_dataset, stats, output_columns)
+
+            if col_missing_accuracy > normal_accuracy*0.75:
+                print(f'\n\n\n\n--------------------!!!!!!!!!!!!    {input_column}   !!!!!!!!!!!!--------------------\n\n\n\n')
+
             col_missing_reverse_accuracy = (normal_accuracy - col_missing_accuracy)/normal_accuracy
 
             column_importance = (col_only_normalized_accuracy + col_missing_reverse_accuracy)/2

--- a/mindsdb/libs/model_examination/column_evaluator.py
+++ b/mindsdb/libs/model_examination/column_evaluator.py
@@ -39,27 +39,32 @@ class ColumnEvaluator():
 
                     vb = get_value_bucket(value, bucket, stats[input_column])
                     if vb not in split_data:
-                        split_data[f'{input_column}_{vb}'] = []
+                        split_data[f'{input_column}_bucket_{vb}'] = []
 
-                    split_data[f'{input_column}_{vb}'].append(value)
+                    split_data[f'{input_column}_bucket_{vb}'].append(value)
 
                 row_wise_data = []
                 max_length = max(list(map(len, split_data.values())))
+
+                columns = []
                 for i in range(max_length):
                     row_wise_data.append([])
                     for k in split_data.keys():
-                        if len(split_data[k]) > i:
-                            row_wise_data[-1].append(split_data[k][i])
-                        else:
-                            row_wise_data[-1].append(None)
+                        # If the sub bucket has less than 6 values, it's no relevant
+                        if len(split_data[k]) > 6:
+                            columns.append(k)
+                            if len(split_data[k]) > i:
+                                row_wise_data[-1].append(split_data[k][i])
+                            else:
+                                row_wise_data[-1].append(None)
 
 
                 input_data = TransactionData()
                 input_data.data_array = row_wise_data
-                input_data.columns = list(split_data.keys())
+                input_data.columns = columns
 
                 sg = StatsGenerator(session=None, transaction=self.transaction)
-                stats = sg.run(input_data=input_data, modify_light_metadata=False)
+                bucket_stats = sg.run(input_data=input_data, modify_light_metadata=False)
 
 
             col_only_normalized_accuracy = col_only_accuracy/normal_accuracy

--- a/mindsdb/libs/model_examination/column_evaluator.py
+++ b/mindsdb/libs/model_examination/column_evaluator.py
@@ -37,9 +37,11 @@ class ColumnEvaluator():
                         bucket = None
 
                     vb = get_value_bucket(value, bucket, stats[input_column])
-                    split_data[vb] =
+                    if vb not in split_data:
+                        split_data[vb] = []
 
-                print(f'\n\n\n\n--------------------!!!!!!!!!!!!    {input_column}   !!!!!!!!!!!!--------------------\n\n\n\n')
+                    split_data[vb].append(value)
+
 
             col_only_normalized_accuracy = col_only_accuracy/normal_accuracy
 

--- a/mindsdb/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb/libs/phases/model_analyzer/model_analyzer.py
@@ -27,7 +27,7 @@ class ModelAnalyzer(BaseModule):
                 validation_dataset[col].append(self.transaction.input_data.data_array[row_ind][col_ind])
 
         # Test some hypotheses about our columns
-        column_evaluator = ColumnEvaluator()
+        column_evaluator = ColumnEvaluator(self.transaction)
         column_importances = column_evaluator.get_column_importance(model=self.transaction.model_backend, output_columns=output_columns, input_columns=input_columns,
         full_dataset=validation_dataset, stats=self.transaction.lmd['column_stats'])
 

--- a/mindsdb/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb/libs/phases/model_analyzer/model_analyzer.py
@@ -28,10 +28,11 @@ class ModelAnalyzer(BaseModule):
 
         # Test some hypotheses about our columns
         column_evaluator = ColumnEvaluator(self.transaction)
-        column_importances = column_evaluator.get_column_importance(model=self.transaction.model_backend, output_columns=output_columns, input_columns=input_columns,
+        column_importances, buckets_stats = column_evaluator.get_column_importance(model=self.transaction.model_backend, output_columns=output_columns, input_columns=input_columns,
         full_dataset=validation_dataset, stats=self.transaction.lmd['column_stats'])
 
         self.transaction.lmd['column_importances'] = column_importances
+        self.transaction.lmd['unusual_columns_buckets_importances'] = buckets_stats
 
         # Create the probabilistic validators for each of the predict column
         probabilistic_validators = {}

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -720,14 +720,14 @@ class StatsGenerator(BaseModule):
             self.log.infoChart(stats[col_name]['data_subtype_dist'], type='list', uid='Data Type Distribution for column "{}"'.format(col_name))
 
 
-    def run(self, columns, input_data, modify_light_metadata):
+    def run(self, input_data, modify_light_metadata):
         """
         # Runs the stats generation phase
         # This shouldn't alter the columns themselves, but rather provide the `stats` metadata object and update the types for each column
         # A lot of information about the data distribution and quality will  also be logged to the server in this phase
         """
 
-        header = columns
+        header = input_data.columns
         non_null_data = {}
         all_sampled_data = {}
 

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -741,7 +741,7 @@ class StatsGenerator(BaseModule):
         # we dont need to generate statistic over all of the data, so we subsample, based on our accepted margin of error
         population_size = len(input_data.data_array)
 
-        if population_size < 5:
+        if population_size < 50:
             sample_size = population_size
         else:
             sample_size = int(calculate_sample_size(population_size=population_size, margin_error=CONFIG.DEFAULT_MARGIN_OF_ERROR, confidence_level=CONFIG.DEFAULT_CONFIDENCE_LEVEL))
@@ -753,7 +753,7 @@ class StatsGenerator(BaseModule):
         self.log.info('population_size={population_size},  sample_size={sample_size}  {percent:.2f}%'.format(population_size=population_size, sample_size=sample_size, percent=(sample_size/population_size)*100))
 
         for sample_i in input_data_sample_indexes:
-            row = input_data.data_array[sample_i])
+            row = input_data.data_array[sample_i]
             for i, val in enumerate(row):
                 column = header[i]
                 value = cast_string_to_python_type(val)

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -630,7 +630,7 @@ class StatsGenerator(BaseModule):
                     col_stats['duplicates_score_warning'] = None
             else:
                 col_stats['duplicates_score_warning'] = None
-                
+
             #Compound scores
             if col_stats['consistency_score'] > 0.25:
                 w = f'The values in column {col_name} rate poorly in terms of consistency. This means the data has too many empty values, values with a hard to determine type and duplicate values. Please see the detailed logs bellow for more info'
@@ -720,14 +720,14 @@ class StatsGenerator(BaseModule):
             self.log.infoChart(stats[col_name]['data_subtype_dist'], type='list', uid='Data Type Distribution for column "{}"'.format(col_name))
 
 
-    def run(self):
+    def run(self, columns):
         """
         # Runs the stats generation phase
         # This shouldn't alter the columns themselves, but rather provide the `stats` metadata object and update the types for each column
         # A lot of information about the data distribution and quality will  also be logged to the server in this phase
         """
 
-        header = self.transaction.input_data.columns
+        header = columns
         non_null_data = {}
         all_sampled_data = {}
 

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -219,7 +219,7 @@ class StatsGenerator(BaseModule):
             subtype_dist[curr_data_subtype] = subtype_dist.pop('Unknown')
 
         all_values = []
-        for row in input_data.data_array:
+        for row in data_array:
             all_values.append(row[col_index])
 
         all_distinct_vals = set(all_values)

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -740,16 +740,20 @@ class StatsGenerator(BaseModule):
 
         # we dont need to generate statistic over all of the data, so we subsample, based on our accepted margin of error
         population_size = len(input_data.data_array)
-        sample_size = int(calculate_sample_size(population_size=population_size, margin_error=CONFIG.DEFAULT_MARGIN_OF_ERROR, confidence_level=CONFIG.DEFAULT_CONFIDENCE_LEVEL))
-        if sample_size > 3000 and sample_size > population_size/8:
-            sample_size = min(round(population_size/8),3000)
+
+        if population_size < 5:
+            sample_size = population_size
+        else:
+            sample_size = int(calculate_sample_size(population_size=population_size, margin_error=CONFIG.DEFAULT_MARGIN_OF_ERROR, confidence_level=CONFIG.DEFAULT_CONFIDENCE_LEVEL))
+            if sample_size > 3000 and sample_size > population_size/8:
+                sample_size = min(round(population_size/8),3000)
+
         # get the indexes of randomly selected rows given the population size
         input_data_sample_indexes = random.sample(range(population_size), sample_size)
         self.log.info('population_size={population_size},  sample_size={sample_size}  {percent:.2f}%'.format(population_size=population_size, sample_size=sample_size, percent=(sample_size/population_size)*100))
 
         for sample_i in input_data_sample_indexes:
-            row = input_data.data_array[sample_i]
-
+            row = input_data.data_array[sample_i])
             for i, val in enumerate(row):
                 column = header[i]
                 value = cast_string_to_python_type(val)


### PR DESCRIPTION
This PR currently adds stats for each sub-bucket of a column if that column is very important and/or unimportant as determined by the `ColumnEvaluator`.

Currently the `StatsGenerator` uses the validation dataset (which is the one used to determine importance by the `ColumnEvaluator` in order to generate the metrics.

Warnings are given much like in the normal stats generator for sub buckets with a low quality score.

Added the column importance score and the column stats for columns with a very low score to the adapted metadata.

This Resolves #163 .