### PR TITLE
Force vectors

### DIFF
--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -232,9 +232,6 @@ class Predictor:
 
             if col in lmd['predict_columns']:
 
-         = columnless_prediction_distribution
-         = all_columns_prediction_distribution
-
                 amd['force_vectors'][col] = {}
                 amd['force_vectors'][col]['normal_data_distribution'] = self.transaction.lmd['all_columns_prediction_distribution']
                 amd['force_vectors'][col]['missing_data_distribution'] = {}

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -235,9 +235,12 @@ class Predictor:
                 # Histograms for plotting the force vectors
                 amd['force_vectors'][col] = {}
                 amd['force_vectors'][col]['normal_data_distribution'] = lmd['all_columns_prediction_distribution'][col]
+                amd['force_vectors'][col]['normal_data_distribution']['type'] = 'categorical'
+
                 amd['force_vectors'][col]['missing_data_distribution'] = {}
                 for missing_column in lmd['columnless_prediction_distribution'][col]:
                     amd['force_vectors'][col]['missing_data_distribution'][missing_column] = lmd['columnless_prediction_distribution'][col][missing_column]
+                    amd['force_vectors'][col]['missing_data_distribution'][missing_column]['type'] = 'categorical'
 
                 icm['importance_score'] = None
                 amd['data_analysis']['target_columns_metadata'].append(icm)

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -230,8 +230,9 @@ class Predictor:
                 print(f'Issue processing column: {icol} !')
                 continue
 
+            amd['force_vectors'] = {}
             if col in lmd['predict_columns']:
-
+                # Histograms for plotting the force vectors
                 amd['force_vectors'][col] = {}
                 amd['force_vectors'][col]['normal_data_distribution'] = self.transaction.lmd['all_columns_prediction_distribution']
                 amd['force_vectors'][col]['missing_data_distribution'] = {}

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -234,10 +234,10 @@ class Predictor:
             if col in lmd['predict_columns']:
                 # Histograms for plotting the force vectors
                 amd['force_vectors'][col] = {}
-                amd['force_vectors'][col]['normal_data_distribution'] = self.transaction.lmd['all_columns_prediction_distribution']
+                amd['force_vectors'][col]['normal_data_distribution'] = slmd['all_columns_prediction_distribution']
                 amd['force_vectors'][col]['missing_data_distribution'] = {}
-                for missing_column in self.transaction.lmd['columnless_prediction_distribution']:
-                    amd['force_vectors'][col]['missing_data_distribution'][missing_column] = self.transaction.lmd['columnless_prediction_distribution'][missing_column]
+                for missing_column in lmd['columnless_prediction_distribution']:
+                    amd['force_vectors'][col]['missing_data_distribution'][missing_column] = lmd['columnless_prediction_distribution'][missing_column]
 
                 icm['importance_score'] = None
                 amd['data_analysis']['target_columns_metadata'].append(icm)

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -234,7 +234,7 @@ class Predictor:
             if col in lmd['predict_columns']:
                 # Histograms for plotting the force vectors
                 amd['force_vectors'][col] = {}
-                amd['force_vectors'][col]['normal_data_distribution'] = slmd['all_columns_prediction_distribution']
+                amd['force_vectors'][col]['normal_data_distribution'] = lmd['all_columns_prediction_distribution']
                 amd['force_vectors'][col]['missing_data_distribution'] = {}
                 for missing_column in lmd['columnless_prediction_distribution']:
                     amd['force_vectors'][col]['missing_data_distribution'][missing_column] = lmd['columnless_prediction_distribution'][missing_column]

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -234,10 +234,10 @@ class Predictor:
             if col in lmd['predict_columns']:
                 # Histograms for plotting the force vectors
                 amd['force_vectors'][col] = {}
-                amd['force_vectors'][col]['normal_data_distribution'] = lmd['all_columns_prediction_distribution']
+                amd['force_vectors'][col]['normal_data_distribution'] = lmd['all_columns_prediction_distribution'][col]
                 amd['force_vectors'][col]['missing_data_distribution'] = {}
-                for missing_column in lmd['columnless_prediction_distribution']:
-                    amd['force_vectors'][col]['missing_data_distribution'][missing_column] = lmd['columnless_prediction_distribution'][missing_column]
+                for missing_column in lmd['columnless_prediction_distribution'][col]:
+                    amd['force_vectors'][col]['missing_data_distribution'][missing_column] = lmd['columnless_prediction_distribution'][col][missing_column]
 
                 icm['importance_score'] = None
                 amd['data_analysis']['target_columns_metadata'].append(icm)
@@ -423,6 +423,8 @@ class Predictor:
         light_transaction_metadata['model_accuracy'] = {'train': {}, 'test': {}}
         light_transaction_metadata['column_importances'] = None
         light_transaction_metadata['unusual_columns_buckets_importances'] = None
+        light_transaction_metadata['columnless_prediction_distribution'] = None
+        light_transaction_metadata['all_columns_prediction_distribution'] = None
         light_transaction_metadata['malformed_columns'] = {'names': [], 'indices': []}
 
 

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -232,6 +232,15 @@ class Predictor:
 
             if col in lmd['predict_columns']:
 
+         = columnless_prediction_distribution
+         = all_columns_prediction_distribution
+
+                amd['force_vectors'][col] = {}
+                amd['force_vectors'][col]['normal_data_distribution'] = self.transaction.lmd['all_columns_prediction_distribution']
+                amd['force_vectors'][col]['missing_data_distribution'] = {}
+                for missing_column in self.transaction.lmd['columnless_prediction_distribution']:
+                    amd['force_vectors'][col]['missing_data_distribution'][missing_column] = self.transaction.lmd['columnless_prediction_distribution'][missing_column]
+
                 icm['importance_score'] = None
                 amd['data_analysis']['target_columns_metadata'].append(icm)
 

--- a/mindsdb/libs/model_examination/column_evaluator.py
+++ b/mindsdb/libs/model_examination/column_evaluator.py
@@ -10,16 +10,27 @@ class ColumnEvaluator():
     """
 
     def __init__(self, transaction):
-        self.columnless_predictions = {}
+        self.columnless_prediction_distribution = {}
+        self.all_columns_prediction_distribution = {}
         self.normal_predictions = None
         self.transaction = transaction
 
     def get_column_importance(self, model, output_columns, input_columns, full_dataset, stats):
         self.normal_predictions = model.predict('validate')
         normal_accuracy = evaluate_accuracy(self.normal_predictions, full_dataset, stats, output_columns)
-
         column_importance_dict = {}
         buckets_stats = {}
+
+        # Histogram for when all columns are present, in order to plot the force vectors
+        for output_column in output_columns:
+            stats_generator = StatsGenerator(session=None, transaction=self.transaction)
+            input_data = TransactionData()
+            input_data.data_array = list(map(lambda x: [x], list(self.normal_predictions[output_column])))
+            input_data.columns = [output_column]
+            validation_set_output_stats = stats_generator.run(input_data=input_data, modify_light_metadata=False)
+
+            if 'histogram' in validation_set_output_stats[output_column]:
+                self.all_columns_prediction_distribution[output_column] = validation_set_output_stats[output_column]['histogram']
 
         for input_column in input_columns:
             # See what happens with the accuracy of the outputs if only this column is present
@@ -33,13 +44,25 @@ class ColumnEvaluator():
             ignore_columns = [input_column]
             col_missing_predictions = model.predict('validate', ignore_columns)
 
-            self.columnless_predictions[input_column] = col_missing_predictions
-
             col_missing_accuracy = evaluate_accuracy(col_missing_predictions, full_dataset, stats, output_columns)
 
             col_missing_reverse_accuracy = (normal_accuracy - col_missing_accuracy)/normal_accuracy
             column_importance = (col_only_normalized_accuracy + col_missing_reverse_accuracy)/2
             column_importance_dict[input_column] = column_importance
+
+            # Histogram for when the column is missing, in order to plot the force vectors
+            self.columnless_prediction_distribution[input_column] = {
+
+            }
+            for output_column in output_columns:
+                stats_generator = StatsGenerator(session=None, transaction=self.transaction)
+                input_data = TransactionData()
+                input_data.data_array = list(map(lambda x: [x], list(col_missing_predictions[output_column])))
+                input_data.columns = [output_column]
+                col_missing_output_stats = stats_generator.run(input_data=input_data, modify_light_metadata=False)
+
+                if 'histogram' in col_missing_output_stats[output_column]:
+                    self.columnless_prediction_distribution[input_column][output_column] = col_missing_output_stats[output_column]['histogram']
 
             # If this coulmn is either very important or not important at all, compute stats for each of the buckets (in the validation data)
             if column_importance > 0.8 or column_importance < 0.2:

--- a/mindsdb/libs/model_examination/column_evaluator.py
+++ b/mindsdb/libs/model_examination/column_evaluator.py
@@ -25,7 +25,7 @@ class ColumnEvaluator():
             # See what happens with the accuracy of the outputs if only this column is present
             ignore_columns = [col for col in input_columns if col != input_column ]
             col_only_predictions = model.predict('validate', ignore_columns)
-            col_only_accuracy = evaluate_accuracy(self.normal_predictions, full_dataset, stats, output_columns)
+            col_only_accuracy = evaluate_accuracy(col_only_predictions, full_dataset, stats, output_columns)
 
             col_only_normalized_accuracy = col_only_accuracy/normal_accuracy
 
@@ -35,7 +35,7 @@ class ColumnEvaluator():
 
             self.columnless_predictions[input_column] = col_missing_predictions
 
-            col_missing_accuracy = evaluate_accuracy(self.normal_predictions, full_dataset, stats, output_columns)
+            col_missing_accuracy = evaluate_accuracy(col_missing_predictions, full_dataset, stats, output_columns)
 
             col_missing_reverse_accuracy = (normal_accuracy - col_missing_accuracy)/normal_accuracy
             column_importance = (col_only_normalized_accuracy + col_missing_reverse_accuracy)/2

--- a/mindsdb/libs/model_examination/column_evaluator.py
+++ b/mindsdb/libs/model_examination/column_evaluator.py
@@ -52,8 +52,9 @@ class ColumnEvaluator():
             column_importance_dict[input_column] = column_importance
 
             # Histogram for when the column is missing, in order to plot the force vectors
-            columnless_prediction_distribution[input_column] = {}
             for output_column in output_columns:
+                if output_column not in columnless_prediction_distribution:
+                    columnless_prediction_distribution[output_column] = {}
                 stats_generator = StatsGenerator(session=None, transaction=self.transaction)
                 input_data = TransactionData()
                 input_data.data_array = list(map(lambda x: [x], list(col_missing_predictions[output_column])))
@@ -61,7 +62,7 @@ class ColumnEvaluator():
                 col_missing_output_stats = stats_generator.run(input_data=input_data, modify_light_metadata=False)
 
                 if 'histogram' in col_missing_output_stats[output_column]:
-                    columnless_prediction_distribution[input_column][output_column] = col_missing_output_stats[output_column]['histogram']
+                    columnless_prediction_distribution[output_column][input_column] = col_missing_output_stats[output_column]['histogram']
 
             # If this coulmn is either very important or not important at all, compute stats for each of the buckets (in the validation data)
             if column_importance > 0.8 or column_importance < 0.2:

--- a/mindsdb/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb/libs/phases/model_analyzer/model_analyzer.py
@@ -30,11 +30,12 @@ class ModelAnalyzer(BaseModule):
 
         # Test some hypotheses about our columns
         column_evaluator = ColumnEvaluator(self.transaction)
-        column_importances, buckets_stats = column_evaluator.get_column_importance(model=self.transaction.model_backend, output_columns=output_columns, input_columns=input_columns,
-        full_dataset=validation_dataset, stats=self.transaction.lmd['column_stats'])
+        column_importances, buckets_stats, columnless_prediction_distribution, all_columns_prediction_distribution = column_evaluator.get_column_importance(model=self.transaction.model_backend, output_columns=output_columns, input_columns=input_columns, full_dataset=validation_dataset, stats=self.transaction.lmd['column_stats'])
+
         self.transaction.lmd['column_importances'] = column_importances
         self.transaction.lmd['unusual_columns_buckets_importances'] = buckets_stats
-
+        self.transaction.lmd['columnless_prediction_distribution'] = columnless_prediction_distribution
+        self.transaction.lmd['all_columns_prediction_distribution'] = all_columns_prediction_distribution
         # Create the probabilistic validators for each of the predict column
         probabilistic_validators = {}
         for col in output_columns:

--- a/tmp.py
+++ b/tmp.py
@@ -1,0 +1,4 @@
+import mindsdb
+
+mdb = mindsdb.Predictor(name='real_estate_model') 
+mdb.learn(from_data="https://raw.githubusercontent.com/mindsdb/mindsdb/master/docs/examples/basic/home_rentals.csv", to_predict='rental_price')


### PR DESCRIPTION
Added a `force_vectors` category to the adapted metadata, which shows the normal distribution of predictions on the validation data, as well as the prediction distribution (histogram) for when a certain column is missing.

The computation for this is done inside the `ColumnEvaluator` using the stats generator to generate the histogram for each of the situations.

Resolves #121 