### PR TITLE
Fix broken link to redirect to docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ print('The predicted price is ${price} with {conf} confidence'.format(price=resu
 ```
 
 
-[Learn More](docs/examples/basic/README.md)
+[Learn More](https://mindsdb.github.io/mindsdb/docs/basic-mindsdb)
 
 ## Report Issues
 


### PR DESCRIPTION
This PR adds a fix for the broken link inside the README that redirects to the docs site.