### PR TITLE
Column naming + probabilistic validator changes

### DIFF
--- a/docs/website/docs/DataSources.md
+++ b/docs/website/docs/DataSources.md
@@ -26,7 +26,7 @@ An important one is the one MindsDB uses to work with files.
 ```python
 from mindsdb import FileDS
 
-ds = FileDS(file, clean_header = True, clean_rows = True, custom_parser = None)
+ds = FileDS(file, clean_rows = True, custom_parser = None)
 
 
 # Now you can pass this DataSource to MindsDB

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -31,7 +31,7 @@ class LightwoodBackend():
 
             lightwood_data_type = None
 
-            other_keys = {}
+            other_keys = {'encoder_attrs': {}}
             if data_type in (DATA_TYPES.NUMERIC):
                 lightwood_data_type = 'numeric'
 
@@ -46,7 +46,7 @@ class LightwoodBackend():
 
             elif data_subtype in (DATA_SUBTYPES.IMAGE):
                 lightwood_data_type = 'image'
-                other_keys['encoding_aim'] = 'speed'
+                other_keys['encoder_attrs']['aim'] = 'speed'
 
             elif data_subtype in (DATA_SUBTYPES.TEXT):
                 lightwood_data_type = 'text'

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -46,7 +46,7 @@ class LightwoodBackend():
 
             elif data_subtype in (DATA_SUBTYPES.IMAGE):
                 lightwood_data_type = 'image'
-                other_keys['encoder_attrs']['aim'] = 'speed'
+                other_keys['encoder_attrs']['aim'] = 'balance'
 
             elif data_subtype in (DATA_SUBTYPES.TEXT):
                 lightwood_data_type = 'text'

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -31,6 +31,7 @@ class LightwoodBackend():
 
             lightwood_data_type = None
 
+            other_keys = {}
             if data_type in (DATA_TYPES.NUMERIC):
                 lightwood_data_type = 'numeric'
 
@@ -45,6 +46,7 @@ class LightwoodBackend():
 
             elif data_subtype in (DATA_SUBTYPES.IMAGE):
                 lightwood_data_type = 'image'
+                other_keys['encoding_aim'] = 'speed'
 
             elif data_subtype in (DATA_SUBTYPES.TEXT):
                 lightwood_data_type = 'text'
@@ -55,16 +57,16 @@ class LightwoodBackend():
                 self.transaction.log.error(f'The lightwood model backend is unable to handle data of type {data_type} and subtype {data_subtype} !')
                 raise Exception('Failed to build data definition for Lightwood model backend')
 
+            col_config = {
+                'name': col_name,
+                'type': lightwood_data_type
+            }
+            col_config.update(other_keys)
+
             if col_name not in self.transaction.lmd['predict_columns']:
-                config['input_features'].append({
-                    'name': col_name,
-                    'type': lightwood_data_type
-                })
+                config['input_features'].append(col_config)
             else:
-                config['output_features'].append({
-                    'name': col_name,
-                    'type': lightwood_data_type
-                })
+                config['output_features'].append(col_config)
 
         return config
 

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -484,6 +484,7 @@ class LudwigBackend():
             predict_dataframe, model_definition =  self._translate_df_to_timeseries_format(predict_dataframe, model_definition, timeseries_cols)
 
         for ignore_col in ignore_columns:
+            ignore_col = col_map[ignore_col]
             try:
                 predict_dataframe[ignore_col] = [None] * len(predict_dataframe[ignore_col])
             except:

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -484,7 +484,9 @@ class LudwigBackend():
             predict_dataframe, model_definition =  self._translate_df_to_timeseries_format(predict_dataframe, model_definition, timeseries_cols)
 
         for ignore_col in ignore_columns:
-            ignore_col = col_map[ignore_col]
+            for tf_col in col_map:
+                if ignore_col == col_map[tf_col]:
+                    ignore_col = tf_col
             try:
                 predict_dataframe[ignore_col] = [None] * len(predict_dataframe[ignore_col])
             except:

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -1,6 +1,6 @@
 from mindsdb.libs.constants.mindsdb import *
 from mindsdb.config import *
-from mindsdb.libs.helpers.general_helpers import disable_console_output
+from mindsdb.libs.helpers.general_helpers import disable_console_output, get_tensorflow_colname
 
 from dateutil.parser import parse as parse_datetime
 import os, sys
@@ -162,6 +162,7 @@ class LudwigBackend():
 
     def _create_ludwig_dataframe(self, mode):
         has_heavy_data = False
+        col_map = {}
 
         if mode == 'train':
             indexes = self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY]
@@ -188,12 +189,14 @@ class LudwigBackend():
         for ele in columns:
             col = ele[0]
             col_ind = ele[1]
+            tf_col = get_tensorflow_colname(col)
+            col_map[tf_col] = col
 
             # Handle malformed columns
             if col in self.transaction.lmd['malformed_columns']['names']:
                 continue
 
-            data[col] = []
+            data[tf_col] = []
 
             col_stats = self.transaction.lmd['column_stats'][col]
             data_subtype = col_stats['data_subtype']
@@ -260,7 +263,7 @@ class LudwigBackend():
                         ts_data_point = float(ts_data_point)
                     except:
                         ts_data_point = parse_datetime(ts_data_point).timestamp()
-                    data[col].append(ts_data_point)
+                    data[tf_col].append(ts_data_point)
 
                 elif ludwig_dtype == 'sequence':
                     arr_str = self.transaction.input_data.data_frame[col][row_ind]
@@ -268,15 +271,15 @@ class LudwigBackend():
                         arr = list(map(float,arr_str.rstrip(']').lstrip('[').split(self.transaction.lmd['column_stats'][col]['separator'])))
                     else:
                         arr = ''
-                    data[col].append(arr)
+                    data[tf_col].append(arr)
 
                 # Date isn't supported yet, so we hack around it
                 elif ludwig_dtype == 'date':
                     if col in data:
                         data.pop(col)
-                        data[col + '_year'] = []
-                        data[col + '_month'] = []
-                        data[col + '_day'] = []
+                        data[tf_col + '_year'] = []
+                        data[tf_col + '_month'] = []
+                        data[tf_col + '_day'] = []
 
                         model_definition['input_features'].append({
                             'name': col + '_year'
@@ -293,9 +296,9 @@ class LudwigBackend():
 
                     date = parse_datetime(self.transaction.input_data.data_frame[col][row_ind])
 
-                    data[col + '_year'].append(date.year)
-                    data[col + '_month'].append(date.month)
-                    data[col + '_day'].append(date.day)
+                    data[tf_col + '_year'].append(date.year)
+                    data[tf_col + '_month'].append(date.month)
+                    data[tf_col + '_day'].append(date.day)
 
                     custom_logic_continue = True
 
@@ -311,34 +314,34 @@ class LudwigBackend():
                     else:
                         unix_ts = parse_datetime(self.transaction.input_data.data_frame[col][row_ind]).timestamp()
 
-                    data[col].append(unix_ts)
+                    data[tf_col].append(unix_ts)
 
                 elif data_subtype in (DATA_SUBTYPES.FLOAT):
                     if type(self.transaction.input_data.data_frame[col][row_ind]) == str:
-                        data[col].append(float(str(self.transaction.input_data.data_frame[col][row_ind]).replace(',','.')))
+                        data[tf_col].append(float(str(self.transaction.input_data.data_frame[col][row_ind]).replace(',','.')))
                     else:
-                        data[col].append(self.transaction.input_data.data_frame[col][row_ind])
+                        data[tf_col].append(self.transaction.input_data.data_frame[col][row_ind])
 
                 elif data_subtype in (DATA_SUBTYPES.INT):
                     if type(self.transaction.input_data.data_frame[col][row_ind]) == str:
-                        data[col].append(round(float(str(self.transaction.input_data.data_frame[col][row_ind]).replace(',','.'))))
+                        data[tf_col].append(round(float(str(self.transaction.input_data.data_frame[col][row_ind]).replace(',','.'))))
                     else:
-                        data[col].append(self.transaction.input_data.data_frame[col][row_ind])
+                        data[tf_col].append(self.transaction.input_data.data_frame[col][row_ind])
 
                 elif data_subtype in (DATA_SUBTYPES.IMAGE):
                     if os.path.isabs(self.transaction.input_data.data_frame[col][row_ind]):
-                        data[col].append(self.transaction.input_data.data_frame[col][row_ind])
+                        data[tf_col].append(self.transaction.input_data.data_frame[col][row_ind])
                     else:
-                        data[col].append(os.path.join(os.getcwd(), self.transaction.input_data.data_frame[col][row_ind]))
+                        data[tf_col].append(os.path.join(os.getcwd(), self.transaction.input_data.data_frame[col][row_ind]))
                 else:
-                    data[col].append(self.transaction.input_data.data_frame[col][row_ind])
+                    data[tf_col].append(self.transaction.input_data.data_frame[col][row_ind])
 
             if custom_logic_continue:
                 continue
 
             if col not in self.transaction.lmd['predict_columns']:
                 input_def = {
-                    'name': col
+                    'name': tf_col
                     ,'type': ludwig_dtype
                 }
                 if encoder is not None:
@@ -375,7 +378,7 @@ class LudwigBackend():
         if len(timeseries_cols) > 0:
             df.sort_values(timeseries_cols)
 
-        return df, model_definition, timeseries_cols, has_heavy_data
+        return df, model_definition, timeseries_cols, has_heavy_data, col_map
 
     def _get_model_dir(self):
         model_dir = None
@@ -399,7 +402,7 @@ class LudwigBackend():
             return gpu_indices
 
     def train(self):
-        training_dataframe, model_definition, timeseries_cols, has_heavy_data = self._create_ludwig_dataframe('train')
+        training_dataframe, model_definition, timeseries_cols, has_heavy_data, col_map = self._create_ludwig_dataframe('train')
 
         if len(timeseries_cols) > 0:
             training_dataframe, model_definition =  self._translate_df_to_timeseries_format(training_dataframe, model_definition, timeseries_cols, 'train')
@@ -474,7 +477,7 @@ class LudwigBackend():
         self.transaction.hmd['ludwig_data'] = {'model_definition': model_definition}
 
     def predict(self, mode='predict', ignore_columns=[]):
-        predict_dataframe, model_definition, timeseries_cols, has_heavy_data = self._create_ludwig_dataframe(mode)
+        predict_dataframe, model_definition, timeseries_cols, has_heavy_data, col_map = self._create_ludwig_dataframe(mode)
         model_definition = self.transaction.hmd['ludwig_data']['model_definition']
 
         if len(timeseries_cols) > 0:
@@ -494,6 +497,8 @@ class LudwigBackend():
 
         for col_name in predictions:
             col_name_normalized = col_name.replace('_predictions', '')
+            if col_name_normalized in col_map:
+                col_name_normalized = col_map[col_name_normalized]
             predictions = predictions.rename(columns = {col_name: col_name_normalized})
 
         return predictions

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -529,7 +529,7 @@ class Predictor:
         else:
             light_transaction_metadata['skip_model_training'] = False
 
-        if 'skip_model_training' in unstable_parameters_dict:
+        if 'skip_stats_generation' in unstable_parameters_dict:
             light_transaction_metadata['skip_stats_generation'] = unstable_parameters_dict['skip_stats_generation']
         else:
             light_transaction_metadata['skip_stats_generation'] = False

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -540,6 +540,11 @@ class Predictor:
         else:
             light_transaction_metadata['skip_model_training'] = False
 
+        if 'skip_model_training' in unstable_parameters_dict:
+            light_transaction_metadata['skip_stats_generation'] = unstable_parameters_dict['skip_stats_generation']
+        else:
+            light_transaction_metadata['skip_stats_generation'] = False
+
         if rebuild_model is False:
             old_lmd = {}
             for k in light_transaction_metadata: old_lmd[k] = light_transaction_metadata[k]

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -423,7 +423,7 @@ class Predictor:
             return False
 
     def learn(self, to_predict, from_data = None, test_from_data=None, group_by = None, window_size_samples = None, window_size_seconds = None,
-    window_size = None, order_by = [], sample_margin_of_error = CONFIG.DEFAULT_MARGIN_OF_ERROR, ignore_columns = [], rename_strange_columns = False,
+    window_size = None, order_by = [], sample_margin_of_error = CONFIG.DEFAULT_MARGIN_OF_ERROR, ignore_columns = [],
     stop_training_in_x_seconds = None, stop_training_in_accuracy = None, backend='ludwig', rebuild_model=True, use_gpu=True,
     disable_optional_analysis=False, unstable_parameters_dict={}):
         """
@@ -443,7 +443,6 @@ class Predictor:
 
         Optional data transformation arguments:
         :param ignore_columns: it simply removes the columns from the data sources
-        :param rename_strange_columns: this tells mindsDB that if columns have special characters, it should try to rename them, this is a legacy argument, as now mindsdb supports any column name
 
         Optional sampling parameters:
         :param sample_margin_error (DEFAULT 0): Maximum expected difference between the true population parameter, such as the mean, and the sample estimate.
@@ -464,7 +463,6 @@ class Predictor:
 
         transaction_type = TRANSACTION_LEARN
         sample_confidence_level = 1 - sample_margin_of_error
-        predict_columns_map = {}
 
         # lets turn into lists: predict, order_by and group by
         predict_columns = [to_predict] if type(to_predict) != type([]) else to_predict
@@ -482,15 +480,6 @@ class Predictor:
 
         is_time_series = True if len(order_by) > 0 else False
 
-        if rename_strange_columns is False:
-            for predict_col in predict_columns:
-                predict_col_as_in_df = from_ds.getColNameAsInDF(predict_col)
-                predict_columns_map[predict_col_as_in_df]=predict_col
-
-            predict_columns = list(predict_columns_map.keys())
-        else:
-            self.log.warning('Note that after version 1.0, the default value for argument rename_strange_columns in MindsDB().learn, will be flipped from True to False, this means that if your data has columns with special characters, MindsDB will not try to rename them by default.')
-
         heavy_transaction_metadata = {}
         heavy_transaction_metadata['name'] = self.name
         heavy_transaction_metadata['from_data'] = from_ds
@@ -504,7 +493,7 @@ class Predictor:
         light_transaction_metadata['data_preparation'] = {}
         light_transaction_metadata['model_backend'] = backend
         light_transaction_metadata['predict_columns'] = predict_columns
-        light_transaction_metadata['model_columns_map'] = {} if rename_strange_columns else from_ds._col_map
+        light_transaction_metadata['model_columns_map'] = from_ds._col_map
         light_transaction_metadata['model_group_by'] = group_by
         light_transaction_metadata['model_order_by'] = order_by
         light_transaction_metadata['window_size_samples'] = window_size_samples

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -125,10 +125,13 @@ class Transaction:
             self.save_metadata()
 
             self.lmd['current_phase'] = MODEL_STATUS_DATA_ANALYSIS
-            self.save_metadata()
-            self._call_phase_module(clean_exit=True, module_name='StatsGenerator', input_data=self.input_data, modify_light_metadata=True, hmd=self.hmd)
+            if 'skip_stats_generation' in self.lmd and self.lmd['skip_stats_generation'] == True:
+                self.load_metadata()
+            else:
+                self.save_metadata()
+                self._call_phase_module(clean_exit=True, module_name='StatsGenerator', input_data=self.input_data, modify_light_metadata=True, hmd=self.hmd)
+                self.save_metadata()
 
-            self.save_metadata()
             self._call_phase_module(clean_exit=True, module_name='DataTransformer', input_data=self.input_data, mode='train')
 
             self.lmd['current_phase'] = MODEL_STATUS_TRAINING

--- a/mindsdb/libs/data_sources/file_ds.py
+++ b/mindsdb/libs/data_sources/file_ds.py
@@ -14,41 +14,7 @@ from mindsdb.libs.data_types.mindsdb_logger import log
 
 
 class FileDS(DataSource):
-
-    def clean(self, header):
-
-        clean_header = []
-        col_count={}
-
-        replace_chars = """ ,./;'[]!@#$%^&*()+{-=+~`}\\|:"<>?"""
-
-        for col in header:
-            orig_col = col
-            for char in replace_chars:
-                col = col.replace(char,'_')
-            col = re.sub('_+','_',col)
-            if col[-1] == '_':
-                col = col[:-1]
-            while col[0] == '_':
-                col = col[1:]
-
-            col_count[col] = 1 if col not in col_count else col_count[col]+1
-            if col_count[col] > 1:
-                col = col+'_'+str(col_count[col])
-
-            if orig_col != col:
-                log.debug('[Column renamed] {orig_col} to {col}'.format(orig_col=orig_col, col=col))
-
-            self._col_map[orig_col] = col
-            clean_header.append(col)
-
-        if clean_header != header:
-            string = """\n    {cols} \n""".format(cols=",\n    ".join(clean_header))
-            log.debug('The Columns have changed, here are the renamed columns: \n {string}'.format(string=string))
-
-
-        return  clean_header
-
+    
     def cleanRow(self, row):
         n_row = []
         for cell in row:

--- a/mindsdb/libs/data_sources/file_ds.py
+++ b/mindsdb/libs/data_sources/file_ds.py
@@ -180,11 +180,10 @@ class FileDS(DataSource):
 
 
 
-    def _setup(self,file, clean_header = True, clean_rows = True, custom_parser = None):
+    def _setup(self,file, clean_rows = True, custom_parser = None):
         """
         Setup from file
         :param file: fielpath or url
-        :param clean_header: if you want to clean header column names
         :param clean_rows:  if you want to clean rows for strange null values
         :param custom_parser: if you want to parse the file with some custom parser
         """
@@ -217,8 +216,8 @@ class FileDS(DataSource):
             header = df.columns.values.tolist()
             file_data = df.values.tolist()
 
-        if clean_header == True:
-            header = self.clean(header)
+        for col in header:
+            self._col_map[col] = col
 
         if clean_rows == True:
             file_list_data = []

--- a/mindsdb/libs/data_types/data_source.py
+++ b/mindsdb/libs/data_types/data_source.py
@@ -27,33 +27,7 @@ class DataSource:
 
         cols = [col if col not in self._col_map else self._col_map[col] for col in column_list]
         self._df = self._df.drop(columns=cols)
-
-    def applyFunctionToColumn(self, column, function):
-        """
-        This applies a function for all rows in a column
-
-        :param column: column to affect
-        :param function: a lambda or function to call
-        :return: None
-        """
-
-        # make sure that we use the column name in the data source
-        column = self.getColNameAsInDF(column)
-
-        self._df[column] = self._df[column].apply(lambda col: function(col))
-
-
-    def getColNameAsInDF(self, column):
-        """
-        Since Columns can be mapped at somepoint in the DF then you can use this to get the DF column name by passing the original value
-
-        :param column:
-        :return: None
-        """
-
-        return column if column not in self._col_map else self._col_map[column]
-
-
+        
     def __getattr__(self, item):
         """
         Map all other functions to the DataFrame

--- a/mindsdb/libs/helpers/general_helpers.py
+++ b/mindsdb/libs/helpers/general_helpers.py
@@ -249,6 +249,15 @@ class suppress_stdout_stderr(object):
         except:
             print('Can\'t disable output on Jupyter notebook')
 
+def get_tensorflow_colname(col):
+    replace_chars = """ ,./;'[]!@#$%^&*()+{-=+~`}\\|:"<>?"""
+
+    for char in replace_chars:
+        col = col.replace(char,'_')
+    col = re.sub('_+','_',col)
+
+    return col
+
 @contextmanager
 # @TODO: Make it work with mindsdb logger/log levels... maybe
 def disable_console_output(activate=True):

--- a/mindsdb/libs/helpers/probabilistic_validator.py
+++ b/mindsdb/libs/helpers/probabilistic_validator.py
@@ -111,6 +111,7 @@ class ProbabilisticValidator():
         np.seterr(divide='ignore')
 
         if self.buckets is not None:
+            print(self.X_buff, self.Y_buff)
             self._probabilistic_model.partial_fit(self.X_buff, self.Y_buff, classes=self.bucket_keys)
         else:
             self._probabilistic_model.partial_fit(self.X_buff, self.Y_buff, classes=[True, False])

--- a/mindsdb/libs/helpers/probabilistic_validator.py
+++ b/mindsdb/libs/helpers/probabilistic_validator.py
@@ -24,10 +24,10 @@ class ProbabilisticValidator():
         As of right now we go with ComplementNB
         """
         # <--- Pick one of the 3
-        self._probabilistic_model = ComplementNB(alpha=self._smoothing_factor)
+        #self._probabilistic_model = ComplementNB(alpha=self._smoothing_factor)
         #, class_prior=[0.5,0.5]
-        #self._probabilistic_model = GaussianNB(var_smoothing=1)
-        #self._probabilistic_model = MultinomialNB(alpha=self._smoothing_factor)
+        #self._probabilistic_model = GaussianNB()
+        self._probabilistic_model = MultinomialNB(alpha=self._smoothing_factor)
         self.X_buff = []
         self.Y_buff = []
 
@@ -69,7 +69,8 @@ class ProbabilisticValidator():
             X[predicted_value_b] = True
             X = X + features_existence
             self.X_buff.append(X)
-            self.Y_buff.append(real_value_b)
+            #print(real_value_b == predicted_value_b)
+            self.Y_buff.append(real_value_b == predicted_value_b)
 
             # If no column is ignored, compute the accuracy for this bucket
             if nr_missing_features == 0:

--- a/mindsdb/libs/helpers/probabilistic_validator.py
+++ b/mindsdb/libs/helpers/probabilistic_validator.py
@@ -24,9 +24,9 @@ class ProbabilisticValidator():
         As of right now we go with ComplementNB
         """
         # <--- Pick one of the 3
-        #self._probabilistic_model = ComplementNB(alpha=self._smoothing_factor)
+        self._probabilistic_model = ComplementNB(alpha=self._smoothing_factor)
         #, class_prior=[0.5,0.5]
-        self._probabilistic_model = GaussianNB()
+        #self._probabilistic_model = GaussianNB()
         #self._probabilistic_model = MultinomialNB(alpha=self._smoothing_factor)
         self.X_buff = []
         self.Y_buff = []
@@ -54,7 +54,6 @@ class ProbabilisticValidator():
         :param predicted_value: The predicted value/label
         :param histogram: The histogram for the predicted column, which allows us to bucketize the `predicted_value` and `real_value`
         """
-        nr_missing_features = len([x for x in features_existence if x is False or x is 0])
 
         predicted_value = predicted_value if self.data_type != DATA_TYPES.NUMERIC else float(predicted_value)
         try:
@@ -69,10 +68,11 @@ class ProbabilisticValidator():
             X[predicted_value_b] = True
             X = X + features_existence
             self.X_buff.append(X)
-            #print(real_value_b == predicted_value_b)
-            self.Y_buff.append(real_value_b == predicted_value_b)
+
+            self.Y_buff.append(real_value_b)
 
             # If no column is ignored, compute the accuracy for this bucket
+            nr_missing_features = len([x for x in features_existence if x is False or x is 0])
             if nr_missing_features == 0:
                 if predicted_value_b not in self.bucket_accuracy:
                     self.bucket_accuracy[predicted_value_b] = []
@@ -147,7 +147,6 @@ class ProbabilisticValidator():
         else:
             X = [features_existence]
 
-        #X = [[predicted_value_b, *features_existence]]
         log_types = np.seterr()
         np.seterr(divide='ignore')
         distribution = self._probabilistic_model.predict_proba(np.array(X))
@@ -170,8 +169,6 @@ if __name__ == "__main__":
         [bool(random.getrandbits(1)), bool(random.getrandbits(1)), bool(random.getrandbits(1))]
         for i in values
     ]
-
-    print(feature_rows)
 
     pbv = ProbabilisticValidator(buckets=[1,2,3,4,5])
 

--- a/mindsdb/libs/helpers/probabilistic_validator.py
+++ b/mindsdb/libs/helpers/probabilistic_validator.py
@@ -111,7 +111,6 @@ class ProbabilisticValidator():
         np.seterr(divide='ignore')
 
         if self.buckets is not None:
-            print(self.X_buff, self.Y_buff)
             self._probabilistic_model.partial_fit(self.X_buff, self.Y_buff, classes=self.bucket_keys)
         else:
             self._probabilistic_model.partial_fit(self.X_buff, self.Y_buff, classes=[True, False])

--- a/mindsdb/libs/helpers/probabilistic_validator.py
+++ b/mindsdb/libs/helpers/probabilistic_validator.py
@@ -26,8 +26,8 @@ class ProbabilisticValidator():
         # <--- Pick one of the 3
         #self._probabilistic_model = ComplementNB(alpha=self._smoothing_factor)
         #, class_prior=[0.5,0.5]
-        #self._probabilistic_model = GaussianNB()
-        self._probabilistic_model = MultinomialNB(alpha=self._smoothing_factor)
+        self._probabilistic_model = GaussianNB()
+        #self._probabilistic_model = MultinomialNB(alpha=self._smoothing_factor)
         self.X_buff = []
         self.Y_buff = []
 

--- a/mindsdb/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb/libs/phases/model_analyzer/model_analyzer.py
@@ -49,7 +49,7 @@ class ModelAnalyzer(BaseModule):
         normal_predictions = self.transaction.model_backend.predict('validate')
 
         # Single observation on the validation dataset when we have no ignorable column
-        if len(ignorable_input_columns) == 0;
+        if len(ignorable_input_columns) == 0:
             for pcol in output_columns:
             for i in range(len(self.transaction.input_data.validation_df[pcol])):
                 probabilistic_validators[pcol].register_observation(features_existence=[True for col in input_columns], real_value=self.transaction.input_data.validation_df[pcol][i], predicted_value=normal_predictions[pcol][i])

--- a/mindsdb/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb/libs/phases/model_analyzer/model_analyzer.py
@@ -63,7 +63,7 @@ class ModelAnalyzer(BaseModule):
                 i = 0
                 for real_val in self.transaction.input_data.validation_df[pcol]:
                     probabilistic_validators[pcol].register_observation(features_existence=features_existence, real_value=real_val, predicted_value=ignore_col_predictions[pcol][i])
-                    probabilistic_validators[pcol].register_observation(features_existence=[True for col in input_columns], real_value=real_val, predicted_value=normal_predictions[pcol][i]))
+                    probabilistic_validators[pcol].register_observation(features_existence=[True for col in input_columns], real_value=real_val, predicted_value=normal_predictions[pcol][i])
                     i += 1
 
         self.transaction.lmd['accuracy_histogram'] = {}

--- a/mindsdb/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb/libs/phases/model_analyzer/model_analyzer.py
@@ -51,8 +51,8 @@ class ModelAnalyzer(BaseModule):
         # Single observation on the validation dataset when we have no ignorable column
         if len(ignorable_input_columns) == 0:
             for pcol in output_columns:
-            for i in range(len(self.transaction.input_data.validation_df[pcol])):
-                probabilistic_validators[pcol].register_observation(features_existence=[True for col in input_columns], real_value=self.transaction.input_data.validation_df[pcol][i], predicted_value=normal_predictions[pcol][i])
+                for i in range(len(self.transaction.input_data.validation_df[pcol])):
+                    probabilistic_validators[pcol].register_observation(features_existence=[True for col in input_columns], real_value=self.transaction.input_data.validation_df[pcol][i], predicted_value=normal_predictions[pcol][i])
 
         # Run on the validation set multiple times, each time with one of the column blanked out
         for column_name in ignorable_input_columns:
@@ -66,11 +66,9 @@ class ModelAnalyzer(BaseModule):
 
             # A separate probabilistic model is trained for each predicted column, we may want to change this in the future, @TODO
             for pcol in output_columns:
-                i = 0
-                for real_val in self.transaction.input_data.validation_df[pcol]:
-                    probabilistic_validators[pcol].register_observation(features_existence=features_existence, real_value=real_val, predicted_value=ignore_col_predictions[pcol][i])
-                    probabilistic_validators[pcol].register_observation(features_existence=[True for col in input_columns], real_value=real_val, predicted_value=normal_predictions[pcol][i])
-                    i += 1
+                for i in range(len(self.transaction.input_data.validation_df[pcol])):
+                    probabilistic_validators[pcol].register_observation(features_existence=features_existence, real_value=self.transaction.input_data.validation_df[pcol][i], predicted_value=ignore_col_predictions[pcol][i])
+                    probabilistic_validators[pcol].register_observation(features_existence=[True for col in input_columns], real_value=self.transaction.input_data.validation_df[pcol][i], predicted_value=normal_predictions[pcol][i])
 
         self.transaction.lmd['accuracy_histogram'] = {}
 

--- a/mindsdb/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb/libs/phases/model_analyzer/model_analyzer.py
@@ -52,7 +52,7 @@ class ModelAnalyzer(BaseModule):
         if len(ignorable_input_columns) == 0:
             for pcol in output_columns:
                 for i in range(len(self.transaction.input_data.validation_df[pcol])):
-                    probabilistic_validators[pcol].register_observation(features_existence=[True for col in input_columns], real_value=self.transaction.input_data.validation_df[pcol][i], predicted_value=normal_predictions[pcol][i])
+                    probabilistic_validators[pcol].register_observation(features_existence=[True for col in input_columns], real_value=self.transaction.input_data.validation_df[pcol].iloc[i], predicted_value=normal_predictions[pcol][i])
 
         # Run on the validation set multiple times, each time with one of the column blanked out
         for column_name in ignorable_input_columns:
@@ -67,8 +67,8 @@ class ModelAnalyzer(BaseModule):
             # A separate probabilistic model is trained for each predicted column, we may want to change this in the future, @TODO
             for pcol in output_columns:
                 for i in range(len(self.transaction.input_data.validation_df[pcol])):
-                    probabilistic_validators[pcol].register_observation(features_existence=features_existence, real_value=self.transaction.input_data.validation_df[pcol][i], predicted_value=ignore_col_predictions[pcol][i])
-                    probabilistic_validators[pcol].register_observation(features_existence=[True for col in input_columns], real_value=self.transaction.input_data.validation_df[pcol][i], predicted_value=normal_predictions[pcol][i])
+                    probabilistic_validators[pcol].register_observation(features_existence=features_existence, real_value=self.transaction.input_data.validation_df[pcol].iloc[i], predicted_value=ignore_col_predictions[pcol][i])
+                    probabilistic_validators[pcol].register_observation(features_existence=[True for col in input_columns], real_value=self.transaction.input_data.validation_df[pcol].iloc[i], predicted_value=normal_predictions[pcol][i])
 
         self.transaction.lmd['accuracy_histogram'] = {}
 

--- a/mindsdb/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb/libs/phases/model_analyzer/model_analyzer.py
@@ -48,11 +48,12 @@ class ModelAnalyzer(BaseModule):
 
         predictions = self.transaction.model_backend.predict('validate')
         for pcol in output_columns:
-            i = 0
-            for real_val in self.transaction.input_data.validation_df[pcol]:
-                predicted_val = predictions[pcol][i]
-                probabilistic_validators[pcol].register_observation(features_existence=[True for col in input_columns], real_value=real_val, predicted_value=predicted_val)
-                i += 1
+            for _ in range(len(input_columns)):
+                i = 0
+                for real_val in self.transaction.input_data.validation_df[pcol]:
+                    predicted_val = predictions[pcol][i]
+                    probabilistic_validators[pcol].register_observation(features_existence=[True for col in input_columns], real_value=real_val, predicted_value=predicted_val)
+                    i += 1
 
         # Run on the validation set multiple times, each time with one of the column blanked out
         for column_name in ignorable_input_columns:

--- a/mindsdb/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb/libs/phases/model_analyzer/model_analyzer.py
@@ -48,6 +48,12 @@ class ModelAnalyzer(BaseModule):
 
         normal_predictions = self.transaction.model_backend.predict('validate')
 
+        # Single observation on the validation dataset when we have no ignorable column
+        if len(ignorable_input_columns) == 0;
+            for pcol in output_columns:
+            for i in range(len(self.transaction.input_data.validation_df[pcol])):
+                probabilistic_validators[pcol].register_observation(features_existence=[True for col in input_columns], real_value=self.transaction.input_data.validation_df[pcol][i], predicted_value=normal_predictions[pcol][i])
+
         # Run on the validation set multiple times, each time with one of the column blanked out
         for column_name in ignorable_input_columns:
             ignore_columns = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ ludwig==0.1.2
 xlrd>=1.0.0
 ImageHash==4.0
 imageio==2.5.0
-lightwood>=0.6.4
+lightwood>=0.6.7


### PR DESCRIPTION
* The probabilistic validator now registers one observation on the true validation dataset for every observation on the validation set with a column nulled out. 

This is done in order not to bias the probabilistic validator on datasets with a lot of columns, when the weighting of the very-relevant observations on the true validation data will be diminished to much by feeding in a lot of ignored-column data. 

I'm not fully sure as to why this works, it has to do with the internals of how the Complement naive bayes gets fit, but in practice it seems to yield good results.

* Removed column renaming from the mindsdb file data source logic, thus fixing a bug where the `when` wasn't working with columns that had special characters in them. 

Also fixed a bug where the prediction was returned in a key == to the modified column name (So, for example, if we predicted `Value A` we had to query `Value_A` to get the prediction). Since column renaming was only needed for ludwig, 

I've added some simple renaming logic to that backend instead (it also handles giving back the correct column names).

* Added passing of `encoder_attrs` to lightwood