### PR TITLE
Various fixes centered mostly around timeseries

### DIFF
--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.3.6'
+__version__ = '1.3.5'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.3.4'
+__version__ = '1.3.5'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.3.5'
+__version__ = '1.3.6'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -144,7 +144,6 @@ class LightwoodBackend():
             train_df = self.transaction.input_data.train_df
             test_df = self.transaction.input_data.test_df
 
-        print(train_df)
         lightwood_config = self._create_lightwood_config()
 
         if self.transaction.lmd['skip_model_training'] == True:
@@ -188,6 +187,7 @@ class LightwoodBackend():
         else:
             run_df = df
 
+        print(run_df)
         predictions = self.predictor.predict(when_data=run_df)
 
         formated_predictions = {}

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -126,6 +126,8 @@ class LightwoodBackend():
         return config
 
     def train(self):
+        lightwood.config.config.CONFIG.USE_CUDA = self.transaction.lmd['use_gpu']
+
         if self.transaction.lmd['model_order_by'] is not None and len(self.transaction.lmd['model_order_by']) > 0:
             train_df = self._create_timeseries_df(self.transaction.input_data.train_df)
             test_df = self._create_timeseries_df(self.transaction.input_data.test_df)
@@ -151,6 +153,8 @@ class LightwoodBackend():
         self.predictor.save(path_to=self.transaction.lmd['lightwood_data']['save_path'])
 
     def predict(self, mode='predict', ignore_columns=[]):
+        lightwood.config.config.CONFIG.USE_CUDA = self.transaction.lmd['use_gpu']
+
         if mode == 'predict':
             # Doing it here since currently data cleanup is included in this, in the future separate data cleanup
             lightwood_config = self._create_lightwood_config()

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -101,6 +101,7 @@ class LightwoodBackend():
 
             elif data_subtype in (DATA_SUBTYPES.TIMESTAMP, DATA_SUBTYPES.DATE):
                 lightwood_data_type = 'datetime'
+                lightwood_data_type = 'time_series'
 
             elif data_subtype in (DATA_SUBTYPES.IMAGE):
                 lightwood_data_type = 'image'
@@ -126,6 +127,7 @@ class LightwoodBackend():
             else:
                 config['output_features'].append(col_config)
 
+        print(config)
         return config
 
     def train(self):

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -112,8 +112,6 @@ class LightwoodBackend():
             elif data_subtype in (DATA_SUBTYPES.TEXT):
                 lightwood_data_type = 'text'
 
-            # @TODO Handle lightwood's time_series data type
-
             else:
                 self.transaction.log.error(f'The lightwood model backend is unable to handle data of type {data_type} and subtype {data_subtype} !')
                 raise Exception('Failed to build data definition for Lightwood model backend')

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -34,6 +34,8 @@ class LightwoodBackend():
                 group_by_ts_map[gb_lookup_key] = []
 
             for col in order_by:
+                if row[col] is None:
+                    row[col] = 0.0
                 try:
                     row[col] = float(row[col])
                 except:
@@ -52,6 +54,7 @@ class LightwoodBackend():
             for order_col in order_by:
                 for i in range(0,len(group_by_ts_map[k])):
                     group_by_ts_map[k][order_col] = group_by_ts_map[k][order_col].astype(object)
+
 
                     numerical_value = float(group_by_ts_map[k][order_col].iloc[i])
                     arr_val = [str(numerical_value)]

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -139,7 +139,12 @@ class LightwoodBackend():
             self.predictor = lightwood.Predictor(load_from_path=os.path.join(CONFIG.MINDSDB_STORAGE_PATH, self.transaction.lmd['name'] + '_lightwood_data'))
         else:
             self.predictor = lightwood.Predictor(lightwood_config)
-            self.predictor.learn(from_data=train_df, test_data=test_df)
+
+            if self.transaction.lmd['stop_training_in_x_seconds'] is None:
+                self.predictor.learn(from_data=train_df, test_data=test_df)
+            else:
+                self.predictor.learn(from_data=train_df, test_data=test_df, stop_training_after_seconds=self.transaction.lmd['stop_training_in_x_seconds'])
+
             self.transaction.log.info('Training accuracy of: {}'.format(self.predictor.train_accuracy))
 
         self.transaction.lmd['lightwood_data']['save_path'] = os.path.join(CONFIG.MINDSDB_STORAGE_PATH, self.transaction.lmd['name'] + '_lightwood_data')

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -66,7 +66,7 @@ class LightwoodBackend():
                     previous_indexes.reverse()
 
                     for prev_i in previous_indexes:
-                        group_by_ts_map[k].iloc[i][order_col].append(group_by_ts_map[k].iloc[prev_i][order_col][-1])
+                        group_by_ts_map[k].iloc[i][order_col].append(group_by_ts_map[k][order_col].iloc[prev_i].split(' ')[-1])
 
                     while len(group_by_ts_map[k].iloc[i][order_col]) <= nr_samples:
                         group_by_ts_map[k].iloc[i][order_col].append('0')
@@ -187,7 +187,6 @@ class LightwoodBackend():
         else:
             run_df = df
 
-        print(run_df)
         predictions = self.predictor.predict(when_data=run_df)
 
         formated_predictions = {}

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -58,7 +58,7 @@ class LudwigBackend():
             new_cols[col] = []
 
         nr_ele = len(df[timeseries_col_name])
-        
+
         i = 0
         while i < nr_ele:
             new_row = {}

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -422,7 +422,7 @@ class Predictor:
             print(e)
             return False
 
-    def learn(self, to_predict, from_data = None, test_from_data=None, group_by = None, window_size = None, order_by = [], sample_margin_of_error = CONFIG.DEFAULT_MARGIN_OF_ERROR, ignore_columns = [], stop_training_in_x_seconds = None, stop_training_in_accuracy = None, backend='lightwood', rebuild_model=True, use_gpu=True, disable_optional_analysis=False, unstable_parameters_dict={}):
+    def learn(self, to_predict, from_data = None, test_from_data=None, group_by = None, window_size = None, order_by = [], sample_margin_of_error = CONFIG.DEFAULT_MARGIN_OF_ERROR, ignore_columns = [], stop_training_in_x_seconds = None, stop_training_in_accuracy = None, backend='lightwood', rebuild_model=True, use_gpu=False, disable_optional_analysis=False, unstable_parameters_dict={}):
         """
         Tells the mind to learn to predict a column or columns from the data in 'from_data'
 
@@ -546,7 +546,7 @@ class Predictor:
         Transaction(session=self, light_transaction_metadata=light_transaction_metadata, heavy_transaction_metadata=heavy_transaction_metadata, logger=self.log)
 
 
-    def predict(self, when={}, when_data = None, update_cached_model = False, use_gpu=True):
+    def predict(self, when={}, when_data = None, update_cached_model = False, use_gpu=False):
         """
         You have a mind trained already and you want to make a prediction
 

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -223,8 +223,8 @@ class Predictor:
             amd['status'] = 'training'
 
         # Shared keys
-        for k in ['name', 'version', 'is_active', 'data_source', 'predict', 'accuracy',
-        'current_phase', 'train_end_at', 'updated_at', 'created_at','data_preparation', 'validation_set_accuracy']:
+        for k in ['name', 'version', 'is_active', 'data_source', 'predict', 'current_phase',
+        'train_end_at', 'updated_at', 'created_at','data_preparation', 'validation_set_accuracy']:
             if k == 'predict':
                 amd[k] = lmd['predict_columns']
             elif k in lmd:

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -202,7 +202,7 @@ class Transaction:
         for predicted_col in self.lmd['predict_columns']:
             output_data[predicted_col] = list(self.hmd['predictions'][predicted_col])
 
-            #probabilistic_validator = unpickle_obj(self.hmd['probabilistic_validators'][predicted_col])
+            probabilistic_validator = unpickle_obj(self.hmd['probabilistic_validators'][predicted_col])
             confidence_column_name = f'{predicted_col}_confidence'
             output_data[confidence_column_name] = [None] * len(output_data[predicted_col])
             evaluations[predicted_col] = [None] * len(output_data[predicted_col])
@@ -214,8 +214,8 @@ class Transaction:
                 features_existance_vector = [False if output_data[col][row_number] is None else True for col in input_columns if col not in self.lmd['malformed_columns']['names']]
 
                 # Create the probabilsitic evaluation
-                #prediction_evaluation = probabilistic_validator.evaluate_prediction_accuracy(features_existence=features_existance_vector, predicted_value=predicted_value)
-                prediction_evaluation = 1
+                prediction_evaluation = probabilistic_validator.evaluate_prediction_accuracy(features_existence=features_existance_vector, predicted_value=predicted_value)
+                #prediction_evaluation = 1
                 if type(prediction_evaluation) == float or type(prediction_evaluation) == int:
                     output_data[confidence_column_name][row_number] = prediction_evaluation
                     evaluations[predicted_col][row_number] = None

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -202,7 +202,7 @@ class Transaction:
         for predicted_col in self.lmd['predict_columns']:
             output_data[predicted_col] = list(self.hmd['predictions'][predicted_col])
 
-            probabilistic_validator = unpickle_obj(self.hmd['probabilistic_validators'][predicted_col])
+            #probabilistic_validator = unpickle_obj(self.hmd['probabilistic_validators'][predicted_col])
             confidence_column_name = f'{predicted_col}_confidence'
             output_data[confidence_column_name] = [None] * len(output_data[predicted_col])
             evaluations[predicted_col] = [None] * len(output_data[predicted_col])
@@ -214,8 +214,9 @@ class Transaction:
                 features_existance_vector = [False if output_data[col][row_number] is None else True for col in input_columns if col not in self.lmd['malformed_columns']['names']]
 
                 # Create the probabilsitic evaluation
-                prediction_evaluation = probabilistic_validator.evaluate_prediction_accuracy(features_existence=features_existance_vector, predicted_value=predicted_value)
-                if type(prediction_evaluation) == float:
+                #prediction_evaluation = probabilistic_validator.evaluate_prediction_accuracy(features_existence=features_existance_vector, predicted_value=predicted_value)
+                prediction_evaluation = 1
+                if type(prediction_evaluation) == float or type(prediction_evaluation) == int:
                     output_data[confidence_column_name][row_number] = prediction_evaluation
                     evaluations[predicted_col][row_number] = None
                 else:

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -99,9 +99,9 @@ class DataTransformer(BaseModule):
 
             if self.transaction.lmd['model_backend'] == 'lightwood':
                 if data_type == DATA_TYPES.DATE:
-                    self._aply_to_all_data(input_data, column, self._standardize_datetime)
                     self._aply_to_all_data(input_data, column, pd.to_datetime)
-
+                    self._aply_to_all_data(input_data, column, self._standardize_datetime)
+                    
         # Un-bias dataset for training
         for colum in self.transaction.lmd['predict_columns']:
             if self.transaction.lmd['column_stats'][column]['data_type'] == DATA_TYPES.CATEGORICAL and self.transaction.lmd['balance_target_category'] == True and mode == 'train':

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -38,13 +38,13 @@ class DataTransformer(BaseModule):
         #return date.date()
 
         # Uncomment if we want to work internally with string type
-        return date.strftime('%y-%m-%d')
+        return date.strftime('%Y-%m-%d')
 
     @staticmethod
-    def _standardize_datetime(datetime_str):
+    def _standardize_datetime(date_str):
         try:
             # will return a datetime object
-            dt = parse_datetime(date_str)
+            dt = parse_datetime(str(date_str))
         except:
             try:
                 dt = datetime.datetime.utcfromtimestamp(date_str)
@@ -55,7 +55,7 @@ class DataTransformer(BaseModule):
 
         # Uncomment if we want to work internally with string type
         # @TODO Decide if we ever need/want the milliseconds
-        return dt.strftime('%y-%m-%d %H:%M:%S')
+        return dt.strftime('%Y-%m-%d %H:%M:%S')
 
     @staticmethod
     def _aply_to_all_data(input_data, column, func):

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -64,7 +64,7 @@ class DataTransformer(BaseModule):
             return dt.timestamp()
         except:
             # @TODO Return `None` after appropriate changes in lightwood
-            return 0
+            return None
 
     @staticmethod
     def _aply_to_all_data(input_data, column, func):
@@ -110,6 +110,7 @@ class DataTransformer(BaseModule):
                 if data_type == DATA_TYPES.DATE:
                     self._aply_to_all_data(input_data, column, self._standardize_datetime)
                     self._aply_to_all_data(input_data, column, self._lightwood_datetime_processing)
+                    self._aply_to_all_data(input_data, column, self._handle_nan)
 
         # Un-bias dataset for training
         for colum in self.transaction.lmd['predict_columns']:

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -100,7 +100,7 @@ class DataTransformer(BaseModule):
             if self.transaction.lmd['model_backend'] == 'lightwood':
                 if data_type == DATA_TYPES.DATE:
                     self._aply_to_all_data(input_data, column, self._standardize_datetime)
-                    self._aply_to_all_data(input_data, column, pd.to_datetime)
+                    self._aply_to_all_data(input_data, column, lambda x: pd.to_datetime(x, errors = 'coerce'))
                     self._aply_to_all_data(input_data, column, lambda x: int(x.timestamp()))
 
         # Un-bias dataset for training

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -99,9 +99,9 @@ class DataTransformer(BaseModule):
 
             if self.transaction.lmd['model_backend'] == 'lightwood':
                 if data_type == DATA_TYPES.DATE:
-                    self._aply_to_all_data(input_data, column, pd.to_datetime)
                     self._aply_to_all_data(input_data, column, self._standardize_datetime)
-                    
+                    self._aply_to_all_data(input_data, column, pd.to_datetime)
+
         # Un-bias dataset for training
         for colum in self.transaction.lmd['predict_columns']:
             if self.transaction.lmd['column_stats'][column]['data_type'] == DATA_TYPES.CATEGORICAL and self.transaction.lmd['balance_target_category'] == True and mode == 'train':

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -1,5 +1,6 @@
 from dateutil.parser import parse as parse_datetime
 import datetime
+import math
 
 import pandas as pd
 from mindsdb.libs.constants.mindsdb import *
@@ -8,6 +9,13 @@ from mindsdb.libs.helpers.text_helpers import clean_float
 
 
 class DataTransformer(BaseModule):
+
+    @staticmethod
+    def _handle_nan(x):
+        if math.isnan(x):
+            return 0 #None
+        else:
+            return x
 
     @staticmethod
     def _try_round(x):
@@ -74,6 +82,7 @@ class DataTransformer(BaseModule):
 
             if data_type == DATA_TYPES.NUMERIC:
                 self._aply_to_all_data(input_data, column, clean_float)
+                self._aply_to_all_data(input_data, column, self._handle_nan)
 
                 if data_subtype == DATA_SUBTYPES.INT:
                     self._aply_to_all_data(input_data, column, DataTransformer._try_round)
@@ -85,12 +94,11 @@ class DataTransformer(BaseModule):
                 elif data_subtype == DATA_SUBTYPES.TIMESTAMP:
                     self._aply_to_all_data(input_data, column, self._standardize_datetime)
 
-            if data_type == DATA_TYPES.CATEGORICAL or data_subtype == DATA_SUBTYPES.DATE:
+            if data_type == DATA_TYPES.CATEGORICAL:
                     self._cast_all_data(input_data, column, 'category')
 
             if self.transaction.lmd['model_backend'] == 'lightwood':
                 if data_type == DATA_TYPES.DATE:
-                    #self._cast_all_data(input_data, column, 'datetime')
                     self._aply_to_all_data(input_data, column, self._standardize_datetime)
                     self._aply_to_all_data(input_data, column, pd.to_datetime)
 

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -101,6 +101,7 @@ class DataTransformer(BaseModule):
                 if data_type == DATA_TYPES.DATE:
                     self._aply_to_all_data(input_data, column, self._standardize_datetime)
                     self._aply_to_all_data(input_data, column, pd.to_datetime)
+                    self._aply_to_all_data(input_data, column, lambda x: int(x.timestamp()))
 
         # Un-bias dataset for training
         for colum in self.transaction.lmd['predict_columns']:

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -12,8 +12,8 @@ class DataTransformer(BaseModule):
 
     @staticmethod
     def _handle_nan(x):
-        if math.isnan(x):
-            return 0 #None
+        if x is not None and math.isnan(x):
+            return 0
         else:
             return x
 
@@ -58,6 +58,15 @@ class DataTransformer(BaseModule):
         return dt.strftime('%Y-%m-%d %H:%M:%S')
 
     @staticmethod
+    def _lightwood_datetime_processing(dt):
+        dt = pd.to_datetime(dt, errors = 'coerce')
+        try:
+            return dt.timestamp()
+        except:
+            # @TODO Return `None` after appropriate changes in lightwood
+            return 0
+
+    @staticmethod
     def _aply_to_all_data(input_data, column, func):
         input_data.data_frame[column] = input_data.data_frame[column].apply(func)
         input_data.train_df[column] = input_data.train_df[column].apply(func)
@@ -100,8 +109,7 @@ class DataTransformer(BaseModule):
             if self.transaction.lmd['model_backend'] == 'lightwood':
                 if data_type == DATA_TYPES.DATE:
                     self._aply_to_all_data(input_data, column, self._standardize_datetime)
-                    self._aply_to_all_data(input_data, column, lambda x: pd.to_datetime(x, errors = 'coerce'))
-                    self._aply_to_all_data(input_data, column, lambda x: int(x.timestamp()))
+                    self._aply_to_all_data(input_data, column, self._lightwood_datetime_processing)
 
         # Un-bias dataset for training
         for colum in self.transaction.lmd['predict_columns']:

--- a/mindsdb/libs/phases/model_analyzer/helpers/column_evaluator.py
+++ b/mindsdb/libs/phases/model_analyzer/helpers/column_evaluator.py
@@ -36,7 +36,7 @@ class ColumnEvaluator():
 
         ignorable_input_columns = []
         for input_column in input_columns:
-            if stats[input_column]['data_type'] != DATA_TYPES.FILE_PATH:
+            if stats[input_column]['data_type'] != DATA_TYPES.FILE_PATH and input_column not in [x[0] for x in self.transaction.lmd['model_order_by']]:
                 ignorable_input_columns.append(input_column)
 
         for input_column in ignorable_input_columns:

--- a/mindsdb/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb/libs/phases/model_analyzer/model_analyzer.py
@@ -42,7 +42,7 @@ class ModelAnalyzer(BaseModule):
 
         ignorable_input_columns = []
         for input_column in input_columns:
-            if self.transaction.lmd['column_stats'][input_column]['data_type'] != DATA_TYPES.FILE_PATH:
+            if self.transaction.lmd['column_stats'][input_column]['data_type'] != DATA_TYPES.FILE_PATH and input_column not in [x[0] for x in self.transaction.lmd['model_order_by']]:
                 ignorable_input_columns.append(input_column)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ ludwig ==  0.1.2
 xlrd >= 1.0.0
 ImageHash ==  4.0
 imageio ==  2.5.0
-lightwood <=  0.8.0
+lightwood <=  0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ ludwig ==  0.1.2
 xlrd >= 1.0.0
 ImageHash ==  4.0
 imageio ==  2.5.0
-lightwood <=  0.8.1
+lightwood <=  0.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ ludwig ==  0.1.2
 xlrd >= 1.0.0
 ImageHash ==  4.0
 imageio ==  2.5.0
-lightwood <=  0.7.7
+lightwood <=  0.8.0

--- a/tests/integration_tests/generated_data_tests.py
+++ b/tests/integration_tests/generated_data_tests.py
@@ -114,6 +114,7 @@ def test_timeseries():
     try:
         results = mdb.predict(when_data=test_file_name,use_gpu=False)
         models = mdb.get_models()
+        print(models)
         mdb.get_model_data(models[0]['name'])
         for row in results:
             expect_columns = [label_headers[0] ,label_headers[0] + '_confidence']

--- a/tests/integration_tests/generated_data_tests.py
+++ b/tests/integration_tests/generated_data_tests.py
@@ -378,7 +378,7 @@ def test_multilabel_prediction():
 setup_testing_logger()
 
 if __name__ == '__main__':
-    test_one_label_prediction_wo_strings()
     test_timeseries()
+    test_one_label_prediction_wo_strings()
     test_multilabel_prediction()
     test_one_label_prediction()

--- a/tests/integration_tests/generated_data_tests.py
+++ b/tests/integration_tests/generated_data_tests.py
@@ -76,7 +76,7 @@ def test_timeseries():
 
     mdb = None
     try:
-        mdb = mindsdb.Predictor(name='test_date_timeseries')
+        mdb = mindsdb.Predictor(name='test_date_timeseries_2')
         logger.debug(f'Succesfully create mindsdb Predictor')
     except:
         print(traceback.format_exc())
@@ -104,7 +104,7 @@ def test_timeseries():
 
     # Predict
     try:
-        mdb = mindsdb.Predictor(name='test_date_timeseries')
+        mdb = mindsdb.Predictor(name='test_date_timeseries_2')
         logger.debug(f'Succesfully create mindsdb Predictor')
     except:
         print(traceback.format_exc())
@@ -112,10 +112,8 @@ def test_timeseries():
         exit(1)
 
     try:
-        results = mdb.predict(when_data=test_file_name,use_gpu=False)
-        models = mdb.get_models()
-        print(models)
-        mdb.get_model_data(models[0]['name'])
+        results = mdb.predict(when_data=test_file_name,use_gpu=False,order_by=feature_headers[0],window_size=3)
+
         for row in results:
             expect_columns = [label_headers[0] ,label_headers[0] + '_confidence']
             for col in expect_columns:
@@ -123,6 +121,10 @@ def test_timeseries():
                     logger.error(f'Prediction failed to return expected column: {col}')
                     logger.debug('Got row: {}'.format(row))
                     exit(1)
+
+        models = mdb.get_models()
+        print(models)
+        mdb.get_model_data(models[0]['name'])
 
         logger.info(f'--------------- Predicting ran succesfully ---------------')
     except:

--- a/tests/integration_tests/generated_data_tests.py
+++ b/tests/integration_tests/generated_data_tests.py
@@ -224,7 +224,7 @@ def test_one_label_prediction_wo_strings():
     logger.debug(f'Creating one-labe test datasets and saving them to {train_file_name} and {test_file_name}, total dataset size will be {data_len} rows')
 
     try:
-        features = generate_value_cols(['int','float','datetime','int'],data_len, separator)
+        features = generate_value_cols(['int','float','datetime','date','int'],data_len, separator)
         labels = [generate_labels_2(features, separator)]
 
         feature_headers = list(map(lambda col: col[0], features))

--- a/tests/integration_tests/generated_data_tests.py
+++ b/tests/integration_tests/generated_data_tests.py
@@ -224,7 +224,7 @@ def test_one_label_prediction_wo_strings():
     logger.debug(f'Creating one-labe test datasets and saving them to {train_file_name} and {test_file_name}, total dataset size will be {data_len} rows')
 
     try:
-        features = generate_value_cols(['int','float','date','int'],data_len, separator)
+        features = generate_value_cols(['int','float','datetime','int'],data_len, separator)
         labels = [generate_labels_2(features, separator)]
 
         feature_headers = list(map(lambda col: col[0], features))
@@ -381,7 +381,7 @@ def test_multilabel_prediction():
 setup_testing_logger()
 
 if __name__ == '__main__':
-    #test_timeseries()
+    test_timeseries()
     test_one_label_prediction_wo_strings()
-    #test_multilabel_prediction()
-    #test_one_label_prediction()
+    test_multilabel_prediction()
+    test_one_label_prediction()

--- a/tests/integration_tests/generated_data_tests.py
+++ b/tests/integration_tests/generated_data_tests.py
@@ -112,7 +112,7 @@ def test_timeseries():
         exit(1)
 
     try:
-        results = mdb.predict(when_data=test_file_name,use_gpu=False,order_by=feature_headers[0],window_size=3)
+        results = mdb.predict(when_data=test_file_name,use_gpu=False)
 
         for row in results:
             expect_columns = [label_headers[0] ,label_headers[0] + '_confidence']
@@ -381,7 +381,7 @@ def test_multilabel_prediction():
 setup_testing_logger()
 
 if __name__ == '__main__':
-    test_timeseries()
+    #test_timeseries()
     test_one_label_prediction_wo_strings()
-    test_multilabel_prediction()
-    test_one_label_prediction()
+    #test_multilabel_prediction()
+    #test_one_label_prediction()


### PR DESCRIPTION
* Fixed the way timeseries data was adapted for lightwood... it was completely **** before, no idea how it even passed the tests
* Handling `nan` float values by simply setting them to `0`
* Fixes around how we standardize date and datetime/timestamp types for lightwood
* No longer ignoring order by columns in the model analysis