### PR TITLE
Added always_use_model_prediction to unstable parameters dict

### DIFF
--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.4.5'
+__version__ = '1.4.6'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -524,6 +524,11 @@ class Predictor:
         else:
             light_transaction_metadata['skip_stats_generation'] = False
 
+        if 'always_use_model_prediction' in unstable_parameters_dict:
+            light_transaction_metadata['always_use_model_prediction'] = unstable_parameters_dict['always_use_model_prediction']
+        else:
+            light_transaction_metadata['always_use_model_prediction'] = False
+
         if rebuild_model is False:
             old_lmd = {}
             for k in light_transaction_metadata: old_lmd[k] = light_transaction_metadata[k]
@@ -545,7 +550,7 @@ class Predictor:
         Transaction(session=self, light_transaction_metadata=light_transaction_metadata, heavy_transaction_metadata=heavy_transaction_metadata, logger=self.log)
 
 
-    def predict(self, when={}, when_data = None, update_cached_model = False, use_gpu=False):
+    def predict(self, when={}, when_data = None, update_cached_model = False, use_gpu=False, unstable_parameters_dict={}):
         """
         You have a mind trained already and you want to make a prediction
 
@@ -577,6 +582,11 @@ class Predictor:
         light_transaction_metadata['use_gpu'] = use_gpu
         light_transaction_metadata['data_preparation'] = {}
 
+        if 'always_use_model_prediction' in unstable_parameters_dict:
+            light_transaction_metadata['always_use_model_prediction'] = unstable_parameters_dict['always_use_model_prediction']
+        else:
+            light_transaction_metadata['always_use_model_prediction'] = False
+            
         transaction = Transaction(session=self, light_transaction_metadata=light_transaction_metadata, heavy_transaction_metadata=heavy_transaction_metadata)
 
         return transaction.output_data

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -230,7 +230,7 @@ class Transaction:
                 features_existance_vector = [False if output_data[col][row_number] is None else True for col in input_columns if col not in self.lmd['malformed_columns']['names']]
 
                 # Create the probabilsitic evaluation
-                prediction_evaluation = probabilistic_validator.evaluate_prediction_accuracy(features_existence=features_existance_vector, predicted_value=predicted_value, self.lmd['always_use_model_prediction'])
+                prediction_evaluation = probabilistic_validator.evaluate_prediction_accuracy(features_existence=features_existance_vector, predicted_value=predicted_value, always_use_model_prediction=self.lmd['always_use_model_prediction'])
 
                 output_data[predicted_col][row_number] = prediction_evaluation.final_value
                 output_data[confidence_column_name][row_number] = prediction_evaluation.most_likely_probability

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -230,7 +230,7 @@ class Transaction:
                 features_existance_vector = [False if output_data[col][row_number] is None else True for col in input_columns if col not in self.lmd['malformed_columns']['names']]
 
                 # Create the probabilsitic evaluation
-                prediction_evaluation = probabilistic_validator.evaluate_prediction_accuracy(features_existence=features_existance_vector, predicted_value=predicted_value)
+                prediction_evaluation = probabilistic_validator.evaluate_prediction_accuracy(features_existence=features_existance_vector, predicted_value=predicted_value, self.lmd['always_use_model_prediction'])
 
                 output_data[predicted_col][row_number] = prediction_evaluation.final_value
                 output_data[confidence_column_name][row_number] = prediction_evaluation.most_likely_probability

--- a/mindsdb/libs/data_types/probability_evaluation.py
+++ b/mindsdb/libs/data_types/probability_evaluation.py
@@ -3,13 +3,14 @@ from mindsdb.libs.constants.mindsdb import *
 
 class ProbabilityEvaluation:
 
-    def __init__(self, buckets, evaluation_distribution, predicted_value):
+    def __init__(self, buckets, evaluation_distribution, predicted_value, always_use_model_prediction):
         self.distribution = evaluation_distribution
         self.predicted_value = predicted_value
         self.buckets = buckets
         self.most_likely_value = None
         self.most_likely_probability = None
         self.final_value = None
+        self.always_use_model_prediction = always_use_model_prediction
 
         if evaluation_distribution is not None:
             self.update(evaluation_distribution, predicted_value)
@@ -147,3 +148,7 @@ class ProbabilityEvaluation:
                     self.final_value = predicted_value
                 else:
                     self.final_value = self.most_likely_value
+
+        # Return the prediction of the model
+        if self.always_use_model_prediction:
+            self.final_value = predicted_value

--- a/mindsdb/libs/helpers/probabilistic_validator.py
+++ b/mindsdb/libs/helpers/probabilistic_validator.py
@@ -132,7 +132,7 @@ class ProbabilisticValidator():
         self._X_buff= []
         self._Y_buff= []
 
-    def evaluate_prediction_accuracy(self, features_existence, predicted_value):
+    def evaluate_prediction_accuracy(self, features_existence, predicted_value, always_use_model_prediction):
         """
         # Fit the probabilistic validator on an observation    def evaluate_prediction_accuracy(self, features_existence, predicted_value):
         :param features_existence: A vector of 0 and 1 representing the existence of all the features (0 == not exists, 1 == exists)
@@ -170,7 +170,7 @@ class ProbabilisticValidator():
             pass
 
 
-        return ProbabilityEvaluation(self.buckets, distribution, predicted_value)
+        return ProbabilityEvaluation(self.buckets, distribution, predicted_value, always_use_model_prediction)
 
 
 


### PR DESCRIPTION
Added the `always_use_model_prediction` parameters to the `unstable_parameters_dict`, and added `unstable_parameters_dict` to the list of argument `predict` can take.

This is in order to side-step models where the bayesian model is not giving us decent results.

This is a temporary fix until we find better bayesian models.