### PR TITLE
Target category balancing

### DIFF
--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -124,8 +124,8 @@ class LightwoodBackend():
                 'type': lightwood_data_type
             }
 
-            if col_name in self.transaction.lmd['lightwood_weight_map']:
-                col_config['weights'] = self.transaction.lmd['lightwood_weight_map'][col_name]
+            if col_name in self.transaction.lmd['weight_map']:
+                col_config['weights'] = self.transaction.lmd['weight_map'][col_name]
 
             col_config.update(other_keys)
 

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -123,6 +123,10 @@ class LightwoodBackend():
                 'name': col_name,
                 'type': lightwood_data_type
             }
+
+            if col_name in self.transaction.lmd['lightwood_weight_map']:
+                col_config['weights'] = self.transaction.lmd['lightwood_weight_map'][col_name]
+
             col_config.update(other_keys)
 
             if col_name not in self.transaction.lmd['predict_columns']:

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -127,6 +127,9 @@ class LightwoodBackend():
             if col_name in self.transaction.lmd['weight_map']:
                 col_config['weights'] = self.transaction.lmd['weight_map'][col_name]
 
+                print(col_name)
+                print(col_config['weights'])
+
             col_config.update(other_keys)
 
             if col_name not in self.transaction.lmd['predict_columns']:

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -126,10 +126,7 @@ class LightwoodBackend():
 
             if col_name in self.transaction.lmd['weight_map']:
                 col_config['weights'] = self.transaction.lmd['weight_map'][col_name]
-
-                print(col_name)
-                print(col_config['weights'])
-
+                
             col_config.update(other_keys)
 
             if col_name not in self.transaction.lmd['predict_columns']:

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -510,7 +510,7 @@ class Predictor:
         light_transaction_metadata['ludwig_data'] = {}
         light_transaction_metadata['weight_map'] = {}
         light_transaction_metadata['equal_accuracy_for_all_output_categories'] = equal_accuracy_for_all_output_categories
-        light_transaction_metadata['output_categories_importance_dictionar'] = output_categories_importance_dictionary if output_categories_importance_dictionary is not None else {}
+        light_transaction_metadata['output_categories_importance_dictionary'] = output_categories_importance_dictionary if output_categories_importance_dictionary is not None else {}
 
         if 'skip_model_training' in unstable_parameters_dict:
             light_transaction_metadata['skip_model_training'] = unstable_parameters_dict['skip_model_training']

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -421,7 +421,7 @@ class Predictor:
             print(e)
             return False
 
-    def learn(self, to_predict, from_data = None, test_from_data=None, group_by = None, window_size = None, order_by = [], sample_margin_of_error = CONFIG.DEFAULT_MARGIN_OF_ERROR, ignore_columns = [], stop_training_in_x_seconds = None, stop_training_in_accuracy = None, backend='lightwood', rebuild_model=True, use_gpu=False, disable_optional_analysis=False, equal_accuracy_for_all_output_categories=False, output_categories_importance_dictionary, unstable_parameters_dict={}):
+    def learn(self, to_predict, from_data = None, test_from_data=None, group_by = None, window_size = None, order_by = [], sample_margin_of_error = CONFIG.DEFAULT_MARGIN_OF_ERROR, ignore_columns = [], stop_training_in_x_seconds = None, stop_training_in_accuracy = None, backend='lightwood', rebuild_model=True, use_gpu=False, disable_optional_analysis=False, equal_accuracy_for_all_output_categories=False, output_categories_importance_dictionary=None, unstable_parameters_dict={}):
         """
         Tells the mind to learn to predict a column or columns from the data in 'from_data'
 

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -508,6 +508,7 @@ class Predictor:
         light_transaction_metadata['validation_set_accuracy'] = None
         light_transaction_metadata['lightwood_data'] = {}
         light_transaction_metadata['ludwig_data'] = {}
+        light_transaction_metadata['weight_map'] = {}
 
         if 'balance_target_category' in unstable_parameters_dict:
             light_transaction_metadata['balance_target_category'] = unstable_parameters_dict['balance_target_category']
@@ -586,7 +587,7 @@ class Predictor:
             light_transaction_metadata['always_use_model_prediction'] = unstable_parameters_dict['always_use_model_prediction']
         else:
             light_transaction_metadata['always_use_model_prediction'] = False
-            
+
         transaction = Transaction(session=self, light_transaction_metadata=light_transaction_metadata, heavy_transaction_metadata=heavy_transaction_metadata)
 
         return transaction.output_data

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -421,7 +421,7 @@ class Predictor:
             print(e)
             return False
 
-    def learn(self, to_predict, from_data = None, test_from_data=None, group_by = None, window_size = None, order_by = [], sample_margin_of_error = CONFIG.DEFAULT_MARGIN_OF_ERROR, ignore_columns = [], stop_training_in_x_seconds = None, stop_training_in_accuracy = None, backend='lightwood', rebuild_model=True, use_gpu=False, disable_optional_analysis=False, unstable_parameters_dict={}):
+    def learn(self, to_predict, from_data = None, test_from_data=None, group_by = None, window_size = None, order_by = [], sample_margin_of_error = CONFIG.DEFAULT_MARGIN_OF_ERROR, ignore_columns = [], stop_training_in_x_seconds = None, stop_training_in_accuracy = None, backend='lightwood', rebuild_model=True, use_gpu=False, disable_optional_analysis=False, equal_accuracy_for_all_output_categories=False, output_categories_importance_dictionary, unstable_parameters_dict={}):
         """
         Tells the mind to learn to predict a column or columns from the data in 'from_data'
 
@@ -509,11 +509,8 @@ class Predictor:
         light_transaction_metadata['lightwood_data'] = {}
         light_transaction_metadata['ludwig_data'] = {}
         light_transaction_metadata['weight_map'] = {}
-
-        if 'balance_target_category' in unstable_parameters_dict:
-            light_transaction_metadata['balance_target_category'] = unstable_parameters_dict['balance_target_category']
-        else:
-            light_transaction_metadata['balance_target_category'] = False
+        light_transaction_metadata['equal_accuracy_for_all_output_categories'] = equal_accuracy_for_all_output_categories
+        light_transaction_metadata['output_categories_importance_dictionar'] = output_categories_importance_dictionary if output_categories_importance_dictionary is not None else {}
 
         if 'skip_model_training' in unstable_parameters_dict:
             light_transaction_metadata['skip_model_training'] = unstable_parameters_dict['skip_model_training']

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -134,11 +134,7 @@ class DataTransformer(BaseModule):
 
 
                 column_is_weighted_in_train = column in self.transaction.lmd['weight_map']
-
-                print(len(input_data.data_frame))
-                print(len(input_data.train_df))
-                print(len(input_data.validation_df))
-
+                
                 for val in occurance_map:
                     copied_rows_train = []
                     copied_rows_test = []
@@ -149,11 +145,13 @@ class DataTransformer(BaseModule):
 
                     while occurance_map[val] < max_val_occurances:
                         if ciclying_map[val] >= len(valid_rows.index) - 1:
-                            input_data.data_frame = input_data.data_frame.append(copied_rows_train)
-                            input_data.train_df = input_data.train_df.append(copied_rows_train)
+                            if len(copied_rows_train) > 0:
+                                input_data.data_frame = input_data.data_frame.append(copied_rows_train)
+                                input_data.train_df = input_data.train_df.append(copied_rows_train)
 
-                            input_data.data_frame = input_data.data_frame.append(copied_rows_test)
-                            input_data.test_df = input_data.test_df.append(copied_rows_test)
+                            if len(copied_rows_test) > 0:
+                                input_data.data_frame = input_data.data_frame.append(copied_rows_test)
+                                input_data.test_df = input_data.test_df.append(copied_rows_test)
 
                             input_data.data_frame = input_data.data_frame.append(copied_rows_validate)
                             input_data.validation_df = input_data.validation_df.append(copied_rows_validate)
@@ -207,9 +205,3 @@ class DataTransformer(BaseModule):
                     if len(copied_rows_validate) > 0:
                         input_data.data_frame = input_data.data_frame.append(copied_rows_validate)
                         input_data.train_df = input_data.validation_df.append(copied_rows_validate)
-
-                print('============')
-                print(len(input_data.data_frame))
-                print(len(input_data.train_df))
-                print(len(input_data.validation_df))
-                print('%%%%%%%%%%%%%')

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -148,7 +148,7 @@ class DataTransformer(BaseModule):
                     valid_rows = input_data.data_frame[input_data.data_frame[colum] == val]
 
                     while occurance_map[val] < max_val_occurances:
-                        if ciclying_map[val] >= len(valid_rows.index):
+                        if ciclying_map[val] >= len(valid_rows.index) - 1:
                             input_data.data_frame = input_data.data_frame.append(copied_rows_train)
                             input_data.train_df = input_data.train_df.append(copied_rows_train)
 
@@ -165,7 +165,7 @@ class DataTransformer(BaseModule):
                             ciclying_map[val] = 0
 
                         index = list(valid_rows.index)[ciclying_map[val]]
-                        
+
                         if index in self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY] and not column_is_weighted_in_train:
                             data_frame_length = data_frame_length + 1
                             copied_row = valid_rows.iloc[ciclying_map[val]]

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -132,11 +132,11 @@ class DataTransformer(BaseModule):
                     for val in occurance_map:
                         lightwood_weight_map[val] = 1 - occurance_map[val]/sum_val_occurances
 
-                        if column in light_transaction_metadata['output_categories_importance_dictionar']:
-                            if val in light_transaction_metadata['output_categories_importance_dictionar'][column]:
-                                lightwood_weight_map[val] = lightwood_weight_map[val] * light_transaction_metadata['output_categories_importance_dictionar'][column][val]
-                            elif '<default>' in light_transaction_metadata['output_categories_importance_dictionar'][column]:
-                                lightwood_weight_map[val] = lightwood_weight_map[val] * light_transaction_metadata['output_categories_importance_dictionar'][column]['<default>']
+                        if column in self.transaction.lmd['output_categories_importance_dictionar']:
+                            if val in self.transaction.lmd['output_categories_importance_dictionar'][column]:
+                                lightwood_weight_map[val] = lightwood_weight_map[val] * self.transaction.lmd['output_categories_importance_dictionar'][column][val]
+                            elif '<default>' in self.transaction.lmd['output_categories_importance_dictionar'][column]:
+                                lightwood_weight_map[val] = lightwood_weight_map[val] * self.transaction.lmd['output_categories_importance_dictionar'][column]['<default>']
 
                         self.transaction.lmd['weight_map'][column] = lightwood_weight_map
 

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -124,17 +124,19 @@ class DataTransformer(BaseModule):
                     occurance_map[self.transaction.lmd['column_stats'][column]['histogram']['x'][i]] = self.transaction.lmd['column_stats'][column]['histogram']['y'][i]
 
                 max_val_occurances = max(occurance_map.values())
+                min_val_occurances = min(occurance_map.values())
+                sum_val_occurances = sum(occurance_map.values())
 
                 if self.transaction.lmd['model_backend'] in ('lightwood'):
                     lightwood_weight_map = {}
                     for val in occurance_map:
-                        lightwood_weight_map[val] = occurance_map[val]/max_val_occurances
+                        lightwood_weight_map[val] = 1 - occurance_map[val]/sum_val_occurances
 
                         self.transaction.lmd['weight_map'][column] = lightwood_weight_map
 
 
                 column_is_weighted_in_train = column in self.transaction.lmd['weight_map']
-                
+
                 for val in occurance_map:
                     copied_rows_train = []
                     copied_rows_test = []

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -123,12 +123,17 @@ class DataTransformer(BaseModule):
                     ciclying_map[self.transaction.lmd['column_stats'][column]['histogram']['x'][i]] = 0
                     occurance_map[self.transaction.lmd['column_stats'][column]['histogram']['x'][i]] = self.transaction.lmd['column_stats'][column]['histogram']['y'][i]
 
-                print(len(input_data.train_df))
-                print(len(input_data.test_df))
-                print(len(input_data.validation_df))
-                print(len(input_data.data_frame))
-
                 max_val_occurances = max(occurance_map.values())
+
+                if self.transaction.lmd['model_backend'] in ('lightwood'):
+                    lightwood_weight_map = {}
+                    for val in occurance_map:
+                        lightwood_weight_map[val] = occurance_map[val]/max_val_occurances
+
+                        if 'lightwood_weight_map' not in self.transaction.lmd:
+                            self.transaction.lmd['lightwood_weight_map'] = {}
+
+                        self.transaction.lmd['lightwood_weight_map'][column] = lightwood_weight_map
 
                 for val in occurance_map:
                     copied_rows_train = []
@@ -193,8 +198,3 @@ class DataTransformer(BaseModule):
                     if len(copied_rows_validate) > 0:
                         input_data.data_frame = input_data.data_frame.append(copied_rows_validate)
                         input_data.train_df = input_data.validation_df.append(copied_rows_validate)
-
-                print(len(input_data.train_df))
-                print(len(input_data.test_df))
-                print(len(input_data.validation_df))
-                print(len(input_data.data_frame))

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -130,9 +130,6 @@ class DataTransformer(BaseModule):
                     for val in occurance_map:
                         lightwood_weight_map[val] = occurance_map[val]/max_val_occurances
 
-                        if 'weight_map' not in self.transaction.lmd:
-                            self.transaction.lmd['weight_map'] = {}
-
                         self.transaction.lmd['weight_map'][column] = lightwood_weight_map
                     continue
 

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -135,6 +135,10 @@ class DataTransformer(BaseModule):
 
                 column_is_weighted_in_train = column in self.transaction.lmd['weight_map']
 
+                print(len(input_data.data_frame))
+                print(len(input_data.train_df))
+                print(len(input_data.validation_df))
+
                 for val in occurance_map:
                     copied_rows_train = []
                     copied_rows_test = []
@@ -144,28 +148,39 @@ class DataTransformer(BaseModule):
                     valid_rows = input_data.data_frame[input_data.data_frame[colum] == val]
 
                     while occurance_map[val] < max_val_occurances:
-                        data_frame_length = data_frame_length + 1
-
                         try:
-                            copied_row = valid_rows.iloc[ciclying_map[val]]
                             index = list(valid_rows.index)[ciclying_map[val]]
-
+                            
                             if index in self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY] and not column_is_weighted_in_train:
+                                data_frame_length = data_frame_length + 1
+                                copied_row = valid_rows.iloc[ciclying_map[val]]
+
+                                self.transaction.input_data.all_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
                                 self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
+
                                 copied_rows_train.append(copied_row)
 
                             elif index in self.transaction.input_data.test_indexes[KEY_NO_GROUP_BY] and not column_is_weighted_in_train:
+                                data_frame_length = data_frame_length + 1
+                                copied_row = valid_rows.iloc[ciclying_map[val]]
+
+                                self.transaction.input_data.all_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
                                 self.transaction.input_data.test_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
+
                                 copied_rows_test.append(copied_row)
 
                             elif index in self.transaction.input_data.validation_indexes[KEY_NO_GROUP_BY]:
+                                data_frame_length = data_frame_length + 1
+                                copied_row = valid_rows.iloc[ciclying_map[val]]
+
+                                self.transaction.input_data.all_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
                                 self.transaction.input_data.validation_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
+
                                 copied_rows_validate.append(copied_row)
+
                             else:
                                 self.transaction.log.error('Somethig went wrong when balancing dataset !')
                                 sys.exit()
-
-                            self.transaction.input_data.all_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
 
                             occurance_map[val] += 1
                             ciclying_map[val] += 1
@@ -199,3 +214,9 @@ class DataTransformer(BaseModule):
                     if len(copied_rows_validate) > 0:
                         input_data.data_frame = input_data.data_frame.append(copied_rows_validate)
                         input_data.train_df = input_data.validation_df.append(copied_rows_validate)
+
+                print('============')
+                print(len(input_data.data_frame))
+                print(len(input_data.train_df))
+                print(len(input_data.validation_df))
+                print('%%%%%%%%%%%%%')

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -113,6 +113,7 @@ class DataTransformer(BaseModule):
                     self._aply_to_all_data(input_data, column, self._lightwood_datetime_processing)
                     self._aply_to_all_data(input_data, column, self._handle_nan)
 
+        for col in
         # Un-bias dataset for training
         for column in self.transaction.lmd['predict_columns']:
             if self.transaction.lmd['column_stats'][column]['data_type'] == DATA_TYPES.CATEGORICAL and self.transaction.lmd['equal_accuracy_for_all_output_categories'] == True and mode == 'train':
@@ -132,11 +133,11 @@ class DataTransformer(BaseModule):
                     for val in occurance_map:
                         lightwood_weight_map[val] = 1 - occurance_map[val]/sum_val_occurances
 
-                        if column in self.transaction.lmd['output_categories_importance_dictionar']:
-                            if val in self.transaction.lmd['output_categories_importance_dictionar'][column]:
-                                lightwood_weight_map[val] = lightwood_weight_map[val] * self.transaction.lmd['output_categories_importance_dictionar'][column][val]
-                            elif '<default>' in self.transaction.lmd['output_categories_importance_dictionar'][column]:
-                                lightwood_weight_map[val] = lightwood_weight_map[val] * self.transaction.lmd['output_categories_importance_dictionar'][column]['<default>']
+                        if column in self.transaction.lmd['output_categories_importance_dictionary']:
+                            if val in self.transaction.lmd['output_categories_importance_dictionary'][column]:
+                                lightwood_weight_map[val] = lightwood_weight_map[val] * self.transaction.lmd['output_categories_importance_dictionary'][column][val]
+                            elif '<default>' in self.transaction.lmd['output_categories_importance_dictionary'][column]:
+                                lightwood_weight_map[val] = lightwood_weight_map[val] * self.transaction.lmd['output_categories_importance_dictionary'][column]['<default>']
 
                         self.transaction.lmd['weight_map'][column] = lightwood_weight_map
 

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -148,42 +148,7 @@ class DataTransformer(BaseModule):
                     valid_rows = input_data.data_frame[input_data.data_frame[colum] == val]
 
                     while occurance_map[val] < max_val_occurances:
-                        try:
-                            index = list(valid_rows.index)[ciclying_map[val]]
-                            print(index)
-
-                            if index in self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY] and not column_is_weighted_in_train:
-                                data_frame_length = data_frame_length + 1
-                                copied_row = valid_rows.iloc[ciclying_map[val]]
-
-                                self.transaction.input_data.all_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
-                                self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
-
-                                copied_rows_train.append(copied_row)
-
-                            elif index in self.transaction.input_data.test_indexes[KEY_NO_GROUP_BY] and not column_is_weighted_in_train:
-                                data_frame_length = data_frame_length + 1
-                                copied_row = valid_rows.iloc[ciclying_map[val]]
-
-                                self.transaction.input_data.all_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
-                                self.transaction.input_data.test_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
-
-                                copied_rows_test.append(copied_row)
-
-                            elif index in self.transaction.input_data.validation_indexes[KEY_NO_GROUP_BY]:
-                                data_frame_length = data_frame_length + 1
-                                copied_row = valid_rows.iloc[ciclying_map[val]]
-
-                                self.transaction.input_data.all_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
-                                self.transaction.input_data.validation_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
-
-                                copied_rows_validate.append(copied_row)
-
-                            occurance_map[val] += 1
-                            ciclying_map[val] += 1
-                        except:
-                            # If there is no next row to copy, append all the previously coppied rows so that we start cycling throug them
-
+                        if ciclying_map[val] >= len(valid_rows.index):
                             input_data.data_frame = input_data.data_frame.append(copied_rows_train)
                             input_data.train_df = input_data.train_df.append(copied_rows_train)
 
@@ -198,7 +163,38 @@ class DataTransformer(BaseModule):
                             copied_rows_validate = []
 
                             ciclying_map[val] = 0
-                            valid_rows = input_data.data_frame[input_data.data_frame[colum] == val]
+
+                        index = list(valid_rows.index)[ciclying_map[val]]
+                        
+                        if index in self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY] and not column_is_weighted_in_train:
+                            data_frame_length = data_frame_length + 1
+                            copied_row = valid_rows.iloc[ciclying_map[val]]
+
+                            self.transaction.input_data.all_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
+                            self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
+
+                            copied_rows_train.append(copied_row)
+
+                        elif index in self.transaction.input_data.test_indexes[KEY_NO_GROUP_BY] and not column_is_weighted_in_train:
+                            data_frame_length = data_frame_length + 1
+                            copied_row = valid_rows.iloc[ciclying_map[val]]
+
+                            self.transaction.input_data.all_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
+                            self.transaction.input_data.test_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
+
+                            copied_rows_test.append(copied_row)
+
+                        elif index in self.transaction.input_data.validation_indexes[KEY_NO_GROUP_BY]:
+                            data_frame_length = data_frame_length + 1
+                            copied_row = valid_rows.iloc[ciclying_map[val]]
+
+                            self.transaction.input_data.all_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
+                            self.transaction.input_data.validation_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
+
+                            copied_rows_validate.append(copied_row)
+
+                        occurance_map[val] += 1
+                        ciclying_map[val] += 1
 
                     if len(copied_rows_train) > 0:
                         input_data.data_frame = input_data.data_frame.append(copied_rows_train)

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -130,10 +130,10 @@ class DataTransformer(BaseModule):
                     for val in occurance_map:
                         lightwood_weight_map[val] = occurance_map[val]/max_val_occurances
 
-                        if 'lightwood_weight_map' not in self.transaction.lmd:
-                            self.transaction.lmd['lightwood_weight_map'] = {}
+                        if 'weight_map' not in self.transaction.lmd:
+                            self.transaction.lmd['weight_map'] = {}
 
-                        self.transaction.lmd['lightwood_weight_map'][column] = lightwood_weight_map
+                        self.transaction.lmd['weight_map'][column] = lightwood_weight_map
                     continue
 
                 for val in occurance_map:

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -149,7 +149,7 @@ class DataTransformer(BaseModule):
                     copied_rows_validate = []
 
                     data_frame_length = len(input_data.data_frame)
-                    valid_rows = input_data.data_frame[input_data.data_frame[colum] == val]
+                    valid_rows = input_data.data_frame[input_data.data_frame[column] == val]
 
                     while occurance_map[val] < max_val_occurances:
                         if ciclying_map[val] >= len(valid_rows.index) - 1:

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -113,7 +113,9 @@ class DataTransformer(BaseModule):
                     self._aply_to_all_data(input_data, column, self._lightwood_datetime_processing)
                     self._aply_to_all_data(input_data, column, self._handle_nan)
 
-        for col in
+        # Initialize this here, will be overwritten if `equal_accuracy_for_all_output_categories` is specified to be True in order to account for it
+        self.transaction.lmd['weight_map'] = self.transaction.lmd['output_categories_importance_dictionary']
+
         # Un-bias dataset for training
         for column in self.transaction.lmd['predict_columns']:
             if self.transaction.lmd['column_stats'][column]['data_type'] == DATA_TYPES.CATEGORICAL and self.transaction.lmd['equal_accuracy_for_all_output_categories'] == True and mode == 'train':

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -131,7 +131,9 @@ class DataTransformer(BaseModule):
                         lightwood_weight_map[val] = occurance_map[val]/max_val_occurances
 
                         self.transaction.lmd['weight_map'][column] = lightwood_weight_map
-                    continue
+
+
+                column_is_weighted_in_train = column in self.transaction.lmd['weight_map']
 
                 for val in occurance_map:
                     copied_rows_train = []
@@ -148,11 +150,11 @@ class DataTransformer(BaseModule):
                             copied_row = valid_rows.iloc[ciclying_map[val]]
                             index = list(valid_rows.index)[ciclying_map[val]]
 
-                            if index in self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY]:
+                            if index in self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY] and not column_is_weighted_in_train:
                                 self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
                                 copied_rows_train.append(copied_row)
 
-                            elif index in self.transaction.input_data.test_indexes[KEY_NO_GROUP_BY]:
+                            elif index in self.transaction.input_data.test_indexes[KEY_NO_GROUP_BY] and not column_is_weighted_in_train:
                                 self.transaction.input_data.test_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
                                 copied_rows_test.append(copied_row)
 
@@ -183,6 +185,7 @@ class DataTransformer(BaseModule):
                             copied_rows_test = []
                             copied_rows_validate = []
 
+                            ciclying_map[val] = 0
                             valid_rows = input_data.data_frame[input_data.data_frame[colum] == val]
 
                     if len(copied_rows_train) > 0:

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -134,6 +134,7 @@ class DataTransformer(BaseModule):
                             self.transaction.lmd['lightwood_weight_map'] = {}
 
                         self.transaction.lmd['lightwood_weight_map'][column] = lightwood_weight_map
+                    continue
 
                 for val in occurance_map:
                     copied_rows_train = []

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -114,8 +114,8 @@ class DataTransformer(BaseModule):
                     self._aply_to_all_data(input_data, column, self._handle_nan)
 
         # Un-bias dataset for training
-        for colum in self.transaction.lmd['predict_columns']:
-            if self.transaction.lmd['column_stats'][column]['data_type'] == DATA_TYPES.CATEGORICAL and self.transaction.lmd['balance_target_category'] == True and mode == 'train':
+        for column in self.transaction.lmd['predict_columns']:
+            if self.transaction.lmd['column_stats'][column]['data_type'] == DATA_TYPES.CATEGORICAL and self.transaction.lmd['equal_accuracy_for_all_output_categories'] == True and mode == 'train':
                 occurance_map = {}
                 ciclying_map = {}
 
@@ -131,6 +131,12 @@ class DataTransformer(BaseModule):
                     lightwood_weight_map = {}
                     for val in occurance_map:
                         lightwood_weight_map[val] = 1 - occurance_map[val]/sum_val_occurances
+
+                        if column in light_transaction_metadata['output_categories_importance_dictionar']:
+                            if val in light_transaction_metadata['output_categories_importance_dictionar'][column]:
+                                lightwood_weight_map[val] = lightwood_weight_map[val] * light_transaction_metadata['output_categories_importance_dictionar'][column][val]
+                            elif '<default>' in light_transaction_metadata['output_categories_importance_dictionar'][column]:
+                                lightwood_weight_map[val] = lightwood_weight_map[val] * light_transaction_metadata['output_categories_importance_dictionar'][column]['<default>']
 
                         self.transaction.lmd['weight_map'][column] = lightwood_weight_map
 

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -150,7 +150,8 @@ class DataTransformer(BaseModule):
                     while occurance_map[val] < max_val_occurances:
                         try:
                             index = list(valid_rows.index)[ciclying_map[val]]
-                            
+                            print(index)
+
                             if index in self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY] and not column_is_weighted_in_train:
                                 data_frame_length = data_frame_length + 1
                                 copied_row = valid_rows.iloc[ciclying_map[val]]
@@ -177,10 +178,6 @@ class DataTransformer(BaseModule):
                                 self.transaction.input_data.validation_indexes[KEY_NO_GROUP_BY].append(data_frame_length)
 
                                 copied_rows_validate.append(copied_row)
-
-                            else:
-                                self.transaction.log.error('Somethig went wrong when balancing dataset !')
-                                sys.exit()
 
                             occurance_map[val] += 1
                             ciclying_map[val] += 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ ludwig ==  0.1.2
 xlrd >= 1.0.0
 ImageHash ==  4.0
 imageio ==  2.5.0
-lightwood >=  0.8.8
+lightwood >=  0.8.9


### PR DESCRIPTION
* Added final interface for target category balancing (making all target categories equally important in the accuracy evaluation regardless of the number of occurrences in the training dataset)
* Added final interface for assigning a custom weight to the target category
* Optimized target category balancing for lightwood, where we can use a weighted loss function for training instead of duplicating rows (row duplication is still done for the validation dataset)