### PR TITLE
fix getting started link throwing 404

### DIFF
--- a/docs/website/website/core/Footer.js
+++ b/docs/website/website/core/Footer.js
@@ -38,7 +38,7 @@ class Footer extends React.Component {
           </a>
           <div>
             <h5>Docs</h5>
-            <a href={this.docUrl('docs/installing-mindsdb', this.props.language)}>
+            <a href={this.docUrl('installing-mindsdb', this.props.language)}>
                Getting started
             </a>              
           </div>


### PR DESCRIPTION
Getting started link in footer is redirecting to an invalid url and git displays `404 page not found`. After this PR it is redirecting to the valid getting started page

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/37393666/64541213-f0060100-d33a-11e9-8656-de15b70da338.png">
