### PR TITLE
Large dataset fixes

### DIFF
--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.6.13'
+__version__ = '1.6.15'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.6.12'
+__version__ = '1.6.13'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -86,7 +86,7 @@ class LightwoodBackend():
         config['output_features'] = []
 
         for col_name in self.transaction.input_data.columns:
-            if col_name in self.transaction.lmd['malformed_columns']['names']:
+            if col_name in self.transaction.lmd['malformed_columns']:
                 continue
 
             col_stats = self.transaction.lmd['column_stats'][col_name]

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -110,7 +110,10 @@ class LightwoodBackend():
                 other_keys['encoder_attrs']['aim'] = 'balance'
 
             elif data_subtype in (DATA_SUBTYPES.TEXT):
-                lightwood_data_type = 'text'
+                if col_name in self.transaction.lmd['force_categorical_encoding']:
+                    lightwood_data_type = 'categorical'
+                else:
+                    lightwood_data_type = 'text'
 
             else:
                 self.transaction.log.error(f'The lightwood model backend is unable to handle data of type {data_type} and subtype {data_subtype} !')
@@ -153,6 +156,13 @@ class LightwoodBackend():
     def train(self):
         lightwood.config.config.CONFIG.USE_CUDA = self.transaction.lmd['use_gpu']
 
+        use_cache = True
+        # @TODO Some code to set the value of `use_cache` based on dataframe size
+        if self.transaction.lmd['force_disable_cache'] is True:
+            use_cache = False
+
+        lightwood.config.config.CONFIG.USE_CACHE = use_cache
+
         if self.transaction.lmd['model_order_by'] is not None and len(self.transaction.lmd['model_order_by']) > 0:
             self.transaction.log.debug('Reshaping data into timeseries format, this may take a while !')
             train_df = self._create_timeseries_df(self.transaction.input_data.train_df)
@@ -181,6 +191,11 @@ class LightwoodBackend():
 
     def predict(self, mode='predict', ignore_columns=[]):
         lightwood.config.config.CONFIG.USE_CUDA = self.transaction.lmd['use_gpu']
+
+        use_cache = True
+        # @TODO Some code to set the value of `use_cache` based on dataframe size
+        if self.transaction.lmd['force_disable_cache'] is True:
+            use_cache = False
 
         if mode == 'predict':
             # Doing it here since currently data cleanup is included in this, in the future separate data cleanup

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -142,7 +142,7 @@ class LudwigBackend():
             col_map[tf_col] = col
 
             # Handle malformed columns
-            if col in self.transaction.lmd['malformed_columns']['names']:
+            if col in self.transaction.lmd['malformed_columns']:
                 continue
 
             data[tf_col] = []

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -465,7 +465,7 @@ class Predictor:
         :param window_size: The number of samples to learn from in the time series
 
         Optional data transformation arguments:
-        :param ignore_columns: it simply removes the columns from the data sources
+        :param ignore_columns: mindsdb will ignore this column
 
         Optional sampling parameters:
         :param sample_margin_of_error (DEFAULT 0): Maximum expected difference between the true population parameter, such as the mean, and the sample estimate.
@@ -583,7 +583,7 @@ class Predictor:
             with open(os.path.join(CONFIG.MINDSDB_STORAGE_PATH, heavy_transaction_metadata['name'] + '_heavy_model_metadata.pickle'), 'rb') as fp:
                 heavy_transaction_metadata= pickle.load(fp)
 
-            for k in ['data_preparation', 'rebuild_model', 'data_source', 'type', 'ignore_columns', 'sample_margin_of_error', 'sample_confidence_level', 'stop_training_in_x_seconds', 'stop_training_in_accuracy']:
+            for k in ['data_preparation', 'rebuild_model', 'data_source', 'type', 'malformed_columns', 'sample_margin_of_error', 'sample_confidence_level', 'stop_training_in_x_seconds', 'stop_training_in_accuracy']:
                 if old_lmd[k] is not None: light_transaction_metadata[k] = old_lmd[k]
 
             for k in ['from_data', 'test_from_data']:

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -241,7 +241,7 @@ class Predictor:
         amd['model_analysis'] = []
 
         for col in lmd['model_columns_map'].keys():
-            if col in lmd['malformed_columns']['names']:
+            if col in lmd['malformed_columns']:
                 continue
 
             try:
@@ -322,7 +322,7 @@ class Predictor:
                         mao['accuracy_histogram']['x_explained'].append(x_explained_member)
 
                     for icol in lmd['model_columns_map'].keys():
-                        if icol in lmd['malformed_columns']['names']:
+                        if icol in lmd['malformed_columns']:
                             continue
                         if icol not in lmd['predict_columns']:
                             try:

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -517,7 +517,6 @@ class Predictor:
         light_transaction_metadata['model_is_time_series'] = is_time_series
         light_transaction_metadata['data_source'] = from_data
         light_transaction_metadata['type'] = transaction_type
-        light_transaction_metadata['ignore_columns'] = ignore_columns
         light_transaction_metadata['window_size'] = window_size
         light_transaction_metadata['sample_margin_of_error'] = sample_margin_of_error
         light_transaction_metadata['sample_confidence_level'] = sample_confidence_level
@@ -530,7 +529,7 @@ class Predictor:
         light_transaction_metadata['columnless_prediction_distribution'] = None
         light_transaction_metadata['all_columns_prediction_distribution'] = None
         light_transaction_metadata['use_gpu'] = use_gpu
-        light_transaction_metadata['malformed_columns'] = []
+        light_transaction_metadata['malformed_columns'] = ignore_columns
         light_transaction_metadata['disable_optional_analysis'] = disable_optional_analysis
         light_transaction_metadata['validation_set_accuracy'] = None
         light_transaction_metadata['lightwood_data'] = {}

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -443,7 +443,7 @@ class Predictor:
         light_transaction_metadata['model_is_time_series'] = False
         light_transaction_metadata['model_group_by'] = []
         light_transaction_metadata['model_order_by'] = []
-        light_transaction_metadata['malformed_columns'] = {'names': [], 'indices': []}
+        light_transaction_metadata['malformed_columns'] = []
         light_transaction_metadata['data_preparation'] = {}
 
         Transaction(session=self, light_transaction_metadata=light_transaction_metadata, heavy_transaction_metadata=heavy_transaction_metadata, logger=self.log)
@@ -530,7 +530,7 @@ class Predictor:
         light_transaction_metadata['columnless_prediction_distribution'] = None
         light_transaction_metadata['all_columns_prediction_distribution'] = None
         light_transaction_metadata['use_gpu'] = use_gpu
-        light_transaction_metadata['malformed_columns'] = {'names': [], 'indices': []}
+        light_transaction_metadata['malformed_columns'] = []
         light_transaction_metadata['disable_optional_analysis'] = disable_optional_analysis
         light_transaction_metadata['validation_set_accuracy'] = None
         light_transaction_metadata['lightwood_data'] = {}

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -560,6 +560,17 @@ class Predictor:
         else:
             light_transaction_metadata['optimize_model'] = False
 
+        if 'force_disable_cache' in unstable_parameters_dict:
+            light_transaction_metadata['force_disable_cache'] = unstable_parameters_dict['force_disable_cache']
+        else:
+            light_transaction_metadata['force_disable_cache'] = False
+
+        if 'force_categorical_encoding' in unstable_parameters_dict:
+            light_transaction_metadata['force_categorical_encoding'] = unstable_parameters_dict['force_categorical_encoding']
+        else:
+            light_transaction_metadata['force_categorical_encoding'] = []
+
+
         if rebuild_model is False:
             old_lmd = {}
             for k in light_transaction_metadata: old_lmd[k] = light_transaction_metadata[k]
@@ -619,6 +630,11 @@ class Predictor:
             light_transaction_metadata['always_use_model_prediction'] = unstable_parameters_dict['always_use_model_prediction']
         else:
             light_transaction_metadata['always_use_model_prediction'] = False
+
+        if 'force_disable_cache' in unstable_parameters_dict:
+            light_transaction_metadata['force_disable_cache'] = unstable_parameters_dict['force_disable_cache']
+        else:
+            light_transaction_metadata['force_disable_cache'] = False
 
         transaction = Transaction(session=self, light_transaction_metadata=light_transaction_metadata, heavy_transaction_metadata=heavy_transaction_metadata)
 

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -245,7 +245,7 @@ class Transaction:
 
                 # Compute the feature existance vector
                 input_columns = [col for col in self.input_data.columns if col not in self.lmd['predict_columns']]
-                features_existance_vector = [False if output_data[col][row_number] is None else True for col in input_columns if col not in self.lmd['malformed_columns']['names']]
+                features_existance_vector = [False if output_data[col][row_number] is None else True for col in input_columns if col not in self.lmd['malformed_columns']]
 
                 # Create the probabilsitic evaluation
                 prediction_evaluation = probabilistic_validator.evaluate_prediction_accuracy(features_existence=features_existance_vector, predicted_value=predicted_value, always_use_model_prediction=self.lmd['always_use_model_prediction'])

--- a/mindsdb/libs/helpers/probabilistic_validator.py
+++ b/mindsdb/libs/helpers/probabilistic_validator.py
@@ -61,7 +61,7 @@ class ProbabilisticValidator():
             predicted_value = predicted_value if self.data_type != DATA_TYPES.NUMERIC else float(predicted_value)
         except:
             predicted_value = None
-            
+
         try:
             real_value = real_value if self.data_type != DATA_TYPES.NUMERIC else float(str(real_value).replace(',','.'))
         except:
@@ -159,7 +159,7 @@ class ProbabilisticValidator():
 
     def evaluate_prediction_accuracy(self, features_existence, predicted_value, always_use_model_prediction):
         """
-        # Fit the probabilistic validator on an observation    def evaluate_prediction_accuracy(self, features_existence, predicted_value):
+        # Fit the probabilistic validator on an observation
         :param features_existence: A vector of 0 and 1 representing the existence of all the features (0 == not exists, 1 == exists)
         :param predicted_value: The predicted value/label
         :return: The probability (from 0 to 1) of our prediction being accurate (within the same histogram bucket as the real value)

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -84,7 +84,7 @@ class DataTransformer(BaseModule):
     def run(self, input_data, mode=None):
         for column in input_data.columns:
 
-            if column in self.transaction.lmd['malformed_columns']['names']:
+            if column in self.transaction.lmd['malformed_columns']:
                 continue
 
             data_type = self.transaction.lmd['column_stats'][column]['data_type']

--- a/mindsdb/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb/libs/phases/model_analyzer/model_analyzer.py
@@ -18,7 +18,6 @@ class ModelAnalyzer(BaseModule):
 
         output_columns = self.transaction.lmd['predict_columns']
         input_columns = [col for col in self.transaction.lmd['columns'] if col not in output_columns and col not in self.transaction.lmd['malformed_columns']]
-
         # Test some hypotheses about our columns
 
         if self.transaction.lmd['disable_optional_analysis'] is False:

--- a/mindsdb/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb/libs/phases/model_analyzer/model_analyzer.py
@@ -17,7 +17,7 @@ class ModelAnalyzer(BaseModule):
         """
 
         output_columns = self.transaction.lmd['predict_columns']
-        input_columns = [col for col in self.transaction.lmd['columns'] if col not in output_columns and col not in self.transaction.lmd['malformed_columns']['names']]
+        input_columns = [col for col in self.transaction.lmd['columns'] if col not in output_columns and col not in self.transaction.lmd['malformed_columns']]
 
         # Test some hypotheses about our columns
 

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -503,7 +503,7 @@ class StatsGenerator(BaseModule):
             if column_status == 'Column empty':
                 if modify_light_metadata:
                     self.transaction.lmd['malformed_columns'].append(col_name)
-                    
+
                 continue
 
             new_col_data = []
@@ -680,5 +680,4 @@ class StatsGenerator(BaseModule):
         '''
 
         self._log_interesting_stats(stats)
-
         return stats

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -503,6 +503,7 @@ class StatsGenerator(BaseModule):
             if column_status == 'Column empty':
                 if modify_light_metadata:
                     self.transaction.lmd['malformed_columns'].append(col_name)
+                    print(self.transaction.lmd['malformed_columns'])
                 continue
 
             new_col_data = []

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -494,6 +494,9 @@ class StatsGenerator(BaseModule):
         col_data_dict = {}
 
         for col_name in all_sampled_data.columns.values:
+            if col_name in self.transaction.lmd['malformed_columns']:
+                continue
+
             col_data = all_sampled_data[col_name].dropna()
             full_col_data = all_sampled_data[col_name]
 

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -503,7 +503,7 @@ class StatsGenerator(BaseModule):
             if column_status == 'Column empty':
                 if modify_light_metadata:
                     self.transaction.lmd['malformed_columns'].append(col_name)
-                    print(self.transaction.lmd['malformed_columns'])
+                    
                 continue
 
             new_col_data = []

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -502,8 +502,7 @@ class StatsGenerator(BaseModule):
 
             if column_status == 'Column empty':
                 if modify_light_metadata:
-                    self.transaction.lmd['malformed_columns']['names'].append(col_name)
-                    self.transaction.lmd['malformed_columns']['indices'].append(i)
+                    self.transaction.lmd['malformed_columns'].append(col_name)
                 continue
 
             new_col_data = []
@@ -629,7 +628,7 @@ class StatsGenerator(BaseModule):
             col_data_dict[col_name] = col_data
 
         for col_name in all_sampled_data.columns:
-            if col_name in self.transaction.lmd['malformed_columns']['names']:
+            if col_name in self.transaction.lmd['malformed_columns']:
                 continue
 
             # Use the multiprocessing pool for computing scores which take a very long time to compute
@@ -682,4 +681,3 @@ class StatsGenerator(BaseModule):
         self._log_interesting_stats(stats)
 
         return stats
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lightwood >= 0.9.12
+lightwood >= 0.10.0
 scikit-image ==  0.14.2
 cython >= 0.29.2
 setuptools >= 21.2.1


### PR DESCRIPTION
1. Added two parameters to the unstable parameters list:
    * `force_categorical_encoding` -- A list of columns which to forcefully treat as categorical, no matter what the stats generator determines to be the actual type
    * `force_disable_cache`  --  Forcefully disable the caching of values when using the lightwood backend, to deal with large datasets

2. The `ignore_columns` argument was currently not working, fixed it's functionality by temporarily pigybacking on the `malformed_columns` functionality. We might wish to separate this in the future, as to no extract these columns to being with.... buuuuut, this was a quicker fix, less prone to bug and it works.