### PR TITLE
Add an error check for \r\n and \n type of strings

### DIFF
--- a/mindsdb/libs/data_sources/file_ds.py
+++ b/mindsdb/libs/data_sources/file_ds.py
@@ -124,8 +124,10 @@ class FileDS(DataSource):
             first_few_lines = []
             i = 0
             for line in data:
-                i += 1
+                if line in ['\r\n','\n']:
+                    continue
                 first_few_lines.append(line)
+                i += 1
                 if i > 0:
                     break
 


### PR DESCRIPTION
problem :
the file_ds.py was not able to find the type of file
given to it due to first_few_lines giving \r\n
so it was not able to find what type of delimiter is used and throws an
error.

Solution :
to fix this an if statement is added to check if line is \r\n or
\n then it will continue else it will append that line in
first_few_lines.

closes #316 