### PR TITLE
Improve extractor

### DIFF
--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.6.18'
+__version__ = '1.7.0'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -115,6 +115,9 @@ class LightwoodBackend():
                 else:
                     lightwood_data_type = 'text'
 
+            elif data_subtype in (DATA_SUBTYPES.ARRAY):
+                lightwood_data_type = 'time_series'
+
             else:
                 self.transaction.log.error(f'The lightwood model backend is unable to handle data of type {data_type} and subtype {data_subtype} !')
                 raise Exception('Failed to build data definition for Lightwood model backend')

--- a/mindsdb/libs/constants/mindsdb.py
+++ b/mindsdb/libs/constants/mindsdb.py
@@ -9,8 +9,6 @@ TRANSACTION_DROP_MODEL ='drop_model'
 STOP_TRAINING = 'stop_training'
 KILL_TRAINING = 'kill_training'
 
-KEY_NO_GROUP_BY = 'ALL_ROWS_NO_GROUP_BY'
-
 
 class DATA_SUBTYPES:
     # Numeric

--- a/mindsdb/libs/constants/mindsdb.py
+++ b/mindsdb/libs/constants/mindsdb.py
@@ -9,9 +9,6 @@ TRANSACTION_DROP_MODEL ='drop_model'
 STOP_TRAINING = 'stop_training'
 KILL_TRAINING = 'kill_training'
 
-KEY_NO_GROUP_BY = 'ALL_ROWS_NO_GROUP_BY'
-
-
 class DATA_SUBTYPES:
     # Numeric
     INT = 'Int'

--- a/mindsdb/libs/constants/mindsdb.py
+++ b/mindsdb/libs/constants/mindsdb.py
@@ -9,6 +9,9 @@ TRANSACTION_DROP_MODEL ='drop_model'
 STOP_TRAINING = 'stop_training'
 KILL_TRAINING = 'kill_training'
 
+KEY_NO_GROUP_BY = 'ALL_ROWS_NO_GROUP_BY'
+
+
 class DATA_SUBTYPES:
     # Numeric
     INT = 'Int'

--- a/mindsdb/libs/data_types/transaction_data.py
+++ b/mindsdb/libs/data_types/transaction_data.py
@@ -7,9 +7,4 @@ class TransactionData():
         self.test_df = None
         self.validation_df = None
 
-        self.train_indexes = {}
-        self.test_indexes = {}
-        self.validation_indexes = {}
-        self.all_indexes = {}
-
         self.columns = []

--- a/mindsdb/libs/data_types/transaction_data.py
+++ b/mindsdb/libs/data_types/transaction_data.py
@@ -7,4 +7,9 @@ class TransactionData():
         self.test_df = None
         self.validation_df = None
 
+        self.train_indexes = {}
+        self.test_indexes = {}
+        self.validation_indexes = {}
+        self.all_indexes = {}
+
         self.columns = []

--- a/mindsdb/libs/data_types/transaction_data.py
+++ b/mindsdb/libs/data_types/transaction_data.py
@@ -6,10 +6,4 @@ class TransactionData():
         self.train_df = None
         self.test_df = None
         self.validation_df = None
-
-        self.train_indexes = {}
-        self.test_indexes = {}
-        self.validation_indexes = {}
-        self.all_indexes = {}
-
         self.columns = []

--- a/mindsdb/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb/libs/phases/data_extractor/data_extractor.py
@@ -59,7 +59,7 @@ class DataExtractor(BaseModule):
 
         elif self.transaction.lmd['type'] == TRANSACTION_LEARN:
             # if its not a time series, randomize the input data and we are learning
-            df = df.sample(frac=1)
+            df = df.sample(frac=1, random_state=len(df))
 
         return df
 
@@ -153,8 +153,6 @@ class DataExtractor(BaseModule):
         group_by = self.transaction.lmd['model_group_by']
 
         # create a list of the column numbers (indexes) that make the group by, this is so that we can greate group by hashes for each row
-        if len(group_by)>0:
-            group_by_col_indexes = [columns.index(group_by_column) for group_by_column in group_by]
 
         # create all indexes by group by, that is all the rows that belong to each group by
         self.transaction.input_data.all_indexes[KEY_NO_GROUP_BY] = []
@@ -164,7 +162,7 @@ class DataExtractor(BaseModule):
         for i, row in self.transaction.input_data.data_frame.iterrows():
 
             if len(group_by) > 0:
-                group_by_value = '_'.join([str(row[group_by_index]) for group_by_index in group_by_col_indexes])
+                group_by_value = '_'.join([str(row[group_by_index]) for group_by_index in [columns.index(group_by_column) for group_by_column in group_by]])
 
                 if group_by_value not in self.transaction.input_data.all_indexes:
                     self.transaction.input_data.all_indexes[group_by_value] = []
@@ -181,10 +179,6 @@ class DataExtractor(BaseModule):
 
             length = len(self.transaction.input_data.all_indexes[key])
             if self.transaction.lmd['type'] == TRANSACTION_LEARN:
-                sample_size = int(calculate_sample_size(population_size=length,
-                                                        margin_error=self.transaction.lmd['sample_margin_of_error'],
-                                                        confidence_level=self.transaction.lmd['sample_confidence_level']))
-
                 # this evals True if it should send the entire group data into test, train or validation as opposed to breaking the group into the subsets
                 should_split_by_group = type(group_by) == list and len(group_by) > 0
 

--- a/mindsdb/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb/libs/phases/data_extractor/data_extractor.py
@@ -154,6 +154,11 @@ class DataExtractor(BaseModule):
         KEY_NO_GROUP_BY = '{PLEASE_DONT_TELL_ME_ANYONE_WOULD_CALL_A_COLUMN_THIS}##ALL_ROWS_NO_GROUP_BY##{PLEASE_DONT_TELL_ME_ANYONE_WOULD_CALL_A_COLUMN_THIS}'
 
         # create all indexes by group by, that is all the rows that belong to each group by
+        all_indexes = {}
+        train_indexes = {}
+        test_indexes = {}
+        validation_indexes = {}
+
         all_indexes[KEY_NO_GROUP_BY] = []
         train_indexes[KEY_NO_GROUP_BY] = []
         test_indexes[KEY_NO_GROUP_BY] = []

--- a/mindsdb/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb/libs/phases/data_extractor/data_extractor.py
@@ -203,6 +203,11 @@ class DataExtractor(BaseModule):
         self.transaction.input_data.train_df = self.transaction.input_data.data_frame.iloc[self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY]].copy()
         self.transaction.input_data.test_df = self.transaction.input_data.data_frame.iloc[self.transaction.input_data.test_indexes[KEY_NO_GROUP_BY]].copy()
         self.transaction.input_data.validation_df = self.transaction.input_data.data_frame.iloc[self.transaction.input_data.validation_indexes[KEY_NO_GROUP_BY]].copy()
+
+        self.transaction.lmd['data_preparation']['test_row_count'] = len(self.transaction.input_data.test_df)
+        self.transaction.lmd['data_preparation']['train_row_count'] = len(self.transaction.input_data.train_df)
+        self.transaction.lmd['data_preparation']['validation_row_count'] = len(self.transaction.input_data.validation_df)
+
         # @TODO: Consider deleting self.transaction.input_data.data_frame here
 
         # log some stats

--- a/mindsdb/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb/libs/phases/data_extractor/data_extractor.py
@@ -151,8 +151,7 @@ class DataExtractor(BaseModule):
 
         is_time_series = self.transaction.lmd['model_is_time_series']
         group_by = self.transaction.lmd['model_group_by']
-
-        # create a list of the column numbers (indexes) that make the group by, this is so that we can greate group by hashes for each row
+        KEY_NO_GROUP_BY = '{PLEASE_DONT_TELL_ME_ANYONE_WOULD_CALL_A_COLUMN_THIS}##ALL_ROWS_NO_GROUP_BY##{PLEASE_DONT_TELL_ME_ANYONE_WOULD_CALL_A_COLUMN_THIS}'
 
         # create all indexes by group by, that is all the rows that belong to each group by
         self.transaction.input_data.all_indexes[KEY_NO_GROUP_BY] = []

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -176,31 +176,20 @@ class DataTransformer(BaseModule):
 
                         index = list(valid_rows.index)[ciclying_map[val]]
 
-                        if index in self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY] and not column_is_weighted_in_train:
+                        if index in self.train_df.index and not column_is_weighted_in_train:
                             data_frame_length = data_frame_length + 1
                             copied_row = valid_rows.iloc[ciclying_map[val]]
-
-                            self.transaction.input_data.all_indexes[KEY_NO_GROUP_BY].append(data_frame_length - 1)
-                            self.transaction.input_data.train_indexes[KEY_NO_GROUP_BY].append(data_frame_length - 1)
-
                             copied_rows_train.append(copied_row)
 
-                        elif index in self.transaction.input_data.test_indexes[KEY_NO_GROUP_BY] and not column_is_weighted_in_train:
+                        elif index in self.test_df.index and not column_is_weighted_in_train:
                             data_frame_length = data_frame_length + 1
                             copied_row = valid_rows.iloc[ciclying_map[val]]
-
-                            self.transaction.input_data.all_indexes[KEY_NO_GROUP_BY].append(data_frame_length - 1)
-                            self.transaction.input_data.test_indexes[KEY_NO_GROUP_BY].append(data_frame_length - 1)
 
                             copied_rows_test.append(copied_row)
 
-                        elif index in self.transaction.input_data.validation_indexes[KEY_NO_GROUP_BY]:
+                        elif index in sself.validation_df.index:
                             data_frame_length = data_frame_length + 1
                             copied_row = valid_rows.iloc[ciclying_map[val]]
-
-                            self.transaction.input_data.all_indexes[KEY_NO_GROUP_BY].append(data_frame_length - 1)
-                            self.transaction.input_data.validation_indexes[KEY_NO_GROUP_BY].append(data_frame_length - 1)
-
                             copied_rows_validate.append(copied_row)
 
                         occurance_map[val] += 1

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -176,18 +176,18 @@ class DataTransformer(BaseModule):
 
                         index = list(valid_rows.index)[ciclying_map[val]]
 
-                        if index in self.train_df.index and not column_is_weighted_in_train:
+                        if index in input_data.train_df.index and not column_is_weighted_in_train:
                             data_frame_length = data_frame_length + 1
                             copied_row = valid_rows.iloc[ciclying_map[val]]
                             copied_rows_train.append(copied_row)
 
-                        elif index in self.test_df.index and not column_is_weighted_in_train:
+                        elif index in input_data.test_df.index and not column_is_weighted_in_train:
                             data_frame_length = data_frame_length + 1
                             copied_row = valid_rows.iloc[ciclying_map[val]]
 
                             copied_rows_test.append(copied_row)
 
-                        elif index in sself.validation_df.index:
+                        elif index in input_data.validation_df.index:
                             data_frame_length = data_frame_length + 1
                             copied_row = valid_rows.iloc[ciclying_map[val]]
                             copied_rows_validate.append(copied_row)

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -673,9 +673,9 @@ class StatsGenerator(BaseModule):
 
             self.transaction.lmd['data_preparation']['total_row_count'] = total_rows
             self.transaction.lmd['data_preparation']['used_row_count'] = sample_size
-            self.transaction.lmd['data_preparation']['test_row_count'] = len(input_data.test_indexes[KEY_NO_GROUP_BY])
-            self.transaction.lmd['data_preparation']['train_row_count'] = len(input_data.train_indexes[KEY_NO_GROUP_BY])
-            self.transaction.lmd['data_preparation']['validation_row_count'] = len(input_data.validation_indexes[KEY_NO_GROUP_BY])
+            self.transaction.lmd['data_preparation']['test_row_count'] = len(input_data.test_df)
+            self.transaction.lmd['data_preparation']['train_row_count'] = len(input_data.train_df)
+            self.transaction.lmd['data_preparation']['validation_row_count'] = len(input_data.validation_df)
 
         ''' @TODO Uncomment when we need multiprocessing, possibly disable on OSX
         pool.close()

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -673,9 +673,6 @@ class StatsGenerator(BaseModule):
 
             self.transaction.lmd['data_preparation']['total_row_count'] = total_rows
             self.transaction.lmd['data_preparation']['used_row_count'] = sample_size
-            self.transaction.lmd['data_preparation']['test_row_count'] = len(input_data.test_df)
-            self.transaction.lmd['data_preparation']['train_row_count'] = len(input_data.train_df)
-            self.transaction.lmd['data_preparation']['validation_row_count'] = len(input_data.validation_df)
 
         ''' @TODO Uncomment when we need multiprocessing, possibly disable on OSX
         pool.close()

--- a/test.py
+++ b/test.py
@@ -2,9 +2,9 @@ from mindsdb import Predictor
 import sys
 import pandas as pd
 
-mdb = Predictor(name='sensor123')
+mdb = Predictor(name='simple_test_predictor')
 
-mdb.learn(to_predict='rental_price',from_data="https://mindsdb-example-data.s3.eu-west-2.amazonaws.com/home_rentals.csv",use_gpu=True,stop_training_in_x_seconds=15)
+mdb.learn(to_predict='rental_price',from_data="https://mindsdb-example-data.s3.eu-west-2.amazonaws.com/home_rentals.csv",use_gpu=True,stop_training_in_x_seconds=30, backend='ludwig')
 p_arr = mdb.predict(when_data='https://mindsdb-example-data.s3.eu-west-2.amazonaws.com/home_rentals.csv')
 
 
@@ -14,4 +14,4 @@ for p in p_arr:
     #print(exp)
     print(exp_s)
 
-print(mdb.get_model_data('sensor123'))
+print(mdb.get_model_data('simple_test_predictor'))

--- a/tests/accuracy_benchmarking/compare.py
+++ b/tests/accuracy_benchmarking/compare.py
@@ -33,7 +33,7 @@ def compare():
 
         logger.info(f'\nRunning checks for test {test_name} in batch {batch_id}, the test took {runtime} seconds and had an accuracy of {accuracy} using {accuracy_function} and training on backend {backend}\nSystem info when ran: (mindsdb_version: {mindsdb_version}, lightwood_version: {lightwood_version}, ludwig_version: {ludwig_version})\n')
 
-        cur.execute('SELECT accuracy, batch_id, batch_started, runtime, mindsdb_version, lightwood_version, ludwig_version, backend FROM mindsdb_accuracy.tests WHERE test_name=%s AND accuracy_function=%s AND accuracy > %s', [test_name,accuracy_function,accuracy])
+        cur.execute('SELECT accuracy, batch_id, batch_started, runtime, mindsdb_version, lightwood_version, ludwig_version, backend FROM mindsdb_accuracy.tests WHERE test_name=%s AND accuracy_function=%s AND (accuracy - 0.0000001) > %s', [test_name,accuracy_function,accuracy])
         better_tests = cur.fetchall()
 
         for row in better_tests:
@@ -42,19 +42,22 @@ def compare():
             old_batch_started = row[2]
             old_runtime = row[3]
 
-            old_mindsdb_version = entity[4]
-            old_lightwood_version = entity[5]
-            old_ludwig_version = entity[6]
-            old_backend = entity[7]
+            old_mindsdb_version = row[4]
+            old_lightwood_version = row[5]
+            old_ludwig_version = row[6]
+            old_backend = row[7]
 
 
             # There's going to be some variation within accuracy, so we only really need to worry if the grap is bigger than 1%
-            if (old_accuracy - accuracy)/accuracy > 0.01:
+            if old_accuracy > accuracy*0.05:
                 worseness_prefix = 'significantly'
                 func = logger.error
-            else:
+            elif old_accuracy > accuracy*0.01:
                 worseness_prefix = ''
                 func = logger.warning
+            else:
+                worseness_prefix = 'possibly'
+                func = logger.debug
 
             func(f'There was a previous test for {test_name} which yielded {worseness_prefix} better results than the current one. The results were:  \n * Accuracy: {old_accuracy} \n * Batch id: {old_batch_id} \n * Batch started: {old_batch_started} \n * Runtime: {old_runtime} \n * Backend: {old_backend} \n * System info when ran: (mindsdb_version: {old_mindsdb_version}, lightwood_version: {old_lightwood_version}, ludwig_version: {old_ludwig_version})\n')
 


### PR DESCRIPTION
## Main things

* Data shuffling during extraction now uses a seed (total length of the data) to obtain more consistency between mindsdb training runs

* Got rid of the indexes external to the data frame from everywhere *but* the data extractor where I still keep them because I want to re-work that more thoroughly and it's tied in with re-factoring how time-series work and for now I don't want to break it... for now it works, and the external-index based logic is de-coupled from where where else:
  1. Got rid of external index usage in ludwig backend
  2. Got rid of external index usage in data transformer
  3. Got rid of external indexes in the `TransactionData` object

* Decoupled Stats generator from needing a train/test/validation split, now it just relies on whatever dataframe gets past to it. This will allow us to run it before most of the logic in the Extractor (but, it would require some minimalist splitting of the extractor), thus the extractor could take into account the target variable's value distribution when creating the testing/validation/training set.

### Also
* Fix to accuracy testing
* Removed some dead code