### PR TITLE
Amd tests

### DIFF
--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.7.11'
+__version__ = '1.7.12'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/tests/ci_tests/tests.py
+++ b/tests/ci_tests/tests.py
@@ -10,8 +10,9 @@ def basic_test(backend='ludwig',use_gpu=True,ignore_columns=[], run_extra=False,
             os.system(f'python3 ../functional_testing/{py_file}')
 
     # Create & Learn
+    to_predict = 'rental_price'
     mdb = mindsdb.Predictor(name='home_rentals_price')
-    mdb.learn(to_predict='rental_price',from_data="https://s3.eu-west-2.amazonaws.com/mindsdb-example-data/home_rentals.csv",backend=backend, stop_training_in_x_seconds=20,use_gpu=use_gpu)
+    #mdb.learn(to_predict=to_predict,from_data="https://s3.eu-west-2.amazonaws.com/mindsdb-example-data/home_rentals.csv",backend=backend, stop_training_in_x_seconds=20,use_gpu=use_gpu)
 
     # Reload & Predict
     model_name = 'home_rentals_price'
@@ -51,8 +52,10 @@ def basic_test(backend='ludwig',use_gpu=True,ignore_columns=[], run_extra=False,
     # Make some simple assertions about it
 
     # @TODO: Sometimes are None, not sure why: [, validation_set_accuracy, accuracy]
-    for k in ['status', 'name', 'version', 'is_active', 'data_source', 'predict', 'current_phase', 'updated_at', 'created_at', 'train_end_at']:
+    for k in ['status', 'name', 'version', 'data_source', 'current_phase', 'updated_at', 'created_at', 'train_end_at']:
         assert(type(amd[k]) == str)
+    assert(type(amd['predict']) == list or type(amd['predict']) == str)
+    assert(type(amd['is_active']) == bool)
 
     for k in amd['data_preparation']:
         assert(type(amd['data_preparation'][k]) == int or type(amd['data_preparation'][k]) == float)
@@ -67,4 +70,9 @@ def basic_test(backend='ludwig',use_gpu=True,ignore_columns=[], run_extra=False,
     assert(len(amd['model_analysis']) > 0)
     assert(type(amd['model_analysis'][0]) == dict)
 
-    
+    for k in amd['force_vectors'][to_predict]['normal_data_distribution']:
+        assert(len(amd['force_vectors'][to_predict]['normal_data_distribution'][k]) > 0)
+
+    for k in amd['force_vectors'][to_predict]['missing_data_distribution']:
+        for sk in amd['force_vectors'][to_predict]['missing_data_distribution'][k]:
+            assert(len(amd['force_vectors'][to_predict]['missing_data_distribution'][k][sk]) > 0)

--- a/tests/ci_tests/tests.py
+++ b/tests/ci_tests/tests.py
@@ -57,11 +57,12 @@ def basic_test(backend='ludwig',use_gpu=True,ignore_columns=[], run_extra=False,
     assert(type(amd['predict']) == list or type(amd['predict']) == str)
     assert(type(amd['is_active']) == bool)
 
+    for k in ['validation_set_accuracy', 'accuracy']:
+        assert(type(amd[k]) == float)
+
     for k in amd['data_preparation']:
         assert(type(amd['data_preparation'][k]) == int or type(amd['data_preparation'][k]) == float)
 
-    assert(type(amd['validation_set_accuracy']) == float)
-    assert(type(amd['accuracy']) == float)
 
     for k in amd['data_analysis']:
         assert(len(amd['data_analysis'][k]) > 0)

--- a/tests/ci_tests/tests.py
+++ b/tests/ci_tests/tests.py
@@ -49,4 +49,22 @@ def basic_test(backend='ludwig',use_gpu=True,ignore_columns=[], run_extra=False,
     # See if we can get the adapted metadata
     amd = mdb.get_model_data(model_name)
     # Make some simple assertions about it
-    assert(5 < len(list(amd.keys())))
+
+    # @TODO: Sometimes are None, not sure why: [, validation_set_accuracy, accuracy]
+    for k in ['status', 'name', 'version', 'is_active', 'data_source', 'predict', 'current_phase', 'updated_at', 'created_at', 'train_end_at']:
+        assert(type(amd[k]) == str)
+
+    for k in amd['data_preparation']:
+        assert(type(amd['data_preparation'][k]) == int or type(amd['data_preparation'][k]) == float)
+
+    assert(type(amd['validation_set_accuracy']) == float)
+    assert(type(amd['accuracy']) == float)
+
+    for k in amd['data_analysis']:
+        assert(len(amd['data_analysis'][k]) > 0)
+        assert(type(amd['data_analysis'][k][0]) == dict)
+
+    assert(len(amd['model_analysis']) > 0)
+    assert(type(amd['model_analysis'][0]) == dict)
+
+    

--- a/tests/ci_tests/tests.py
+++ b/tests/ci_tests/tests.py
@@ -12,7 +12,7 @@ def basic_test(backend='ludwig',use_gpu=True,ignore_columns=[], run_extra=False,
     # Create & Learn
     to_predict = 'rental_price'
     mdb = mindsdb.Predictor(name='home_rentals_price')
-    #mdb.learn(to_predict=to_predict,from_data="https://s3.eu-west-2.amazonaws.com/mindsdb-example-data/home_rentals.csv",backend=backend, stop_training_in_x_seconds=20,use_gpu=use_gpu)
+    mdb.learn(to_predict=to_predict,from_data="https://s3.eu-west-2.amazonaws.com/mindsdb-example-data/home_rentals.csv",backend=backend, stop_training_in_x_seconds=20,use_gpu=use_gpu)
 
     # Reload & Predict
     model_name = 'home_rentals_price'


### PR DESCRIPTION
Added some type & length validation for the adapted metadata being returned by the model to avoid previous bugs where huge chunks of it stopped being generated due to a small change.

In the future consider validating against a more in-depth schema and/or validating against an actual object, for now this sanity check should solve most types of bugs encountered here. 

Close #324 