### PR TITLE
Foreign key

### DIFF
--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.7.17'
+__version__ = '1.7.18'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -86,7 +86,7 @@ class LightwoodBackend():
         config['output_features'] = []
 
         for col_name in self.transaction.input_data.columns:
-            if col_name in self.transaction.lmd['malformed_columns']:
+            if col_name in self.transaction.lmd['columns_to_ignore']:
                 continue
 
             col_stats = self.transaction.lmd['column_stats'][col_name]

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -136,7 +136,7 @@ class LudwigBackend():
             col_map[tf_col] = col
 
             # Handle malformed columns
-            if col in self.transaction.lmd['malformed_columns']:
+            if col in self.transaction.lmd['columns_to_ignore']:
                 continue
 
             data[tf_col] = []

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -246,7 +246,7 @@ class Predictor:
         amd['model_analysis'] = []
 
         for col in lmd['model_columns_map'].keys():
-            if col in lmd['malformed_columns']:
+            if col in lmd['columns_to_ignore']:
                 continue
 
             try:
@@ -328,7 +328,7 @@ class Predictor:
                         mao['accuracy_histogram']['x_explained'].append(x_explained_member)
 
                     for icol in lmd['model_columns_map'].keys():
-                        if icol in lmd['malformed_columns']:
+                        if icol in lmd['columns_to_ignore']:
                             continue
                         if icol not in lmd['predict_columns']:
                             try:
@@ -512,7 +512,7 @@ class Predictor:
         light_transaction_metadata['model_is_time_series'] = False
         light_transaction_metadata['model_group_by'] = []
         light_transaction_metadata['model_order_by'] = []
-        light_transaction_metadata['malformed_columns'] = []
+        light_transaction_metadata['columns_to_ignore'] = []
         light_transaction_metadata['data_preparation'] = {}
         light_transaction_metadata['predict_columns'] = []
 
@@ -607,7 +607,7 @@ class Predictor:
         light_transaction_metadata['columnless_prediction_distribution'] = None
         light_transaction_metadata['all_columns_prediction_distribution'] = None
         light_transaction_metadata['use_gpu'] = use_gpu
-        light_transaction_metadata['malformed_columns'] = ignore_columns
+        light_transaction_metadata['columns_to_ignore'] = ignore_columns
         light_transaction_metadata['disable_optional_analysis'] = disable_optional_analysis
         light_transaction_metadata['validation_set_accuracy'] = None
         light_transaction_metadata['lightwood_data'] = {}
@@ -661,7 +661,7 @@ class Predictor:
             with open(os.path.join(CONFIG.MINDSDB_STORAGE_PATH, heavy_transaction_metadata['name'] + '_heavy_model_metadata.pickle'), 'rb') as fp:
                 heavy_transaction_metadata= pickle.load(fp)
 
-            for k in ['data_preparation', 'rebuild_model', 'data_source', 'type', 'malformed_columns', 'sample_margin_of_error', 'sample_confidence_level', 'stop_training_in_x_seconds', 'stop_training_in_accuracy']:
+            for k in ['data_preparation', 'rebuild_model', 'data_source', 'type', 'columns_to_ignore', 'sample_margin_of_error', 'sample_confidence_level', 'stop_training_in_x_seconds', 'stop_training_in_accuracy']:
                 if old_lmd[k] is not None: light_transaction_metadata[k] = old_lmd[k]
 
             for k in ['from_data', 'test_from_data']:

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -647,6 +647,12 @@ class Predictor:
         else:
             light_transaction_metadata['force_categorical_encoding'] = []
 
+        if 'handle_foreign_keys' in unstable_parameters_dict:
+            light_transaction_metadata['handle_foreign_keys'] = unstable_parameters_dict['handle_foreign_keys']
+        else:
+            light_transaction_metadata['handle_foreign_keys'] = False
+
+
 
         if rebuild_model is False:
             old_lmd = {}

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -652,6 +652,11 @@ class Predictor:
         else:
             light_transaction_metadata['handle_foreign_keys'] = False
 
+        if 'handle_text_as_categorical' in unstable_parameters_dict:
+            light_transaction_metadata['handle_text_as_categorical'] = unstable_parameters_dict['handle_text_as_categorical']
+        else:
+            light_transaction_metadata['handle_text_as_categorical'] = False
+
 
 
         if rebuild_model is False:

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -271,7 +271,7 @@ class Transaction:
 
                     # Compute the feature existance vector
                     input_columns = [col for col in self.input_data.columns if col not in self.lmd['predict_columns']]
-                    features_existance_vector = [False if output_data[col][row_number] is None else True for col in input_columns if col not in self.lmd['malformed_columns']]
+                    features_existance_vector = [False if output_data[col][row_number] is None else True for col in input_columns if col not in self.lmd['columns_to_ignore']]
 
                     # Create the probabilsitic evaluation
                     prediction_evaluation = probabilistic_validator.evaluate_prediction_accuracy(features_existence=features_existance_vector, predicted_value=predicted_value, always_use_model_prediction=self.lmd['always_use_model_prediction'])

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -89,9 +89,9 @@ class DataTransformer(BaseModule):
     def run(self, input_data):
         for column in input_data.columns:
 
-            if column in self.transaction.lmd['malformed_columns']:
+            if column in self.transaction.lmd['columns_to_ignore']:
                 continue
-
+            
             data_type = self.transaction.lmd['column_stats'][column]['data_type']
             data_subtype = self.transaction.lmd['column_stats'][column]['data_subtype']
 

--- a/mindsdb/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb/libs/phases/model_analyzer/model_analyzer.py
@@ -14,7 +14,7 @@ class ModelAnalyzer(BaseModule):
         """
 
         output_columns = self.transaction.lmd['predict_columns']
-        input_columns = [col for col in self.transaction.lmd['columns'] if col not in output_columns and col not in self.transaction.lmd['malformed_columns']]
+        input_columns = [col for col in self.transaction.lmd['columns'] if col not in output_columns and col not in self.transaction.lmd['columns_to_ignore']]
         # Test some hypotheses about our columns
 
         if self.transaction.lmd['disable_optional_analysis'] is False:

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -236,7 +236,7 @@ class StatsGenerator(BaseModule):
             nr_vals = len(all_values)
             nr_distinct_vals = len(all_distinct_vals)
 
-            if nr_vals/20 > nr_distinct_vals and (curr_data_type not in [DATA_TYPES.NUMERIC, DATA_TYPES.DATE] or nr_distinct_vals < 20):
+            if ( nr_vals/20 > nr_distinct_vals and (curr_data_type not in [DATA_TYPES.NUMERIC, DATA_TYPES.DATE] or nr_distinct_vals < 20) ) or (curr_data_subtype == DATA_SUBTYPES.TEXT and self.transaction.lmd['handle_text_as_categorical']):
                 additional_info['other_potential_subtypes'].append(curr_data_type)
                 additional_info['other_potential_types'].append(curr_data_subtype)
                 curr_data_type = DATA_TYPES.CATEGORICAL

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -236,7 +236,7 @@ class StatsGenerator(BaseModule):
             nr_vals = len(all_values)
             nr_distinct_vals = len(all_distinct_vals)
 
-            if nr_vals/20 > nr_distinct_vals and (curr_data_type not in [DATA_TYPES.NUMERIC, DATA_TYPES.DATE] or nr_distinct_vals < 20) and nr_distinct_vals < 2000:
+            if nr_vals/20 > nr_distinct_vals and (curr_data_type not in [DATA_TYPES.NUMERIC, DATA_TYPES.DATE] or nr_distinct_vals < 20):
                 additional_info['other_potential_subtypes'].append(curr_data_type)
                 additional_info['other_potential_types'].append(curr_data_subtype)
                 curr_data_type = DATA_TYPES.CATEGORICAL


### PR DESCRIPTION
Added a way for the stats generator to detect "foreign keys" (e.g. account ids, location ids, usernames... etc). This is not perfect but testing on a few datasets gave in promising results.

There an option in the unstable parameter dictionary `handle_foreign_keys` and then set to `True` mindsdb will act upon these, for now it only does so by removing them from training.

Dropped the cap on the dimension of categorical columns, since now the autoencoder in lightwood should deal with that and ludwig didn't have much of a problem with it, as far as I can remember.