### PR TITLE
Import model fix

### DIFF
--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.9.3'
+__version__ = '1.9.5'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -398,25 +398,29 @@ class Predictor:
         :param mindsdb_storage_dir: full_path that contains your mindsdb predictor zip file
         :return: bool (True/False) True if mind was importerd successfully
         """
-        previous_models = os.listidr(CONFIG.MINDSDB_STORAGE_PATH)
+        previous_models = os.listdir(CONFIG.MINDSDB_STORAGE_PATH)
         shutil.unpack_archive(model_archive_path, extract_dir=CONFIG.MINDSDB_STORAGE_PATH)
-        
-        new_model_files = set(os.listidr(CONFIG.MINDSDB_STORAGE_PATH)) - set(previous_models)
+
+        new_model_files = set(os.listdir(CONFIG.MINDSDB_STORAGE_PATH)) - set(previous_models)
+        model_names = []
         for file in new_model_files:
             if '_light_model_metadata.pickle' in file:
                 model_name = file.replace('_light_model_metadata.pickle', '')
+                model_names.append(model_name)
 
-        with open(os.path.join(CONFIG.MINDSDB_STORAGE_PATH, model_name + '_light_model_metadata.pickle'), 'rb') as fp:
-            lmd = pickle.load(fp)
 
-        if 'ludwig_data' in lmd and 'ludwig_save_path' in lmd['ludwig_save_path']:
-            lmd['ludwig_data']['ludwig_save_path'] = str(os.path.join(CONFIG.MINDSDB_STORAGE_PATH),os.path.basename(lmd['ludwig_data']['ludwig_save_path']))
+        for moel_name in model_names:
+            with open(os.path.join(CONFIG.MINDSDB_STORAGE_PATH, model_name + '_light_model_metadata.pickle'), 'rb') as fp:
+                lmd = pickle.load(fp)
 
-        if 'lightwood_data' in lmd and 'save_path' in lmd['lightwood_data']:
-            lmd['lightwood_data']['save_path'] = str(os.path.join(CONFIG.MINDSDB_STORAGE_PATH),os.path.basename(lmdlmd['lightwood_data']['save_path']))
+            if 'ludwig_data' in lmd and 'ludwig_save_path' in lmd['ludwig_data']:
+                lmd['ludwig_data']['ludwig_save_path'] = str(os.path.join(CONFIG.MINDSDB_STORAGE_PATH),os.path.basename(lmd['ludwig_data']['ludwig_save_path']))
 
-        with open(os.path.join(CONFIG.MINDSDB_STORAGE_PATH, model_name + '_light_model_metadata.pickle'), 'wb') as fp:
-            pickle.dump(lmd, fp,protocol=pickle.HIGHEST_PROTOCOL)
+            if 'lightwood_data' in lmd and 'save_path' in lmd['lightwood_data']:
+                lmd['lightwood_data']['save_path'] = str(os.path.join(CONFIG.MINDSDB_STORAGE_PATH),os.path.basename(lmdlmd['lightwood_data']['save_path']))
+
+            with open(os.path.join(CONFIG.MINDSDB_STORAGE_PATH, model_name + '_light_model_metadata.pickle'), 'wb') as fp:
+                pickle.dump(lmd, fp,protocol=pickle.HIGHEST_PROTOCOL)
 
 
     def load_model(self, model_archive_path=None):

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -391,14 +391,32 @@ class Predictor:
             print(e)
             return False
 
-    def load(self, mindsdb_storage_dir):
+    def load(self, model_archive_path):
         """
         If you want to import a mindsdb instance storage from a file
 
         :param mindsdb_storage_dir: full_path that contains your mindsdb predictor zip file
         :return: bool (True/False) True if mind was importerd successfully
         """
-        shutil.unpack_archive(mindsdb_storage_dir, extract_dir=CONFIG.MINDSDB_STORAGE_PATH)
+        previous_models = os.listidr(CONFIG.MINDSDB_STORAGE_PATH)
+        shutil.unpack_archive(model_archive_path, extract_dir=CONFIG.MINDSDB_STORAGE_PATH)
+        
+        new_model_files = set(os.listidr(CONFIG.MINDSDB_STORAGE_PATH)) - set(previous_models)
+        for file in new_model_files:
+            if '_light_model_metadata.pickle' in file:
+                model_name = file.replace('_light_model_metadata.pickle', '')
+
+        with open(os.path.join(CONFIG.MINDSDB_STORAGE_PATH, model_name + '_light_model_metadata.pickle'), 'rb') as fp:
+            lmd = pickle.load(fp)
+
+        if 'ludwig_data' in lmd and 'ludwig_save_path' in lmd['ludwig_save_path']:
+            lmd['ludwig_data']['ludwig_save_path'] = str(os.path.join(CONFIG.MINDSDB_STORAGE_PATH),os.path.basename(lmd['ludwig_data']['ludwig_save_path']))
+
+        if 'lightwood_data' in lmd and 'save_path' in lmd['lightwood_data']:
+            lmd['lightwood_data']['save_path'] = str(os.path.join(CONFIG.MINDSDB_STORAGE_PATH),os.path.basename(lmdlmd['lightwood_data']['save_path']))
+
+        with open(os.path.join(CONFIG.MINDSDB_STORAGE_PATH, model_name + '_light_model_metadata.pickle'), 'wb') as fp:
+            pickle.dump(lmd, fp,protocol=pickle.HIGHEST_PROTOCOL)
 
 
     def load_model(self, model_archive_path=None):

--- a/tests/ci_tests/tests.py
+++ b/tests/ci_tests/tests.py
@@ -62,7 +62,7 @@ def basic_test(backend='lightwood',use_gpu=True,ignore_columns=[], run_extra=Fal
     # Create & Learn
     to_predict = 'rental_price'
     mdb = mindsdb.Predictor(name='home_rentals_price')
-    mdb.learn(to_predict=to_predict,from_data="https://s3.eu-west-2.amazonaws.com/mindsdb-example-data/home_rentals.csv",backend=backend, stop_training_in_x_seconds=20,use_gpu=use_gpu)
+    mdb.learn(to_predict=to_predict,from_data="https://s3.eu-west-2.amazonaws.com/mindsdb-example-data/home_rentals.csv",backend=backend, stop_training_in_x_seconds=10,use_gpu=use_gpu)
 
     # Reload & Predict
     model_name = 'home_rentals_price'


### PR DESCRIPTION
Model importing now works, in that it correctly modifies the lightwood and ludwig model pathing, it also supports importing multiple models from the same zip file, which is appropriate since we support exporting all the models at once in a single zip file.

This resolves #364 