### PR TITLE
Travis Build not failing for script failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
 before_script: cd tests/ci_tests
 # run tests
 script:
+  - set -e
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait 60 python fast_test.py; fi
   - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait 60 python3 full_test.py; fi
   - cd ../..


### PR DESCRIPTION
Solves #352.

Travis build was not failing as there was no option set in the `script` tag of travis.yml for taking actions if it fails. At present `script` tag is only executing tests script and as those scripts are running so there are no issues found and build will pass.

As per present scenerio the build will fail only if the scripts are not excuted such as the file which was executed using those scripts was not present there.

I guess adding `set -e` option will cause it to fail if there occurs an error in the script.
This was the only solution that came to my mind. We can use `pytest` or other tests rather than just running scripts manually if we want Travis to catch it automatically. For the present code, I think this should work. 