### PR TITLE
Travis CI: Find Python syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,8 @@ script:
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then travis_wait 15 python fast_test.py; fi
   - if [ "$TRAVIS_OS_NAME" != "windows" ]; then travis_wait 15 python3 full_test.py; fi
   - cd ../..
+  - pip install flake8
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
 before_deploy:
   - if [[ "$DEPLOYMENT_ENV" = "true" && "$TRAVIS_BRANCH" = "master" ]]; then cd docs/website/website; fi

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -414,7 +414,7 @@ class LudwigBackend():
                 if k not in self.transaction.lmd['model_accuracy']['train']:
                     self.transaction.lmd['model_accuracy']['train'][k] = []
                     self.transaction.lmd['model_accuracy']['test'][k] = []
-                elif k is not 'combined':
+                elif k != 'combined':
                     # We should be adding the accuracy here but we only have it for combined, so, for now use that, will only affect multi-output scenarios anyway
                     pass
                 else:

--- a/mindsdb/libs/helpers/parser.py
+++ b/mindsdb/libs/helpers/parser.py
@@ -1,4 +1,4 @@
-
+from mindsdb.libs.data_types.mindsdb_logger import log
 
 test = """
 

--- a/mindsdb/libs/helpers/probabilistic_validator.py
+++ b/mindsdb/libs/helpers/probabilistic_validator.py
@@ -87,7 +87,7 @@ class ProbabilisticValidator():
 
 
             # If no column is ignored, compute the accuracy for this bucket
-            nr_missing_features = len([x for x in features_existence if x is False or x is 0])
+            nr_missing_features = len([x for x in features_existence if x in (False, 0)])
             if nr_missing_features == 0:
                 if real_value_b not in self.bucket_accuracy:
                     self.bucket_accuracy[real_value_b] = []

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -147,21 +147,21 @@ class StatsGenerator(BaseModule):
             current_type_guess = 'Unknown'
 
             # Check if Nr
-            if current_subtype_guess is 'Unknown' or current_type_guess is 'Unknown':
+            if current_subtype_guess == 'Unknown' or current_type_guess == 'Unknown':
                 subtype = self._is_number(element)
                 if subtype is not False:
                     current_type_guess = DATA_TYPES.NUMERIC
                     current_subtype_guess = subtype
 
             # Check if date
-            if current_subtype_guess is 'Unknown' or current_type_guess is 'Unknown':
+            if current_subtype_guess == 'Unknown' or current_type_guess == 'Unknown':
                 subtype = self._get_date_type(element)
                 if subtype is not False:
                     current_type_guess = DATA_TYPES.DATE
                     current_subtype_guess = subtype
 
             # Check if sequence
-            if current_subtype_guess is 'Unknown' or current_type_guess is 'Unknown':
+            if current_subtype_guess == 'Unknown' or current_type_guess == 'Unknown':
                 for char in [',','\t','|',' ']:
                     try:
                         all_nr = True
@@ -179,7 +179,7 @@ class StatsGenerator(BaseModule):
                         break
 
             # Check if file
-            if current_subtype_guess is 'Unknown' or current_type_guess is 'Unknown':
+            if current_subtype_guess == 'Unknown' or current_type_guess == 'Unknown':
                 subtype = self._get_file_type(element)
                 if subtype is not False:
                     current_type_guess = DATA_TYPES.FILE_PATH

--- a/mindsdb/scraps.py
+++ b/mindsdb/scraps.py
@@ -52,7 +52,7 @@ def getColPermutations(possible_columns, max_num_of_perms = 100):
                 break
 
      ret = [perm.split(':') for perm in list(permutations.keys())]
-    return ret
+     return ret
 
 
 

--- a/mindsdb/scraps.py
+++ b/mindsdb/scraps.py
@@ -12,7 +12,7 @@ def getAllButOnePermutations(possible_columns):
         possible_columns_2 = [col3 for col3 in possible_columns if col3 != col ]
         n_perms = ":".join(possible_columns_2)
 
-         permutations[n_perms] = 1
+        permutations[n_perms] = 1
 
     ret = [perm.split(':') for perm in list(permutations.keys())]
     return ret
@@ -27,17 +27,17 @@ def getColPermutations(possible_columns, max_num_of_perms = 100):
     """
 
 
-     permutations = {col: 1 for col in possible_columns}
+    permutations = {col: 1 for col in possible_columns}
 
-     for perm_size in range(len(possible_columns)-1):
+    for perm_size in range(len(possible_columns)-1):
 
-         for permutation in list(permutations.keys()):
+        for permutation in list(permutations.keys()):
 
-             tokens_in_perm = permutation.split(':')
+            tokens_in_perm = permutation.split(':')
             if len(tokens_in_perm) == perm_size:
                 tokens_in_perm.sort()
 
-                 for col in possible_columns:
+                for col in possible_columns:
                     if col in tokens_in_perm:
                         continue
                     new_perm = tokens_in_perm + [col]
@@ -45,16 +45,14 @@ def getColPermutations(possible_columns, max_num_of_perms = 100):
                     new_perm_string = ':'.join(new_perm)
                     permutations[new_perm_string] = 1
 
-                     if len(permutations) > max_num_of_perms:
+                    if len(permutations) > max_num_of_perms:
                         break
 
-             if len(permutations) > max_num_of_perms:
+            if len(permutations) > max_num_of_perms:
                 break
 
-     ret = [perm.split(':') for perm in list(permutations.keys())]
-     return ret
-
-
+    ret = [perm.split(':') for perm in list(permutations.keys())]
+    return ret
 
 
 def getBestFitDistribution(self, data, bins=40):

--- a/mindsdb/scraps.py
+++ b/mindsdb/scraps.py
@@ -3,6 +3,9 @@ This file contains bits of codes that we might want to keep for later use,
 , but that are are currently not used anywhere in the codebase.
 '''
 
+# flake8: noqa
+
+
 # Previously in: mindsdb/libs/helpers/train_helpers.py
 def getAllButOnePermutations(possible_columns):
 


### PR DESCRIPTION
https://travis-ci.org/mindsdb/mindsdb/jobs/653113896#L1020

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.