### PR TITLE
Various Fixes for issues that accumulated 

### DIFF
--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.13.9'
+__version__ = '1.13.10'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -31,6 +31,7 @@ class LightwoodBackend():
 
         for _, row in original_df.iterrows():
             gb_lookup_key = self._get_group_by_key(group_by, row)
+            print(f'\n\n{gb_lookup_key}\n\n')
             if gb_lookup_key not in group_by_ts_map:
                 group_by_ts_map[gb_lookup_key] = []
 

--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -14,7 +14,6 @@ import pandas as pd
 from imageio import imread
 
 
-# @TODO: Define generci interface, similar to 'base_module' in the phases
 class LudwigBackend():
 
     def __init__(self, transaction):

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -52,7 +52,7 @@ class Transaction:
 
         self.run()
 
-    # @TODO Make it more generic, move to general helpers, use inside predictor instead of linline loading
+
     def load_metadata(self):
         try:
             import resource
@@ -76,7 +76,7 @@ class Transaction:
         except:
             self.log.error(f'Could not load mindsdb heavy metadata in the file: {fn}')
 
-    # @TODO Make it more generic, move to general helpers
+
     def save_metadata(self):
         fn = os.path.join(CONFIG.MINDSDB_STORAGE_PATH, self.lmd['name'] + '_light_model_metadata.pickle')
         self.lmd['updated_at'] = str(datetime.datetime.now())

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -128,8 +128,7 @@ class Transaction:
             if clean_exit:
                 sys.exit(1)
             else:
-                raise ValueError(error)
-                return None
+                raise Exception(error)
         finally:
             self.lmd['is_active'] = False
 
@@ -156,7 +155,7 @@ class Transaction:
             self.lmd['current_phase'] = MODEL_STATUS_PREPARING
             self.save_metadata()
 
-            self._call_phase_module(clean_exit=True, module_name='DataExtractor')
+            self._call_phase_module(clean_exit=False, module_name='DataExtractor')
             self.save_metadata()
 
             self.lmd['current_phase'] = MODEL_STATUS_DATA_ANALYSIS
@@ -164,19 +163,19 @@ class Transaction:
                 self.load_metadata()
             else:
                 self.save_metadata()
-                self._call_phase_module(clean_exit=True, module_name='StatsGenerator', input_data=self.input_data, modify_light_metadata=True, hmd=self.hmd)
+                self._call_phase_module(clean_exit=False, module_name='StatsGenerator', input_data=self.input_data, modify_light_metadata=True, hmd=self.hmd)
                 self.save_metadata()
 
-            self._call_phase_module(clean_exit=True, module_name='DataSplitter')
+            self._call_phase_module(clean_exit=False, module_name='DataSplitter')
 
-            self._call_phase_module(clean_exit=True, module_name='DataTransformer', input_data=self.input_data)
+            self._call_phase_module(clean_exit=False, module_name='DataTransformer', input_data=self.input_data)
             self.lmd['current_phase'] = MODEL_STATUS_TRAINING
             self.save_metadata()
-            self._call_phase_module(clean_exit=True, module_name='ModelInterface', mode='train')
+            self._call_phase_module(clean_exit=False, module_name='ModelInterface', mode='train')
 
             self.lmd['current_phase'] = MODEL_STATUS_ANALYZING
             self.save_metadata()
-            self._call_phase_module(clean_exit=True, module_name='ModelAnalyzer')
+            self._call_phase_module(clean_exit=False, module_name='ModelAnalyzer')
 
             self.lmd['current_phase'] = MODEL_STATUS_TRAINED
             self.save_metadata()

--- a/mindsdb/libs/helpers/general_helpers.py
+++ b/mindsdb/libs/helpers/general_helpers.py
@@ -210,7 +210,6 @@ def get_tensorflow_colname(col):
     return col
 
 @contextmanager
-# @TODO: Make it work with mindsdb logger/log levels... maybe
 def disable_console_output(activate=True):
     try:
         try:

--- a/mindsdb/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb/libs/phases/data_extractor/data_extractor.py
@@ -78,6 +78,10 @@ class DataExtractor(BaseModule):
                 df = self.transaction.hmd['when_data']
                 df = df.where((pd.notnull(df)), None)
 
+                for col in self.transaction.lmd['columns']:
+                    if col not in df.columns:
+                        df[col] = [None] * len(df)
+
             elif self.transaction.hmd['model_when_conditions'] is not None:
 
                 # if no data frame yet, make one

--- a/mindsdb/libs/phases/data_transformer/data_transformer.py
+++ b/mindsdb/libs/phases/data_transformer/data_transformer.py
@@ -49,11 +49,7 @@ class DataTransformer(BaseModule):
                 dt = datetime.datetime.utcfromtimestamp(date_str)
             except:
                 return None
-        # Uncomment if we want to work internally date type
-        #return dt
 
-        # Uncomment if we want to work internally with string type
-        # @TODO Decide if we ever need/want the milliseconds
         return dt.strftime('%Y-%m-%d %H:%M:%S')
 
     @staticmethod
@@ -62,7 +58,6 @@ class DataTransformer(BaseModule):
         try:
             return dt.timestamp()
         except:
-            # @TODO Return `None` after appropriate changes in lightwood
             return None
 
     @staticmethod

--- a/mindsdb/libs/phases/model_analyzer/helpers/column_evaluator.py
+++ b/mindsdb/libs/phases/model_analyzer/helpers/column_evaluator.py
@@ -29,7 +29,6 @@ class ColumnEvaluator():
 
         # Histogram for when all columns are present, in order to plot the force vectors
         for output_column in output_columns:
-            # @TODO: Running stats generator just to get the histogram is very inefficient, change this
             validation_set_output_column_histogram, _ = StatsGenerator.get_histogram(normal_predictions[output_column], data_type=stats[output_column]['data_type'],data_subtype=stats[output_column]['data_subtype'])
 
             if validation_set_output_column_histogram is not None:

--- a/mindsdb/libs/phases/stats_generator/scores.py
+++ b/mindsdb/libs/phases/stats_generator/scores.py
@@ -199,11 +199,7 @@ def compute_similariy_score(stats, columns, col_name):
         if other_col_name == col_name:
             continue
         else:
-            # @TODO Figure out why computing matthews_corrcoef is so slow, possibly find a better implementation and replace it with that
-            #try:
-            #    similarity = matthews_corrcoef(list(map(str,col_data)), list(map(str,columns[other_col_name])))
-            #    similarities.append((other_col_name,similarity))
-            #except:
+            # @TODO Figure out why computing matthews_corrcoef is so slow, possibly find a better implementation and replace it with that. Matthews corrcoef code was: similarity = matthews_corrcoef(list(map(str,col_data)), list(map(str,columns[other_col_name])))
             similarity = 0
             X1 = list(map(str,col_data))
             X2 = list(map(str,columns[other_col_name]))

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -225,11 +225,6 @@ class StatsGenerator(BaseModule):
             type_dist[curr_data_type] = type_dist.pop('Unknown')
             subtype_dist[curr_data_subtype] = subtype_dist.pop('Unknown')
 
-
-        # @TODO: Extremely slow for large datasets, make it faster
-        import time
-        a = round(time.time(),3)
-        print(f"Started at: {a}")
         if curr_data_type != DATA_TYPES.CATEGORICAL and curr_data_subtype != DATA_SUBTYPES.DATE:
             all_values = data_frame[col_name]
             all_distinct_vals = set(all_values)
@@ -251,9 +246,6 @@ class StatsGenerator(BaseModule):
 
                 type_dist[curr_data_type] = len(data)
                 subtype_dist[curr_data_subtype] = len(data)
-        b = round(time.time() - a,3)
-        print(f"Ended at: {b}")
-        exit()
 
         if col_name in self.transaction.lmd['force_categorical_encoding']:
             curr_data_type = DATA_TYPES.CATEGORICAL

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -142,7 +142,7 @@ class StatsGenerator(BaseModule):
 
         for element in data:
             # Maybe use list of functions in the future
-            element = element
+            element = str(element)
             current_subtype_guess = 'Unknown'
             current_type_guess = 'Unknown'
 

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -185,8 +185,6 @@ class StatsGenerator(BaseModule):
                     current_type_guess = DATA_TYPES.FILE_PATH
                     current_subtype_guess = subtype
 
-            # If nothing works, assume it's categorical or sequential and determine type later (based on all the data in the column)
-
             if current_type_guess not in type_dist:
                 type_dist[current_type_guess] = 1
             else:
@@ -205,7 +203,7 @@ class StatsGenerator(BaseModule):
         # assume that the type is the one with the most prevalent type_dist
         for data_type in type_dist:
             # If any of the members are Unknown, use that data type (later to be turned into CATEGORICAL or SEQUENTIAL), since otherwise the model will crash when casting
-            # @TODO consider removing rows where data type is unknown in the future, might just be corrupt data... a bit hard to imply currently
+            # @TODO consider removing or flagging rows where data type is unknown in the future, might just be corrupt data... a bit hard to imply currently
             if data_type == 'Unknown':
                 curr_data_type = 'Unknown'
                 break
@@ -229,6 +227,9 @@ class StatsGenerator(BaseModule):
 
 
         # @TODO: Extremely slow for large datasets, make it faster
+        import time
+        a = round(time.time(),3)
+        print(f"Started at: {a}")
         if curr_data_type != DATA_TYPES.CATEGORICAL and curr_data_subtype != DATA_SUBTYPES.DATE:
             all_values = data_frame[col_name]
             all_distinct_vals = set(all_values)
@@ -250,6 +251,9 @@ class StatsGenerator(BaseModule):
 
                 type_dist[curr_data_type] = len(data)
                 subtype_dist[curr_data_subtype] = len(data)
+        b = round(time.time() - a,3)
+        print(f"Ended at: {b}")
+        exit()
 
         if col_name in self.transaction.lmd['force_categorical_encoding']:
             curr_data_type = DATA_TYPES.CATEGORICAL

--- a/tests/ci_tests/tests.py
+++ b/tests/ci_tests/tests.py
@@ -35,7 +35,6 @@ def test_force_vectors(amd, to_predict):
 
 def test_adapted_model_data(amd, to_predict):
     amd = amd
-    # @TODO: Sometimes are None, not sure why: [, validation_set_accuracy, accuracy]
     for k in ['status', 'name', 'version', 'data_source', 'current_phase', 'updated_at', 'created_at',
               'train_end_at']:
         assert (type(amd[k]) == str)

--- a/tests/integration_tests/data_generators.py
+++ b/tests/integration_tests/data_generators.py
@@ -22,7 +22,6 @@ def generate_timeseries(length, bounds=(0,1852255420), _type='timestamp',period=
 
 def rand_str(length=random.randrange(4,120)):
     # Create a list of unicode characters within the range 0000-D7FF
-    # @TODO Copy pasted the 0xD7FF value, not 100% sure it returns all uncideo chars, maybe check that
     random_unicodes = [chr(random.randrange(0xD7FF)) for _ in range(0, length)]
     return u"".join(random_unicodes)
 
@@ -79,7 +78,7 @@ def generate_value_cols(types, length, separator=',', ts_period=48*3600):
 
         for n in range(length):
             val = gen_fun()
-            # @TODO Maybe escpae the separator rather than replace
+            # @TODO: Maybe escpae the separator rather than replace them
             if type(val) == str:
                 val = val.replace(separator,'_').replace('\n','_').replace('\r','_')
             columns[-1].append(val)


### PR DESCRIPTION
Pushing the various fixes I work on today here.

* Resolves #390 

* Fixed a bug reported by Max and seen previously where `when_data` datasources could not have missing input columns, even though we supported this with `when` (just assuming the missing inputs have value `None`). This same behavior is now supported for `when_data` (note: this is the method used to pass larger structures such as files and data-frames to `predict`)

* Mindsdb contained a bunch of @TODOs most of them outdated and/or incorrect (by this point) removed he incorrect/now-irrelevant ones, did the small changes required by a few others. A few are still left, but those are useful to keep in there, not important enough to be issues, but important enough to have an easy way of greping for them.

* Stats generator now runs with pandas dataframes containing bool's