### PR TITLE
Confidence changes

### DIFF
--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.13.15'
+__version__ = '1.14.0'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -250,6 +250,7 @@ class LightwoodBackend():
                     confidences[-1] = sum(confidences[-1])/len(confidences[-1])
                 formated_predictions[f'{k}_confidences'] = confidences
 
-        print(formated_predictions[f'{k}_confidences'])
-        
+            if 'confidence_range' in predictions[k]:
+                formated_predictions[f'{k}_confidence_range'] = predictions[k]['confidence_range']
+
         return formated_predictions

--- a/mindsdb/libs/backends/lightwood.py
+++ b/mindsdb/libs/backends/lightwood.py
@@ -235,7 +235,21 @@ class LightwoodBackend():
         formated_predictions = {}
         for k in predictions:
             formated_predictions[k] = predictions[k]['predictions']
-            if 'confidences' in predictions[k]:
-                formated_predictions[f'{k}_confidences'] = predictions[k]['confidences']
 
+            confidence_arr = []
+            for confidence_name in ['selfaware_confidences','loss_confidences']:
+                if confidence_name in predictions[k]:
+                    confidence_arr.append(predictions[k][confidence_name])
+
+            if len(confidence_arr) > 0:
+                confidences = []
+                for n in range(len(confidence_arr[0])):
+                    confidences.append([])
+                    for i in range(len(confidence_arr)):
+                        confidences[-1].append(confidence_arr[i][n])
+                    confidences[-1] = sum(confidences[-1])/len(confidences[-1])
+                formated_predictions[f'{k}_confidences'] = confidences
+
+        print(formated_predictions[f'{k}_confidences'])
+        
         return formated_predictions

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -499,7 +499,7 @@ class Predictor:
         :return: bool (True/False) True if mind was exported successfully
         """
 
-        with open(os.path.join(CONFIG.MINDSDB_STORAGE_PATH, old_model_name + '_light_model_metadata.pickle'), 'rb') as fp:
+        with open(os.path.join(CONFIG.MINDSDB_STORAGE_PATH, model_name + '_light_model_metadata.pickle'), 'rb') as fp:
             lmd = pickle.load(fp)
 
             try:

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -280,19 +280,6 @@ class Transaction:
                     output_data[confidence_column_name][row_number] = prediction_evaluation.most_likely_probability
                     evaluations[predicted_col][row_number] = prediction_evaluation
 
-
-                if f'{predicted_col}_model_confidence' in output_data:
-                    # Scale model confidence between the confidences of the probabilsitic validator
-                    mc_arr = np.array(output_data[f'{predicted_col}_model_confidence'])
-
-                    normalized_model_confidences = ( (mc_arr - np.min(mc_arr)) / (np.max(mc_arr) - np.min(mc_arr)) ) * (np.max(output_data[confidence_column_name]) - np.min(output_data[confidence_column_name])) + np.min(output_data[confidence_column_name])
-
-                    # In case the model confidence is smaller than that yielded after scaling, use the model confidence directly, replaced negative numbers with zero confidence
-                    for i in range(len(output_data[f'{predicted_col}_model_confidence'])):
-                        if output_data[f'{predicted_col}_model_confidence'][i] < 0:
-                            output_data[f'{predicted_col}_model_confidence'][i] = 0
-                        output_data[f'{predicted_col}_model_confidence'][i] = min(output_data[f'{predicted_col}_model_confidence'][i],normalized_model_confidences[i])
-
             if mode == 'predict':
                 self.output_data = PredictTransactionOutputData(transaction=self, data=output_data, evaluations=evaluations)
             else:

--- a/mindsdb/libs/data_types/transaction_output_row.py
+++ b/mindsdb/libs/data_types/transaction_output_row.py
@@ -55,7 +55,7 @@ class TransactionOutputRow:
                 else:
                     value_range = [cluster['buckets'][0],cluster['buckets'][-1]]
 
-                answers[pred_col]['explanation']['confidence_interval'] = [range_pretty_start, range_end_start]
+                answers[pred_col]['explanation']['confidence_interval'] = value_range
 
             important_missing_cols = get_important_missing_cols(self.transaction_output.transaction.lmd, prediction_row, pred_col)
             answers[pred_col]['explanation']['important_missing_information'] = important_missing_cols

--- a/mindsdb/libs/data_types/transaction_output_row.py
+++ b/mindsdb/libs/data_types/transaction_output_row.py
@@ -30,10 +30,9 @@ class TransactionOutputRow:
             cluster = clusters[0]
 
             answers[pred_col]['predicted_value'] = cluster['value']
-            answers[pred_col]['confidence'] = round(cluster['confidence'] * 100)
 
             if f'{pred_col}_model_confidence' in prediction_row:
-                answers[pred_col]['confidence'] = round((prediction_row[f'{pred_col}_model_confidence'] * 100 + answers[pred_col]['confidence'])/2)
+                answers[pred_col]['confidence'] = round((prediction_row[f'{pred_col}_model_confidence'] * 2 + cluster['confidence'] * 1)/3, 4) * 100
 
             quality = 'very confident'
             if answers[pred_col]['confidence'] < 80:

--- a/mindsdb/libs/data_types/transaction_output_row.py
+++ b/mindsdb/libs/data_types/transaction_output_row.py
@@ -32,6 +32,8 @@ class TransactionOutputRow:
 
             if f'{pred_col}_model_confidence' in prediction_row:
                 answers[pred_col]['confidence'] = round((prediction_row[f'{pred_col}_model_confidence'] * 2 + cluster['confidence'] * 1)/3, 4) * 100
+            else:
+                answers[pred_col]['confidence'] = cluster['confidence'] * 100
 
             quality = 'very confident'
             if answers[pred_col]['confidence'] < 80:

--- a/mindsdb/libs/data_types/transaction_output_row.py
+++ b/mindsdb/libs/data_types/transaction_output_row.py
@@ -24,7 +24,7 @@ class TransactionOutputRow:
 
             prediction_row = {col: self.data[col][self.row_index] for col in list(set(self.data.keys()) - set('confidence_range'))}
 
-            answers[pred_col]['predicted_value'] = prediction_row[pred_col][pred_col]
+            answers[pred_col]['predicted_value'] = prediction_row[pred_col]
 
             evaluation = self.evaluations[pred_col][self.row_index]
             clusters = evaluation.explain(self.transaction_output.transaction.lmd['column_stats'][pred_col])
@@ -64,8 +64,6 @@ class TransactionOutputRow:
             if self.transaction_output.extra_insights is not None:
                 answers[pred_col]['explanation']['extra_insights'] = self.transaction_output.extra_insights[pred_col]
 
-        for col in answers:
-            print(answers[col]['confidence'])
         return answers
 
     def explain(self):


### PR DESCRIPTION
Various changes to source confidence from lightwood without normalization and rely on that confidence more when available.

Source predictions and numerical ranges directly from lightwood, bypassing the bayesian model (maybe revert back ? maybe make the current flag for this work again or add a new one ?).

Fixed model deletion.

