### PR TITLE
Cleanup and getColPermutations logic fix

### DIFF
--- a/mindsdb/libs/backends/ludwig.py
+++ b/mindsdb/libs/backends/ludwig.py
@@ -275,14 +275,14 @@ class LudwigBackend():
                     data[tf_col].append(unix_ts)
 
                 elif data_subtype in (DATA_SUBTYPES.FLOAT):
-                    if type(row[col]) == str:
-                        data[tf_col].append(float(str(row[col]).replace(',','.')))
+                    if isinstance(row[col], str):
+                        data[tf_col].append(float(str(row[col]).replace(',', '.')))
                     else:
                         data[tf_col].append(row[col])
 
                 elif data_subtype in (DATA_SUBTYPES.INT):
-                    if type(row[col]) == str:
-                        data[tf_col].append(round(float(str(row[col]).replace(',','.'))))
+                    if isinstance(row[col], str):
+                        data[tf_col].append(round(float(str(row[col]).replace(',', '.'))))
                     else:
                         data[tf_col].append(row[col])
 

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -603,9 +603,9 @@ class Predictor:
         sample_confidence_level = 1 - sample_margin_of_error
 
         # lets turn into lists: predict, order_by and group by
-        predict_columns = [to_predict] if type(to_predict) != type([]) else to_predict
-        group_by = group_by if type(group_by) == type([]) else [group_by] if group_by else []
-        order_by = order_by if type(order_by) == type([]) else [order_by] if order_by else []
+        predict_columns = to_predict if isinstance(to_predict, list) else [to_predict]
+        group_by = group_by if isinstance(group_by, list) else [group_by] if group_by else []
+        order_by = order_by if isinstance(order_by, list) else [order_by] if order_by else []
 
         if len(predict_columns) == 0:
             error = 'You need to specify a column to predict'
@@ -614,7 +614,7 @@ class Predictor:
 
         # lets turn order by into tuples if not already
         # each element ('column_name', 'boolean_for_ascending <default=true>')
-        order_by = [(col_name, True) if type(col_name) != type(()) else col_name for col_name in order_by]
+        order_by = [col_name if isinstance(col_name, tuple) else (col_name, True) for col_name in order_by]
 
         is_time_series = True if len(order_by) > 0 else False
 
@@ -623,7 +623,7 @@ class Predictor:
         the server doesn't handle non-file data sources at the moment, so this shouldn't prove an issue,
         once we want to support datasources such as s3 and databases for the server we need to add name as a concept (or, preferably, before that)
         '''
-        data_source_name = from_data if type(from_data) == str else 'Unkown'
+        data_source_name = from_data if isinstance(from_data, str) else 'Unkown'
 
         heavy_transaction_metadata = {}
         heavy_transaction_metadata['name'] = self.name
@@ -747,7 +747,7 @@ class Predictor:
 
         accuracy_dict = {}
         for col in lmd['predict_columns']:
-            if type(accuracy_score_functions) == type({}):
+            if isinstance(accuracy_score_functions, dict):
                 acc_f = accuracy_score_functions[col]
             else:
                 acc_f = accuracy_score_functions
@@ -784,7 +784,7 @@ class Predictor:
         when_ds = None if when_data is None else getDS(when_data)
 
         # lets turn into lists: when
-        when = [when] if type(when) in [type(None), type({})] else when
+        when = [when] if isinstance(when, (type(None), dict)) else when
 
         heavy_transaction_metadata = {}
         if when_ds is None:

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -587,11 +587,20 @@ class Predictor:
         :return:
         """
 
+        if ignore_columns is None:
+            ignore_columns = []
+        
+        if group_by is None:
+            group_by = []
+
+        if order_by is None:
+            order_by = []
+
         # lets turn into lists: predict, ignore, group_by, order_by
-        predict_columns = to_predict if isinstance(to_predict, list) else [to_predict] if to_predict else []
-        ignore_columns = ignore_columns if isinstance(ignore_columns, list) else [ignore_columns] if ignore_columns else []
-        group_by = group_by if isinstance(group_by, list) else [group_by] if group_by else []
-        order_by = order_by if isinstance(order_by, list) else [order_by] if order_by else []
+        predict_columns = to_predict if isinstance(to_predict, list) else [to_predict]
+        ignore_columns = ignore_columns if isinstance(ignore_columns, list) else [ignore_columns]
+        group_by = group_by if isinstance(group_by, list) else [group_by]
+        order_by = order_by if isinstance(order_by, list) else [order_by]
 
         # lets turn order by into list of tuples if not already
         # each element ('column_name', 'boolean_for_ascending <default=true>')

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -765,9 +765,6 @@ class Predictor:
         :return: TransactionOutputData object
         """
 
-        if when is None:
-            when = {}
-
         if unstable_parameters_dict is None:
             unstable_parameters_dict = {}
 
@@ -780,7 +777,7 @@ class Predictor:
         when_ds = None if when_data is None else getDS(when_data)
 
         # lets turn into lists: when
-        when = [when] if isinstance(when, (type(None), dict)) else when
+        when = [when] if isinstance(when, dict) else when if when is not None else []
 
         heavy_transaction_metadata = {}
         if when_ds is None:

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -99,7 +99,7 @@ class Transaction:
         for k in self.hmd:
             if k not in null_out_fields:
                 save_hmd[k] = self.hmd[k]
-            if k == 'model_backend' and type(self.hmd['model_backend']) != type(str()):
+            if k == 'model_backend' and not isinstance(self.hmd['model_backend'], str):
                 save_hmd[k] = None
 
         try:

--- a/mindsdb/libs/data_sources/file_ds.py
+++ b/mindsdb/libs/data_sources/file_ds.py
@@ -38,7 +38,7 @@ class FileDS(DataSource):
         data = BytesIO()
 
         # get data from either url or file load in memory
-        if file[:5] == 'http:' or file[:6] == 'https:':
+        if file.startswith('http:') or file.startswith('https:'):
             r = requests.get(file, stream=True)
             if r.status_code == 200:
                 for chunk in r:
@@ -108,7 +108,7 @@ class FileDS(DataSource):
         if len(text) > 0:
             text = text.strip()
             # it it looks like a json, then try to parse it
-            if text != "" and ((text[0] == "{") or (text[0] == "[")):
+            if text.startswith('{') or text.startswith('['):
                 try:
                     json.loads(data.read())
                     data.seek(0)

--- a/mindsdb/libs/helpers/debugging.py
+++ b/mindsdb/libs/helpers/debugging.py
@@ -4,13 +4,13 @@ import os
 def print_key_and_type(d, nl=''):
     for k in d:
         print(nl + str(k))
-    if type(d[k]) == dict:
-        print_key_and_type(d[k],nl + '  ')
-    if type(d[k]) == list:
+    if isinstance(d[k], dict):
+        print_key_and_type(d[k], nl + '  ')
+    if isinstance(d[k], list):
         try:
-            if type(d[k][0]) == dict:
+            if isinstance(d[k][0], dict):
                 print('[\n')
-                print_key_and_type(d[k][0],nl + '  ')
+                print_key_and_type(d[k][0], nl + '  ')
                 print('\n]')
             else:
                 print(nl + '[' + str(type(d[k][0])) + ']')

--- a/mindsdb/libs/helpers/general_helpers.py
+++ b/mindsdb/libs/helpers/general_helpers.py
@@ -228,7 +228,7 @@ def disable_console_output(activate=True):
 
 def value_isnan(value):
     try:
-        if type(value) == float:
+        if isinstance(value, float):
             a = int(value)
         isnan = False
     except:

--- a/mindsdb/libs/helpers/text_helpers.py
+++ b/mindsdb/libs/helpers/text_helpers.py
@@ -14,11 +14,12 @@ import json
 import hashlib
 import numpy
 
+
 def clean_float(val):
-    if type(val) in [type(int(1)), type(1.0)] :
+    if isinstance(val, (int, float)):
         return float(val)
 
-    if isinstance(val, (float, int, numpy.float64)):
+    if isinstance(val, numpy.float64):
         return val
 
     val = str(val)

--- a/mindsdb/libs/phases/data_splitter/data_splitter.py
+++ b/mindsdb/libs/phases/data_splitter/data_splitter.py
@@ -51,7 +51,7 @@ class DataSplitter(BaseModule):
         # move indexes to corresponding train, test, validation, etc and trim input data accordingly
         if self.transaction.lmd['type'] == TRANSACTION_LEARN:
             for key in all_indexes:
-                should_split_by_group = type(group_by) == list and len(group_by) > 0
+                should_split_by_group = isinstance(group_by, list) and len(group_by) > 0
 
                 #If this is a group by, skip the `KEY_NO_GROUP_BY` key
                 if should_split_by_group and key == KEY_NO_GROUP_BY:

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -294,7 +294,7 @@ class StatsGenerator(BaseModule):
     def get_words_histogram(data, is_full_text=False):
         """ Returns an array of all the words that appear in the dataset and the number of times each word appears in the dataset """
 
-        splitter = lambda w, t: [wi.split(t) for wi in w] if type(w) == type([]) else splitter(w,t)
+        splitter = lambda w, t: [wi.split(t) for wi in w] if isinstance(w, list) else splitter(w, t)
 
         if is_full_text:
             # get all words in every cell and then calculate histograms

--- a/mindsdb/scraps.py
+++ b/mindsdb/scraps.py
@@ -5,6 +5,8 @@ This file contains bits of codes that we might want to keep for later use,
 
 # flake8: noqa
 
+from itertools import combinations, permutations
+
 
 # Previously in: mindsdb/libs/helpers/train_helpers.py
 def getAllButOnePermutations(possible_columns):
@@ -22,40 +24,43 @@ def getAllButOnePermutations(possible_columns):
 
 
 # Previously in mindsdb/libs/phases/stats_generator.py
-def getColPermutations(possible_columns, max_num_of_perms = 100):
+# NOTE: This function used to confuse permutations & combinations,
+# so I made both get_col_combinations() and get_col_permutations()
+def get_col_combinations(columns, n=100):
     """
-    Get all possible combinations given a list of column names
-     :return: Given Input = [a,b,c]
-             Then, Output=  [ [a], [b], [c], [a,b], [a,c], [b,c] ]
+    Given a list of column names, finds first :param:n:
+    combinations (without replacement).
+    
+    :param columns: list of column names
+    :param n: max number of combinations
+    
+    :yields: example: [a, b, c] -> [[a], [b], [c], [a, b], [a, c], [b, c]]
     """
 
+    count = 0
+    for i in range(1, len(columns)):
+        for combo in combinations(columns, i):
+            if count < n:
+                count += 1
+                yield combo
 
-    permutations = {col: 1 for col in possible_columns}
 
-    for perm_size in range(len(possible_columns)-1):
+def get_col_permutations(columns, n=100):
+    """
+    Given a list of column names, finds first :param:n: permutations
+    
+    :param columns: list of column names
+    :param n: max number of permutations
+    
+    :yields: example: [a, b, c] -> [[a], [b], [c], [a, b], [b, a], [a, c], [c, a], [b, c], [c, b]]
+    """
 
-        for permutation in list(permutations.keys()):
-
-            tokens_in_perm = permutation.split(':')
-            if len(tokens_in_perm) == perm_size:
-                tokens_in_perm.sort()
-
-                for col in possible_columns:
-                    if col in tokens_in_perm:
-                        continue
-                    new_perm = tokens_in_perm + [col]
-                    new_perm.sort()
-                    new_perm_string = ':'.join(new_perm)
-                    permutations[new_perm_string] = 1
-
-                    if len(permutations) > max_num_of_perms:
-                        break
-
-            if len(permutations) > max_num_of_perms:
-                break
-
-    ret = [perm.split(':') for perm in list(permutations.keys())]
-    return ret
+    count = 0
+    for i in range(1, len(columns)):
+        for perm in permutations(columns, i):
+            if count < n:
+                count += 1
+                yield perm
 
 
 def getBestFitDistribution(self, data, bins=40):

--- a/tests/ci_tests/tests.py
+++ b/tests/ci_tests/tests.py
@@ -66,7 +66,7 @@ def basic_test(backend='lightwood',use_gpu=True, run_extra=False, IS_CI_TEST=Fal
             if ctn:
                 continue
             
-            code = os.system(f'py ../functional_testing/{py_file}')
+            code = os.system(f'python3 ../functional_testing/{py_file}')
             if code != 0:
                 raise Exception(f'Test failed with status code: {code} !')
 

--- a/tests/ci_tests/tests.py
+++ b/tests/ci_tests/tests.py
@@ -7,21 +7,21 @@ def test_data_analysis(amd, to_predict):
     data_analysis = amd['data_analysis']
     for k in data_analysis:
         assert (len(data_analysis[k]) > 0)
-        assert (type(data_analysis[k][0]) == dict)
+        assert isinstance(data_analysis[k][0], dict)
 
 def test_model_analysis(amd, to_predict):
     model_analysis = amd['model_analysis']
     assert (len(model_analysis) > 0)
-    assert (type(model_analysis[0]) == dict)
+    assert isinstance(model_analysis[0], dict)
     input_importance = model_analysis[0]["overall_input_importance"]
     assert (len(input_importance) > 0)
-    assert (type(input_importance) == dict)
+    assert isinstance(input_importance, dict)
 
     for column, importance in zip(input_importance["x"], input_importance["y"]):
-        assert (type(column) == str)
+        assert isinstance(column, str)
         assert (len(column) > 0)
 
-        assert (type(importance) == float or type(importance) == int)
+        assert isinstance(importance, (float, int))
         assert (importance > 0)
 
 def test_force_vectors(amd, to_predict):
@@ -37,16 +37,16 @@ def test_adapted_model_data(amd, to_predict):
     amd = amd
     for k in ['status', 'name', 'version', 'data_source', 'current_phase', 'updated_at', 'created_at',
               'train_end_at']:
-        assert (type(amd[k]) == str)
+        assert isinstance(amd[k], str)
 
-    assert (type(amd['predict']) == list or type(amd['predict']) == str)
-    assert (type(amd['is_active']) == bool)
+    assert isinstance(amd['predict'], (list, str))
+    assert isinstance(amd['is_active'], bool)
 
     for k in ['validation_set_accuracy', 'accuracy']:
-        assert (type(amd[k]) == float)
+        assert isinstance(amd[k], float)
 
     for k in amd['data_preparation']:
-        assert (type(amd['data_preparation'][k]) == int or type(amd['data_preparation'][k]) == float)
+        assert isinstance(amd['data_preparation'][k], (int, float))
     test_data_analysis(amd, to_predict)
     test_model_analysis(amd, to_predict)
     #test_force_vectors(amd, to_predict)
@@ -66,7 +66,7 @@ def basic_test(backend='lightwood',use_gpu=True, run_extra=False, IS_CI_TEST=Fal
             if ctn:
                 continue
             
-            code = os.system(f'python3 ../functional_testing/{py_file}')
+            code = os.system(f'py ../functional_testing/{py_file}')
             if code != 0:
                 raise Exception(f'Test failed with status code: {code} !')
 

--- a/tests/integration_tests/data_generators.py
+++ b/tests/integration_tests/data_generators.py
@@ -79,7 +79,7 @@ def generate_value_cols(types, length, separator=',', ts_period=48*3600):
         for n in range(length):
             val = gen_fun()
             # @TODO: Maybe escpae the separator rather than replace them
-            if type(val) == str:
+            if isinstance(val, str):
                 val = val.replace(separator,'_').replace('\n','_').replace('\r','_')
             columns[-1].append(val)
 
@@ -113,7 +113,7 @@ def generate_labels_2(columns, separator=','):
     for n in range(1, len(columns[-1])):
         value = 1
         for i in range(len(columns)):
-            if type(columns[i][n]) == str:
+            if isinstance(columns[i][n], str):
                 operand = len(columns[i][n])
             else:
                 operand = columns[i][n]


### PR DESCRIPTION
`mindsdb/scraps/getColPermutations()`'s name says **permutations** while in docstring it says **combinations**, so I made two functions both for combinations and permutations that work according to their description.

**PEP-8:**
_Object type comparisons should always use isinstance() instead of comparing types directly._
_Use `.startswith()` and `.endswith()` instead of string slicing to check for prefixes or suffixes._
