### PR TITLE
Drop null targets

### DIFF
--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.17.2'
+__version__ = '1.17.3'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/libs/phases/model_interface/model_interface.py
+++ b/mindsdb/libs/phases/model_interface/model_interface.py
@@ -6,7 +6,6 @@ import datetime
 
 class ModelInterface(BaseModule):
     def run(self, mode='train'):
-
         try:
             from mindsdb.libs.backends.ludwig import LudwigBackend
         except ImportError as e:
@@ -16,7 +15,7 @@ class ModelInterface(BaseModule):
         try:
             from mindsdb.libs.backends.lightwood import LightwoodBackend
         except ImportError as e:
-            self.transaction.log.warning(e)
+            self.log.warning(e)
 
         if self.transaction.hmd['model_backend'] == 'ludwig':
             self.transaction.model_backend = LudwigBackend(self.transaction)


### PR DESCRIPTION
Drops the target columns if they are null, this is done as part of a newly added cleanup in the `DataSplitter`, I realized some cleanup/transformations ought to be done before that point and some after, will maybe split the DataTrasnformer into two modules to do this in the future, no need to bother for now.

Also version bump that should deploy changes from the previous PR, also small logging fix in the `ModelInterface`