### PR TITLE
Numerical accuracy changes

### DIFF
--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.17.3'
+__version__ = '1.17.4'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -274,6 +274,14 @@ class Predictor:
                     confusion_matrix = lmd['confusion_matrices'][col]
                 else:
                     confusion_matrix = None
+
+                if 'accuracy_samples' in lmd and col in lmd['accuracy_samples']:
+                    accuracy_samples = lmd['accuracy_samples'][col]
+                else:
+                    accuracy_samples = None
+
+
+
                 # Model analysis building for each of the predict columns
                 mao = {
                     'column_name': col
@@ -298,6 +306,7 @@ class Predictor:
                         ,'x_explained': []
                   }
                   ,"confusion_matrix": confusion_matrix
+                  ,"accuracy_samples": accuracy_samples
                 }
 
 
@@ -589,7 +598,7 @@ class Predictor:
 
         if ignore_columns is None:
             ignore_columns = []
-        
+
         if group_by is None:
             group_by = []
 
@@ -614,7 +623,7 @@ class Predictor:
         test_from_ds = None if test_from_data is None else getDS(test_from_data)
 
         transaction_type = TRANSACTION_LEARN
-        sample_confidence_level = 1 - sample_margin_of_error        
+        sample_confidence_level = 1 - sample_margin_of_error
 
         if len(predict_columns) == 0:
             error = 'You need to specify a column to predict'

--- a/mindsdb/libs/helpers/probabilistic_validator.py
+++ b/mindsdb/libs/helpers/probabilistic_validator.py
@@ -192,7 +192,7 @@ class ProbabilisticValidator():
 
         accuracy_samples = None
         if len(self.numerical_samples_arr) > 0:
-            nr_samples = max(400,len(self.numerical_samples_arr))
+            nr_samples = min(400,len(self.numerical_samples_arr))
             sampled_numerical_samples_arr = random.sample(self.numerical_samples_arr, nr_samples)
             accuracy_samples = {
                 'y': [x[0] for x in sampled_numerical_samples_arr]

--- a/mindsdb/libs/helpers/probabilistic_validator.py
+++ b/mindsdb/libs/helpers/probabilistic_validator.py
@@ -109,7 +109,8 @@ class ProbabilisticValidator():
                 X[-1] += feature_existance
 
 
-        sampling_tuples_arr = random.sample(sampling_tuples_arr,400)
+        if len(sampling_tuples_arr) > 400:
+            sampling_tuples_arr = random.sample(sampling_tuples_arr,400)
         self.real_values_sampled = [x[0] for x in sampling_tuples_arr]
         self.normal_predictions_sampled = [x[1] for x in sampling_tuples_arr]
 

--- a/mindsdb/libs/helpers/probabilistic_validator.py
+++ b/mindsdb/libs/helpers/probabilistic_validator.py
@@ -194,15 +194,14 @@ class ProbabilisticValidator():
             'real': bucket_values
         }
 
+        accuracy_samples = None
         if len(self.real_values_sampled) > 0:
-            cm['accuracy_samples'] = {
-                'x': self.normal_predictions_sampled
-                ,'y': self.real_values_sampled
+            accuracy_samples = {
+                'y': self.normal_predictions_sampled
+                ,'x': self.real_values_sampled
             }
 
-        print(cm)
-
-        return overall_accuracy, accuracy_histogram, cm
+        return overall_accuracy, accuracy_histogram, cm, accuracy_samples
 
 if __name__ == "__main__":
     pass

--- a/mindsdb/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb/libs/phases/model_analyzer/model_analyzer.py
@@ -37,11 +37,12 @@ class ModelAnalyzer(BaseModule):
                 column_importance = (1 - empty_inpurt_accuracy[col]/normal_accuracy)
                 column_importance = np.ceil(10*column_importance)
                 self.transaction.lmd['column_importances'][col] = float(10 if column_importance > 10 else column_importance)
-        
+
         # Run Probabilistic Validator
         overall_accuracy_arr = []
         self.transaction.lmd['accuracy_histogram'] = {}
         self.transaction.lmd['confusion_matrices'] = {}
+        self.transaction.lmd['accuracy_samples'] = {}
         self.transaction.hmd['probabilistic_validators'] = {}
 
         for col in output_columns:
@@ -49,13 +50,14 @@ class ModelAnalyzer(BaseModule):
             predictions_arr = [normal_predictions] + [empty_input_predictions[col] for col in ignorable_input_columns]
 
             pval.fit(self.transaction.input_data.validation_df, predictions_arr, [[x] for x in ignorable_input_columns])
-            overall_accuracy, accuracy_histogram, cm = pval.get_accuracy_stats()
+            overall_accuracy, accuracy_histogram, cm, accuracy_samples = pval.get_accuracy_stats()
             overall_accuracy_arr.append(overall_accuracy)
 
             self.transaction.lmd['accuracy_histogram'][col] = accuracy_histogram
             self.transaction.lmd['confusion_matrices'][col] = cm
+            self.transaction.lmd['accuracy_samples'][col] = accuracy_samples
             self.transaction.hmd['probabilistic_validators'][col] = pickle_obj(pval)
-        
+
         self.transaction.lmd['validation_set_accuracy'] = sum(overall_accuracy_arr)/len(overall_accuracy_arr)
 
 def test():

--- a/mindsdb/libs/phases/model_analyzer/model_analyzer.py
+++ b/mindsdb/libs/phases/model_analyzer/model_analyzer.py
@@ -58,6 +58,7 @@ class ModelAnalyzer(BaseModule):
             self.transaction.lmd['accuracy_samples'][col] = accuracy_samples
             self.transaction.hmd['probabilistic_validators'][col] = pickle_obj(pval)
 
+        print(overall_accuracy_arr)
         self.transaction.lmd['validation_set_accuracy'] = sum(overall_accuracy_arr)/len(overall_accuracy_arr)
 
 def test():


### PR DESCRIPTION
* Calculating numerical accuracy in the `ProbabilisticValidator` based on whether or not the real values falls within the predicted range.

* Making the "will fall in the numerical range" the target of the Bayesian model used for confidence determination in the `ProbabilisticValidator` for numerical targets.

* Getting a sample of max 400 predicted-ranges + real-values from the validation datasets, this sample can be used to plot the accuracy graph for numerical values instead of the confusion matrix.