### PR TITLE
Cast column as string in case of different type

### DIFF
--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.18.1'
+__version__ = '1.18.2'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/libs/phases/stats_generator/data_preparation.py
+++ b/mindsdb/libs/phases/stats_generator/data_preparation.py
@@ -23,7 +23,7 @@ def clean_int_and_date_data(col_data, log):
     cleaned_data = []
 
     for ele in col_data:
-        if str(ele) not in ['', str(None), str(False), str(np.nan), 'NaN', 'nan', 'NA', 'null'] and (not ele or not ele.isspace()):
+        if str(ele) not in ['', str(None), str(False), str(np.nan), 'NaN', 'nan', 'NA', 'null'] and (not ele or not str(ele).isspace()):
             try:
                 cleaned_data.append(clean_float(ele))
             except Exception as e1:


### PR DESCRIPTION
This PR fixes the `AttributeError: 'int' object has no attribute 'isspace'` bug. Sometimes the column in `clean_init_and_date_data` method is of type int so the isspace can throw error, as in [this example](https://community.mindsdb.com/t/pandas-dataframe/92/2).