### PR TITLE
Manual (Sub)type setting

### DIFF
--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.18.2'
+__version__ = '1.18.3'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.18.3'
+__version__ = '1.18.4'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.18.0'
+__version__ = '1.18.1'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/libs/constants/mindsdb.py
+++ b/mindsdb/libs/constants/mindsdb.py
@@ -29,9 +29,6 @@ class DATA_SUBTYPES:
     VIDEO = 'Video'
     AUDIO = 'Audio'
 
-    # URL
-    # How do we detect the tpye here... maybe setup async download for random sample an stats ?
-
     # SEQUENTIAL
     TEXT = 'Text'
     ARRAY = 'Array' # Do we even want to support arrays / structs / nested ... etc ?
@@ -41,7 +38,6 @@ class DATA_TYPES:
     DATE = 'Date'
     CATEGORICAL = 'Categorical'
     FILE_PATH = 'File Path'
-    URL = 'Url'
     SEQUENTIAL = 'Sequential'
 
 class DATA_TYPES_SUBTYPES:
@@ -50,7 +46,6 @@ class DATA_TYPES_SUBTYPES:
         ,DATA_TYPES.DATE:(DATA_SUBTYPES.DATE, DATA_SUBTYPES.TIMESTAMP)
         ,DATA_TYPES.CATEGORICAL:(DATA_SUBTYPES.SINGLE, DATA_SUBTYPES.MULTIPLE)
         ,DATA_TYPES.FILE_PATH:(DATA_SUBTYPES.IMAGE, DATA_SUBTYPES.VIDEO, DATA_SUBTYPES.AUDIO)
-        ,DATA_TYPES.URL:()
         ,DATA_TYPES.SEQUENTIAL:(DATA_SUBTYPES.TEXT, DATA_SUBTYPES.ARRAY)
     }
 

--- a/mindsdb/libs/controllers/predictor.py
+++ b/mindsdb/libs/controllers/predictor.py
@@ -25,7 +25,6 @@ class Predictor:
         :param name: the namespace you want to identify this mind instance with
         :param root_folder: the folder where you want to store this mind or load from
         :param log_level: the desired log level
-
         """
 
         # initialize variables
@@ -567,6 +566,9 @@ class Predictor:
         light_transaction_metadata['force_categorical_encoding'] = []
         light_transaction_metadata['handle_text_as_categorical'] = False
 
+        light_transaction_metadata['data_types'] = {}
+        light_transaction_metadata['data_subtypes'] = {}
+
         Transaction(session=self, light_transaction_metadata=light_transaction_metadata, heavy_transaction_metadata=heavy_transaction_metadata, logger=self.log)
         return self.get_model_data(model_name=None, lmd=light_transaction_metadata)
 
@@ -680,7 +682,9 @@ class Predictor:
         light_transaction_metadata['weight_map'] = {}
         light_transaction_metadata['confusion_matrices'] = {}
         light_transaction_metadata['empty_columns'] = []
-
+        light_transaction_metadata['data_types'] = {}
+        light_transaction_metadata['data_subtypes'] = {}
+        
         light_transaction_metadata['equal_accuracy_for_all_output_categories'] = equal_accuracy_for_all_output_categories
         light_transaction_metadata['output_categories_importance_dictionary'] = output_categories_importance_dictionary if output_categories_importance_dictionary is not None else {}
 
@@ -723,7 +727,6 @@ class Predictor:
             light_transaction_metadata['use_selfaware_model'] = unstable_parameters_dict['use_selfaware_model']
         else:
             light_transaction_metadata['use_selfaware_model'] = True
-
 
         if rebuild_model is False:
             old_lmd = {}

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -171,7 +171,7 @@ class Transaction:
 
             self._call_phase_module(module_name='DataCleaner', stage=0)
             self.save_metadata()
-            
+
             self._call_phase_module(module_name='DataSplitter')
 
             self._call_phase_module(module_name='DataTransformer', input_data=self.input_data)

--- a/mindsdb/libs/data_types/data_source.py
+++ b/mindsdb/libs/data_types/data_source.py
@@ -6,16 +6,28 @@ class DataSource:
 
     def __init__(self, *args, **kwargs):
         self.log = log
+        self.data_types = {}
+        self.data_subtypes = {}
         df, col_map = self._setup(*args, **kwargs)
-        self.setDF(df, col_map)
+        self.setDF(df, col_map, **kwargs)
         self._cleanup()
 
-    def _setup(self, df, data_subtypes=None):
+    def _setup(self, df):
         col_map = {}
 
         for col in df.columns:
             col_map[col] = col
 
+        return df, col_map
+
+    def _cleanup(self):
+        pass
+
+    @property
+    def df(self):
+        return self._df
+
+    def setDF(self, df, col_map, data_subtypes=None):
         if data_subtypes is not None:
             self.data_types = {}
             for col in data_subtypes:
@@ -28,17 +40,6 @@ class DataSource:
                 for col_type in DATA_TYPES_SUBTYPES.subtypes:
                     if col_subtype in DATA_TYPES_SUBTYPES.subtypes[col_type]:
                         self.data_types[col] = col_type
-
-        return df, col_map
-
-    def _cleanup(self):
-        pass
-
-    @property
-    def df(self):
-        return self._df
-
-    def setDF(self, df, col_map):
         self._df = df
         self._col_map = col_map
 

--- a/mindsdb/libs/data_types/data_source.py
+++ b/mindsdb/libs/data_types/data_source.py
@@ -1,4 +1,6 @@
 from mindsdb.libs.data_types.mindsdb_logger import log
+from mindsdb.libs.constants.mindsdb import DATA_TYPES_SUBTYPES
+
 
 class DataSource:
 
@@ -8,10 +10,25 @@ class DataSource:
         self.setDF(df, col_map)
         self._cleanup()
 
-    def _setup(self, df):
+    def _setup(self, df, data_subtypes=None):
         col_map = {}
+
         for col in df.columns:
             col_map[col] = col
+
+        if data_subtypes is not None:
+            self.data_types = {}
+            for col in data_subtypes:
+                if col not in col_map:
+                    del data_subtypes[col]
+                    log.warning(f'Column {col} not present in your data, ignoring the "{data_subtypes[col]}" subtype you specified for it')
+
+            self.data_subtypes = data_subtypes
+            for col_subtype in self.data_subtypes:
+                for col_type in DATA_TYPES_SUBTYPES.subtypes:
+                    if col_subtype in DATA_TYPES_SUBTYPES.subtypes[col_type]:
+                        self.data_types[col] = col_type
+
         return df, col_map
 
     def _cleanup(self):

--- a/mindsdb/libs/data_types/data_source.py
+++ b/mindsdb/libs/data_types/data_source.py
@@ -4,15 +4,15 @@ from mindsdb.libs.constants.mindsdb import DATA_TYPES_SUBTYPES
 
 class DataSource:
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs, data_subtypes=None):
         self.log = log
         self.data_types = {}
         self.data_subtypes = {}
         df, col_map = self._setup(*args, **kwargs)
-        self.setDF(df, col_map, **kwargs)
+        self.setDF(df, col_map, data_subtypes)
         self._cleanup()
 
-    def _setup(self, df):
+    def _setup(self, df, **kwargs):
         col_map = {}
 
         for col in df.columns:
@@ -27,7 +27,7 @@ class DataSource:
     def df(self):
         return self._df
 
-    def setDF(self, df, col_map, data_subtypes=None):
+    def setDF(self, df, col_map, data_subtypes):
         if data_subtypes is not None:
             self.data_types = {}
             for col in data_subtypes:

--- a/mindsdb/libs/data_types/data_source.py
+++ b/mindsdb/libs/data_types/data_source.py
@@ -29,7 +29,6 @@ class DataSource:
 
     def set_subtypes(self, data_subtypes):
         if data_subtypes is not None:
-            self.data_types = {}
             for col in data_subtypes:
                 if col not in self._col_map:
                     del data_subtypes[col]

--- a/mindsdb/libs/data_types/data_source.py
+++ b/mindsdb/libs/data_types/data_source.py
@@ -36,7 +36,8 @@ class DataSource:
                     log.warning(f'Column {col} not present in your data, ignoring the "{data_subtypes[col]}" subtype you specified for it')
 
             self.data_subtypes = data_subtypes
-            for col_subtype in self.data_subtypes:
+            for col in self.data_subtypes:
+                col_subtype = self.data_subtypes[col]
                 if col_subtype not in [getattr(DATA_SUBTYPES,x) for x in DATA_SUBTYPES.__dict__ if '__' not in x]:
                     raise Exception(f'Invalid data subtype: {col_subtype}')
 

--- a/mindsdb/libs/data_types/data_source.py
+++ b/mindsdb/libs/data_types/data_source.py
@@ -1,15 +1,15 @@
 from mindsdb.libs.data_types.mindsdb_logger import log
-from mindsdb.libs.constants.mindsdb import DATA_TYPES_SUBTYPES
+from mindsdb.libs.constants.mindsdb import DATA_TYPES_SUBTYPES, DATA_TYPES, DATA_SUBTYPES
 
 
 class DataSource:
 
-    def __init__(self, *args, **kwargs, data_subtypes=None):
+    def __init__(self, *args, **kwargs):
         self.log = log
         self.data_types = {}
         self.data_subtypes = {}
         df, col_map = self._setup(*args, **kwargs)
-        self.setDF(df, col_map, data_subtypes)
+        self._set_df(df, col_map)
         self._cleanup()
 
     def _setup(self, df, **kwargs):
@@ -27,19 +27,25 @@ class DataSource:
     def df(self):
         return self._df
 
-    def setDF(self, df, col_map, data_subtypes):
+    def set_subtypes(data_subtypes):
         if data_subtypes is not None:
             self.data_types = {}
             for col in data_subtypes:
-                if col not in col_map:
+                if col not in self._col_map:
                     del data_subtypes[col]
                     log.warning(f'Column {col} not present in your data, ignoring the "{data_subtypes[col]}" subtype you specified for it')
 
             self.data_subtypes = data_subtypes
             for col_subtype in self.data_subtypes:
+                if col_subtype not in [getattr(DATA_SUBTYPES,x) for x in DATA_SUBTYPES.__dict__ if '__' not in x]:
+                    raise Exception(f'Invalid data subtype: {col_subtype}')
+
                 for col_type in DATA_TYPES_SUBTYPES.subtypes:
                     if col_subtype in DATA_TYPES_SUBTYPES.subtypes[col_type]:
                         self.data_types[col] = col_type
+
+    def _set_df(self, df, col_map):
+
         self._df = df
         self._col_map = col_map
 

--- a/mindsdb/libs/data_types/data_source.py
+++ b/mindsdb/libs/data_types/data_source.py
@@ -27,7 +27,7 @@ class DataSource:
     def df(self):
         return self._df
 
-    def set_subtypes(data_subtypes):
+    def set_subtypes(self, data_subtypes):
         if data_subtypes is not None:
             self.data_types = {}
             for col in data_subtypes:

--- a/mindsdb/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb/libs/phases/data_extractor/data_extractor.py
@@ -131,13 +131,10 @@ class DataExtractor(BaseModule):
                     return
 
     def _set_user_data_subtypes(self):
-        if 'from_data' in self.transaction.lmd:
-            if len(self.transaction.lmd['from_data'].data_subtypes) > 0:
-                for col in self.transaction.lmd['from_data'].data_subtypes:
-                    self.transaction.lmd['data_types'][col] = self.transaction.lmd['from_data'].data_types[col]
-                    self.transaction.lmd['data_subtypes'][col] = self.transaction.lmd['from_data'].data_subtypes[col]
-
-
+        if 'from_data' in self.transaction.hmd:
+            for col in self.transaction.hmd['from_data'].data_subtypes:
+                self.transaction.lmd['data_types'][col] = self.transaction.hmd['from_data'].data_types[col]
+                self.transaction.lmd['data_subtypes'][col] = self.transaction.hmd['from_data'].data_subtypes[col]
 
     def run(self):
         # --- Dataset gets randomized or sorted (if timeseries) --- #
@@ -149,6 +146,8 @@ class DataExtractor(BaseModule):
         self.transaction.lmd['columns'] = self.transaction.input_data.columns
         self.transaction.input_data.data_frame = result
         # --- Some information about the dataset gets transplanted into transaction level variables --- #
+
+        self._set_user_data_subtypes()
 
         # --- Some preliminary dataset integrity checks --- #
         self._validate_input_data_integrity()

--- a/mindsdb/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb/libs/phases/data_extractor/data_extractor.py
@@ -131,7 +131,7 @@ class DataExtractor(BaseModule):
                     return
 
     def _set_user_data_subtypes(self):
-        if 'from_data' in self.transaction.hmd:
+        if 'from_data' in self.transaction.hmd and self.transaction.hmd['from_data'] is not None:
             for col in self.transaction.hmd['from_data'].data_subtypes:
                 self.transaction.lmd['data_types'][col] = self.transaction.hmd['from_data'].data_types[col]
                 self.transaction.lmd['data_subtypes'][col] = self.transaction.hmd['from_data'].data_subtypes[col]

--- a/mindsdb/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb/libs/phases/data_extractor/data_extractor.py
@@ -130,6 +130,15 @@ class DataExtractor(BaseModule):
                     raise ValueError(err)
                     return
 
+    def _set_user_data_subtypes(self):
+        if 'from_data' in self.transaction.lmd:
+            if len(self.transaction.lmd['from_data'].data_subtypes) > 0:
+                for col in self.transaction.lmd['from_data'].data_subtypes:
+                    self.transaction.lmd['data_types'][col] = self.transaction.lmd['from_data'].data_types[col]
+                    self.transaction.lmd['data_subtypes'][col] = self.transaction.lmd['from_data'].data_subtypes[col]
+
+
+
     def run(self):
         # --- Dataset gets randomized or sorted (if timeseries) --- #
         result = self._get_prepared_input_df()

--- a/mindsdb/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb/libs/phases/data_extractor/data_extractor.py
@@ -114,12 +114,6 @@ class DataExtractor(BaseModule):
             self.log.error(error)
             raise ValueError(error)
 
-        # make sure that the column we are trying to predict is on the input_data
-        # else fail, because we cannot predict data we dont have
-
-        #if self.transaction.lmd['model_is_time_series'] or self.transaction.lmd['type'] == TRANSACTION_LEARN:
-        # ^ How did this even make sense before ? Why did it not crash tests ? Pressumably because the predict col was loaded into `input_data` as an empty col
-
         if self.transaction.lmd['type'] == TRANSACTION_LEARN:
             for col_target in self.transaction.lmd['predict_columns']:
                 if col_target not in self.transaction.input_data.columns:

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -133,6 +133,14 @@ class StatsGenerator(BaseModule):
         subtype_dist = {}
         additional_info = {'other_potential_subtypes': [], 'other_potential_types': []}
 
+
+        if col_name in self.transaction.lmd['data_subtypes']:
+            curr_data_type = self.transaction.lmd['data_types'][col_name]
+            curr_data_subtype = self.transaction.lmd['data_subtypes'][col_name]
+            type_dist[curr_data_type] = len(data)
+            subtype_dist[curr_data_subtype] = len(data)
+            return curr_data_type, curr_data_subtype, type_dist, subtype_dist, additional_info, 'Column ok'
+
         # calculate type_dist
         if len(data) < 1:
             self.log.warning(f'Column {col_name} has no data in it. Please remove {col_name} from the training file or fill in some of the values !')

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -139,6 +139,7 @@ class StatsGenerator(BaseModule):
             curr_data_subtype = self.transaction.lmd['data_subtypes'][col_name]
             type_dist[curr_data_type] = len(data)
             subtype_dist[curr_data_subtype] = len(data)
+            self.log.info(f'Manually setting the types for column {col_name} to {curr_data_type}->{curr_data_subtype}')
             return curr_data_type, curr_data_subtype, type_dist, subtype_dist, additional_info, 'Column ok'
 
         # calculate type_dist

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -133,7 +133,8 @@ class StatsGenerator(BaseModule):
         subtype_dist = {}
         additional_info = {'other_potential_subtypes': [], 'other_potential_types': []}
 
-
+        print(self.transaction.lmd['data_subtypes'])
+        exit()
         if col_name in self.transaction.lmd['data_subtypes']:
             curr_data_type = self.transaction.lmd['data_types'][col_name]
             curr_data_subtype = self.transaction.lmd['data_subtypes'][col_name]

--- a/mindsdb/libs/phases/stats_generator/stats_generator.py
+++ b/mindsdb/libs/phases/stats_generator/stats_generator.py
@@ -133,8 +133,6 @@ class StatsGenerator(BaseModule):
         subtype_dist = {}
         additional_info = {'other_potential_subtypes': [], 'other_potential_types': []}
 
-        print(self.transaction.lmd['data_subtypes'])
-        exit()
         if col_name in self.transaction.lmd['data_subtypes']:
             curr_data_type = self.transaction.lmd['data_types'][col_name]
             curr_data_subtype = self.transaction.lmd['data_subtypes'][col_name]

--- a/tests/ci_tests/tests.py
+++ b/tests/ci_tests/tests.py
@@ -58,11 +58,8 @@ def basic_test(backend='lightwood',use_gpu=True, run_extra=False, IS_CI_TEST=Fal
             # Skip data source tests since installing dependencies is annoying
             # @TODO: Figure out a way to make travis install required dependencies on osx
 
-            ctn = False
-            for name in ['all_data_sources', 'custom_model']:
-                if name in py_file:
-                    ctn = True
-            if ctn:
+            if any(x in py_file for x in ['all_data_sources', 'custom_model']):
+                print(py_file)
                 continue
 
             code = os.system(f'python3 ../functional_testing/{py_file}')

--- a/tests/ci_tests/tests.py
+++ b/tests/ci_tests/tests.py
@@ -59,7 +59,6 @@ def basic_test(backend='lightwood',use_gpu=True, run_extra=False, IS_CI_TEST=Fal
             # @TODO: Figure out a way to make travis install required dependencies on osx
 
             if any(x in py_file for x in ['all_data_sources', 'custom_model']):
-                print(py_file)
                 continue
 
             code = os.system(f'python3 ../functional_testing/{py_file}')

--- a/tests/functional_testing/data_source_setting.py
+++ b/tests/functional_testing/data_source_setting.py
@@ -1,1 +1,8 @@
-from mindsdb.libs.helpers.multi_data_source import getDS
+from mindsdb.libs.data_sources.file_ds import FileDS
+import mindsdb
+
+
+data_source = FileDS('https://github.com/mindsdb/mindsdb-examples/blob/master/benchmarks/german_credit_data/processed_data/test.csv', data_subtypes={})
+
+analysis = mindsdb.analyse_dataset(data_source)
+print(analysis['data_analysis_v2'])

--- a/tests/functional_testing/data_source_setting.py
+++ b/tests/functional_testing/data_source_setting.py
@@ -17,14 +17,13 @@ a2 = analysis_mod['data_analysis_v2']
 assert(len(a1) == len(a2))
 assert(a1['over_draft']['typing']['data_type'] == a2['over_draft']['typing']['data_type'])
 
-print(a2['Average_Credit_Balance']['typing']['data_subtype'], a2['Average_Credit_Balance']['typing']['data_type'])
 assert(a1['credit_usage']['typing']['data_type'] == a2['credit_usage']['typing']['data_type'])
 assert(a1['credit_usage']['typing']['data_subtype'] != a2['credit_usage']['typing']['data_subtype'])
 assert(a2['credit_usage']['typing']['data_subtype'] == DATA_SUBTYPES.INT)
 
 assert(a1['Average_Credit_Balance']['typing']['data_type'] != a2['Average_Credit_Balance']['typing']['data_type'])
 assert(a1['Average_Credit_Balance']['typing']['data_subtype'] != a2['Average_Credit_Balance']['typing']['data_subtype'])
-assert(a2['Average_Credit_Balance']['typing']['data_subtype'] == DATA_SUBTYPES.Text)
+assert(a2['Average_Credit_Balance']['typing']['data_subtype'] == DATA_SUBTYPES.TEXT)
 assert(a2['Average_Credit_Balance']['typing']['data_type'] == DATA_TYPES.SEQUENTIAL)
 
 assert(a1['existing_credits']['typing']['data_type'] == a2['existing_credits']['typing']['data_type'])

--- a/tests/functional_testing/data_source_setting.py
+++ b/tests/functional_testing/data_source_setting.py
@@ -1,8 +1,10 @@
 from mindsdb.libs.data_sources.file_ds import FileDS
+
+
+
+data_source = FileDS('https://raw.githubusercontent.com/mindsdb/mindsdb-examples/master/benchmarks/german_credit_data/processed_data/test.csv')
+data_source.set_subtypes({})
+
 import mindsdb
-
-
-data_source = FileDS('https://github.com/mindsdb/mindsdb-examples/blob/master/benchmarks/german_credit_data/processed_data/test.csv', data_subtypes={})
-
 analysis = mindsdb.analyse_dataset(data_source)
 print(analysis['data_analysis_v2'])

--- a/tests/functional_testing/data_source_setting.py
+++ b/tests/functional_testing/data_source_setting.py
@@ -9,7 +9,7 @@ data_source_mod = FileDS('https://raw.githubusercontent.com/mindsdb/mindsdb-exam
 data_source_mod.set_subtypes({'credit_usage': 'Int', 'Average_Credit_Balance': 'Text','existing_credits': 'Binary Category'})
 
 import mindsdb
-analysis = mindsdb.Predictor('analyzer1').analyse_dataset(data_source)
+#analysis = mindsdb.Predictor('analyzer1').analyse_dataset(data_source)
 analysis_mod = mindsdb.Predictor('analyzer2').analyse_dataset(data_source_mod)
 
 a1 = analysis['data_analysis_v2']
@@ -17,6 +17,7 @@ a2 = analysis_mod['data_analysis_v2']
 assert(len(a1) == len(a2))
 assert(a1['over_draft']['typing']['data_type'] == a2['over_draft']['typing']['data_type'])
 
+print(a2['Average_Credit_Balance']['typing']['data_subtype'], a2['Average_Credit_Balance']['typing']['data_type'])
 assert(a1['credit_usage']['typing']['data_type'] == a2['credit_usage']['typing']['data_type'])
 assert(a1['credit_usage']['typing']['data_subtype'] != a2['credit_usage']['typing']['data_subtype'])
 assert(a2['credit_usage']['typing']['data_subtype'] == DATA_SUBTYPES.INT)

--- a/tests/functional_testing/data_source_setting.py
+++ b/tests/functional_testing/data_source_setting.py
@@ -6,7 +6,7 @@ data_source = FileDS('https://raw.githubusercontent.com/mindsdb/mindsdb-examples
 data_source.set_subtypes({})
 
 data_source_mod = FileDS('https://raw.githubusercontent.com/mindsdb/mindsdb-examples/master/benchmarks/german_credit_data/processed_data/test.csv')
-data_source_mod.set_subtypes({'credit_usage': 'Int', 'Average_Credit_Balance': 'Text','existing credits': 'Binary Category'})
+data_source_mod.set_subtypes({'credit_usage': 'Int', 'Average_Credit_Balance': 'Text','existing_credits': 'Binary Category'})
 
 import mindsdb
 analysis = mindsdb.Predictor('analyzer1').analyse_dataset(data_source)
@@ -26,6 +26,6 @@ assert(a1['Average_Credit_Balance']['typing']['data_subtype'] != a2['Average_Cre
 assert(a2['Average_Credit_Balance']['typing']['data_subtype'] == DATA_SUBTYPES.Text)
 assert(a2['Average_Credit_Balance']['typing']['data_type'] == DATA_TYPES.SEQUENTIAL)
 
-assert(a1['existing credits']['typing']['data_type'] == a2['existing credits']['typing']['data_type'])
-assert(a1['existing credits']['typing']['data_subtype'] != a2['existing credits']['typing']['data_subtype'])
-assert(a2['existing credits']['typing']['data_subtype'] == DATA_SUBTYPES.SINGLE)
+assert(a1['existing_credits']['typing']['data_type'] == a2['existing_credits']['typing']['data_type'])
+assert(a1['existing_credits']['typing']['data_subtype'] != a2['existing_credits']['typing']['data_subtype'])
+assert(a2['existing_credits']['typing']['data_subtype'] == DATA_SUBTYPES.SINGLE)

--- a/tests/functional_testing/data_source_setting.py
+++ b/tests/functional_testing/data_source_setting.py
@@ -1,10 +1,31 @@
 from mindsdb.libs.data_sources.file_ds import FileDS
-
+from mindsdb.libs.constants.mindsdb import DATA_TYPES, DATA_SUBTYPES
 
 
 data_source = FileDS('https://raw.githubusercontent.com/mindsdb/mindsdb-examples/master/benchmarks/german_credit_data/processed_data/test.csv')
 data_source.set_subtypes({})
 
+data_source_mod = FileDS('https://raw.githubusercontent.com/mindsdb/mindsdb-examples/master/benchmarks/german_credit_data/processed_data/test.csv')
+data_source_mod.set_subtypes({'credit_usage': 'Int', 'Average_Credit_Balance': 'Text','existing credits': 'Binary Category'})
+
 import mindsdb
-analysis = mindsdb.analyse_dataset(data_source)
-print(analysis['data_analysis_v2'])
+analysis = mindsdb.Predictor('analyzer1').analyse_dataset(data_source)
+analysis_mod = mindsdb.Predictor('analyzer2').analyse_dataset(data_source_mod)
+
+a1 = analysis['data_analysis_v2']
+a2 = analysis_mod['data_analysis_v2']
+assert(len(a1) == len(a2))
+assert(a1['over_draft']['typing']['data_type'] == a2['over_draft']['typing']['data_type'])
+
+assert(a1['credit_usage']['typing']['data_type'] == a2['credit_usage']['typing']['data_type'])
+assert(a1['credit_usage']['typing']['data_subtype'] != a2['credit_usage']['typing']['data_subtype'])
+assert(a2['credit_usage']['typing']['data_subtype'] == DATA_SUBTYPES.INT)
+
+assert(a1['Average_Credit_Balance']['typing']['data_type'] != a2['Average_Credit_Balance']['typing']['data_type'])
+assert(a1['Average_Credit_Balance']['typing']['data_subtype'] != a2['Average_Credit_Balance']['typing']['data_subtype'])
+assert(a2['Average_Credit_Balance']['typing']['data_subtype'] == DATA_SUBTYPES.Text)
+assert(a2['Average_Credit_Balance']['typing']['data_type'] == DATA_TYPES.SEQUENTIAL)
+
+assert(a1['existing credits']['typing']['data_type'] == a2['existing credits']['typing']['data_type'])
+assert(a1['existing credits']['typing']['data_subtype'] != a2['existing credits']['typing']['data_subtype'])
+assert(a2['existing credits']['typing']['data_subtype'] == DATA_SUBTYPES.SINGLE)

--- a/tests/functional_testing/data_source_setting.py
+++ b/tests/functional_testing/data_source_setting.py
@@ -9,7 +9,7 @@ data_source_mod = FileDS('https://raw.githubusercontent.com/mindsdb/mindsdb-exam
 data_source_mod.set_subtypes({'credit_usage': 'Int', 'Average_Credit_Balance': 'Text','existing_credits': 'Binary Category'})
 
 import mindsdb
-#analysis = mindsdb.Predictor('analyzer1').analyse_dataset(data_source)
+analysis = mindsdb.Predictor('analyzer1').analyse_dataset(data_source)
 analysis_mod = mindsdb.Predictor('analyzer2').analyse_dataset(data_source_mod)
 
 a1 = analysis['data_analysis_v2']

--- a/tests/functional_testing/data_source_setting.py
+++ b/tests/functional_testing/data_source_setting.py
@@ -1,0 +1,1 @@
+from mindsdb.libs.helpers.multi_data_source import getDS


### PR DESCRIPTION
* Added a method to the `DataSource` superclass that all datasource inherit to allow for manual setting of the data subtypes of a certain column. We only allow subtype setting (instead of typesetting or the ability to set either/or type and subtype) because:

a) We'd have to change the `StatsGenerator` quite a lot to find a subtype under specific type constraints and this proved too difficult
b) Setting the subtype also dictates the data type, so setting a subtype is enough to set both
c) I don't see many cases in which a user would want and know what type to set for his data better than mindsdb but not what subtype.

* Made mindsdb able to use said types and subtypes, when specified, instead of those inferred by the `StatsGenerator` (the type inference step is skipped for columns where the subtype is specified)
* Added a decent test suite to check if this works.

Example usage:

```
data_source_mod = FileDS('https://raw.githubusercontent.com/mindsdb/mindsdb-examples/master/benchmarks/german_credit_data/processed_data/test.csv')
data_source_mod.set_subtypes({'credit_usage': 'Int', 'Average_Credit_Balance': 'Text','existing_credits': 'Binary Category'})
```

This resolves #451 