### PR TITLE
Clickhouse datasource: fixed query endings with semicolon

### DIFF
--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.18.1'
+__version__ = '1.18.3'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/libs/data_sources/clickhouse_ds.py
+++ b/mindsdb/libs/data_sources/clickhouse_ds.py
@@ -14,7 +14,7 @@ class ClickhouseDS(DataSource):
             log.error(err_msg)
             raise Exception(err_msg)
         
-        query = f'{query} FORMAT JSON'
+        query = f'{query.rstrip(" ;")} FORMAT JSON'
         log.info(f'Getting data via the query: "{query}""')
 
         params = {'user': user}


### PR DESCRIPTION
When creating ClickHouse DS from query ended with semicolon is error raised with unclear message.