### PR TITLE
fix-478

### DIFF
--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.25.0'
+__version__ = '1.25.1'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/libs/phases/data_analyzer/data_analyzer.py
+++ b/mindsdb/libs/phases/data_analyzer/data_analyzer.py
@@ -60,7 +60,7 @@ def get_text_histogram(data):
         and the number of times each word appears in the dataset """
     words = []
     for cell in data:
-        words += splitRecursive(cell, WORD_SEPARATORS)
+        words.extend(splitRecursive(cell, WORD_SEPARATORS))
 
     hist = get_hist(words)
     return hist
@@ -275,10 +275,11 @@ class DataAnalyzer(BaseModule):
             stats[col_name]['empty_cells'] = stats_v2[col_name]['empty']['empty_cells']
             stats[col_name]['empty_percentage'] = stats_v2[col_name]['empty']['empty_percentage']
 
-            hist_data = col_data
             if data_type == DATA_TYPES.CATEGORICAL:
                 hist_data = input_data.data_frame[col_name]
                 stats_v2[col_name]['unique'] = get_uniq_values_report(input_data.data_frame[col_name])
+            else:
+                hist_data = col_data
 
             histogram, percentage_buckets = get_histogram(hist_data,
                                                           data_type=data_type,
@@ -296,7 +297,7 @@ class DataAnalyzer(BaseModule):
                 if biased_buckets:
                     stats_v2[col_name]['bias']['biased_buckets'] = biased_buckets
                 if S < 0.8:
-                    if data_type in (DATA_TYPES.CATEGORICAL):
+                    if data_type == DATA_TYPES.CATEGORICAL:
                         warning_str =  "You may to check if some categories occur too often to too little in this columns."
                     else:
                         warning_str = "You may want to check if you see something suspicious on the right-hand-side graph."

--- a/mindsdb/libs/phases/data_extractor/data_extractor.py
+++ b/mindsdb/libs/phases/data_extractor/data_extractor.py
@@ -96,6 +96,11 @@ class DataExtractor(BaseModule):
             return None
 
         df = self._apply_sort_conditions_to_df(df)
+
+        # Mutable lists -> immutable tuples
+        # (lists caused TypeError: uhashable type 'list' in TypeDeductor phase)
+        df = df.applymap(lambda cell: tuple(cell) if isinstance(cell, list) else cell)
+
         groups = df.columns.to_series().groupby(df.dtypes).groups
 
         if np.dtype('datetime64[ns]') in groups:

--- a/mindsdb/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb/libs/phases/type_deductor/type_deductor.py
@@ -23,7 +23,7 @@ def get_file_subtype_if_exists(path):
             return DATA_SUBTYPES.AUDIO
     except Exception:
         # Not a file or file doesn't exist
-        pass
+        return None
 
 
 def get_number_subtype(string):

--- a/mindsdb/libs/phases/type_deductor/type_deductor.py
+++ b/mindsdb/libs/phases/type_deductor/type_deductor.py
@@ -128,7 +128,7 @@ class TypeDeductor(BaseModule):
                          type_check_date,
                          type_check_sequence,
                          type_check_file]
-        for element in data:
+        for element in map(str, data):
             data_type_guess, subtype_guess = None, None
             for type_checker in type_checkers:
                 data_type_guess, subtype_guess = type_checker(element)


### PR DESCRIPTION
Resolves #478 

Some of `type_checker` functions assume input value to be of type `str`, so data is mapped to str now.

All values of input dataframe of type `list` are converted to tuples in `DataExtractor` phase. That solves issue when `DataAnalyzer` tried to get a unique set of column values, but values of type `list` are not hashable and it raised `TypeError`.