### PR TITLE
Add warnings that TransactionOutputRow.explain() is deprecated

### DIFF
--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'MindsDB'
 __package_name__ = 'mindsdb'
-__version__ = '1.27.0'
+__version__ = '1.27.1'
 __description__ = "MindsDB's goal is to make it very simple for developers to use the power of artificial neural networks in their projects."
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb/libs/controllers/transaction.py
+++ b/mindsdb/libs/controllers/transaction.py
@@ -298,7 +298,6 @@ class Transaction:
                 for i, nulled_col_name in enumerate(nulled_out_columns):
                     nulled_out_predicted_value = nulled_out_predictions[i].explanation[predicted_col]['predicted_value']
                     nulled_confidence = nulled_out_predictions[i].explanation[predicted_col]['confidence']
-                    print(actual_confidence - nulled_confidence, actual_confidence, nulled_confidence)
                     confidence_variation = actual_confidence - nulled_confidence
 
                     input_confidence[predicted_col][nulled_col_name] = round(confidence_variation,3)

--- a/mindsdb/libs/data_types/transaction_output_row.py
+++ b/mindsdb/libs/data_types/transaction_output_row.py
@@ -1,3 +1,4 @@
+import logging
 from mindsdb.libs.helpers.explain_prediction import explain_prediction, get_important_missing_cols
 from mindsdb.libs.constants.mindsdb import *
 
@@ -64,6 +65,8 @@ class TransactionOutputRow:
         return answers
 
     def explain(self):
+        logging.warning('TransactionOutputRow.explain() is outdated, please use the TransactionOutputRow.explanation property.')
+
         answers = {}
         for pred_col in self.predict_columns:
             answers[pred_col] = []
@@ -137,7 +140,3 @@ class TransactionOutputRow:
 
     def raw_predictions(self):
         return {key: self.data[key][self.row_index] for key in list(self.data.keys()) if key.startswith('model_')}
-
-    @property
-    def _predicted_values(self):
-        return {pred_col: evaluations[pred_col][self.row_index].predicted_value for pred_col in evaluations}

--- a/mindsdb/libs/helpers/explain_prediction.py
+++ b/mindsdb/libs/helpers/explain_prediction.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 from mindsdb.libs.constants.mindsdb import *
 from mindsdb.libs.helpers.general_helpers import value_isnan
@@ -24,12 +25,13 @@ def explain_prediction(lmd, prediction_row, confidence, pred_col):
         :param prediction_row: The row that was predicted by the model backend and processed by mindsdb
         :return: A, hopefully human readable, string containing the explanation
     '''
+
     if lmd['column_importances'] is None or len(lmd['column_importances']) < 2:
         important_cols = [col for col in lmd['columns'] if col not in lmd['predict_columns']]
         useless_cols = []
     else:
-        top_20_val = np.percentile(list(lmd['column_importances'].values()),80)
-        bottom_20_val = np.percentile(list(lmd['column_importances'].values()),20)
+        top_20_val = np.percentile(list(lmd['column_importances'].values()), 80)
+        bottom_20_val = np.percentile(list(lmd['column_importances'].values()), 20)
 
         important_cols = [col for col in lmd['column_importances'] if lmd['column_importances'][col] >= top_20_val]
         useless_cols = [col for col in lmd['column_importances'] if lmd['column_importances'][col] <= bottom_20_val]
@@ -63,16 +65,6 @@ def explain_prediction(lmd, prediction_row, confidence, pred_col):
         percentage_bucket_percentage = round(100*bucket_occurances/total_occuraces, 2)
 
         column_confidence = confidence * 100
-
-        confidence_str = 'very confident'
-        if confidence < 0.80:
-            confidence_str = 'confident'
-        if confidence < 0.60:
-            confidence_str = 'somewhat confident'
-        if confidence < 0.40:
-            confidence_str = 'not very confident'
-        if confidence < 0.20:
-            confidence_str = 'not confident'
 
         if percentage_bucket_percentage < 2:
             column_explanation = f'A similar value for the predicted column {pred_col} occurs rarely in your dataset'

--- a/tests/ci_tests/tests.py
+++ b/tests/ci_tests/tests.py
@@ -87,7 +87,7 @@ def basic_test(backend='lightwood', use_gpu=True, IS_CI_TEST=False):
     print(type(prediction[0]['rental_price_confidence']))
 
     print('\n\n========================\n\n')
-    print(prediction[0].explain())
+    print(prediction[0].explain()) # Warning: Deprecated explainer
     print(prediction[0].explanation)
     print(prediction[0].raw_predictions())
     print('\n\n')

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -101,10 +101,10 @@ class TestPredictor:
 
         result = mdb.predict(when={"numeric_x": 10, 'categorical_x': 1})
         explanation_new = result[0].explanation['numeric_y']
-        assert explanation_new['predicted_value']
+        assert explanation_new['predicted_value'] is not None
         assert explanation_new['confidence_interval']
         assert explanation_new['confidence'] >= 0.8
-        assert not explanation_new['important_missing_information']
+        assert explanation_new['important_missing_information'] == []
         assert explanation_new['prediction_quality'] == 'very confident'
 
 

--- a/tests/unit_tests/libs/controllers/test_predictor.py
+++ b/tests/unit_tests/libs/controllers/test_predictor.py
@@ -85,19 +85,28 @@ class TestPredictor:
     def test_explain_prediction(self):
         mdb = Predictor(name='test_home_rentals')
 
+        n_points = 100
+        input_dataframe = pd.DataFrame({
+            'numeric_x': list(range(n_points)),
+            'categorical_x': [int(x % 2 == 0) for x in range(n_points)],
+        }, index=list(range(n_points)))
+
+        input_dataframe['numeric_y'] = input_dataframe.numeric_x + 2*input_dataframe.categorical_x
+
         mdb.learn(
-            from_data="https://s3.eu-west-2.amazonaws.com/mindsdb-example-data/home_rentals.csv",
-            to_predict='rental_price',
+            from_data=input_dataframe,
+            to_predict='numeric_y',
             stop_training_in_x_seconds=1
         )
 
-        result = mdb.predict(when={"number_of_rooms": 2, "sqft": 1384})
-        explanation = result[0].explain()['rental_price'][0]
-        assert explanation['value']
-        assert explanation['confidence']
-        assert explanation['explanation']
-        assert explanation['simple']
-        assert explanation['model_result']
+        result = mdb.predict(when={"numeric_x": 10, 'categorical_x': 1})
+        explanation_new = result[0].explanation['numeric_y']
+        assert explanation_new['predicted_value']
+        assert explanation_new['confidence_interval']
+        assert explanation_new['confidence'] >= 0.8
+        assert not explanation_new['important_missing_information']
+        assert explanation_new['prediction_quality'] == 'very confident'
+
 
     @pytest.mark.skip(reason="Causes error in probabilistic validator")
     @pytest.mark.slow


### PR DESCRIPTION
Makes it harder to be confused by the old explainer, see:
https://github.com/mindsdb/mindsdb/issues/510
