### PR TITLE
simplify installer, add windows-specific paths for mindsdb data

### DIFF
--- a/distributions/windows/install.py
+++ b/distributions/windows/install.py
@@ -62,10 +62,12 @@ os.system('{} {} --no-warn-script-location'.format(PYTHON_EXE, get_pip_filename)
 os.remove(get_pip_filename)
 
 os.system('{} -m pip install torch==1.5.0+cpu torchvision==0.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html --no-warn-script-location'.format(PYTHON_EXE))
-os.system('{} -m pip install {} --no-warn-script-location'.format(PYTHON_EXE, lib))
+os.system('{} -m pip install mindsdb --no-warn-script-location'.format(PYTHON_EXE))
 
 print('generating run_server.bat')
 with open(os.path.join(INSTALL_DIR, 'run_server.bat'), 'w') as f:
-    lines = ['{} -m pip install {} --upgrade mindsdb --no-warn-script-location']
-    lines.append('{} -m mindsdb'.format(PYTHON_EXE))
+    lines = [
+        '{} -m pip install mindsdb --upgrade --no-warn-script-location'.format(PYTHON_EXE),
+        '{} -m mindsdb'.format(PYTHON_EXE)
+    ]
     f.write('\n'.join(lines))

--- a/distributions/windows/install.py
+++ b/distributions/windows/install.py
@@ -9,8 +9,8 @@ PY_EMBED_URL = 'https://www.python.org/ftp/python/3.7.4/python-3.7.4-embed-amd64
 GET_PIP_URL = 'https://bootstrap.pypa.io/get-pip.py'
 VC_REDIST_URL = 'https://aka.ms/vs/16/release/vc_redist.x64.exe'
 
-if len(sys.argv) < 3:
-    sys.exit('Usage: ./{} install_dir storage_dir'.format(__file__.split('.')[0]))
+if len(sys.argv) < 2:
+    sys.exit('Usage: ./{} install_dir'.format(__file__.split('.')[0]))
 
 
 def make_dir(d):
@@ -19,11 +19,9 @@ def make_dir(d):
 
 
 INSTALL_DIR = os.path.join(os.path.abspath(sys.argv[1]), 'mindsdb')
-STORAGE_DIR = os.path.join(os.path.abspath(sys.argv[2]), 'mindsdb_storage')
 PYTHON_DIR = os.path.join(INSTALL_DIR, 'python')
 
 make_dir(INSTALL_DIR)
-make_dir(STORAGE_DIR)
 make_dir(PYTHON_DIR)
 
 PTH_PATH = os.path.join(PYTHON_DIR, 'python37._pth')
@@ -63,16 +61,11 @@ get_pip_filename = download_file(GET_PIP_URL)
 os.system('{} {} --no-warn-script-location'.format(PYTHON_EXE, get_pip_filename))
 os.remove(get_pip_filename)
 
-LIBS = ['lightwood', 'mindsdb_native', 'mindsdb']
-
 os.system('{} -m pip install torch==1.5.0+cpu torchvision==0.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html --no-warn-script-location'.format(PYTHON_EXE))
-
-for lib in LIBS:
-    os.system('{} -m pip install {} --no-warn-script-location'.format(PYTHON_EXE, lib))
+os.system('{} -m pip install {} --no-warn-script-location'.format(PYTHON_EXE, lib))
 
 print('generating run_server.bat')
 with open(os.path.join(INSTALL_DIR, 'run_server.bat'), 'w') as f:
-    lines = ['{} -m pip install {} --upgrade --no-warn-script-location'.format(PYTHON_EXE, lib) for lib in LIBS]
-    lines.append('set MINDSDB_STORAGE_PATH={}'.format(STORAGE_DIR))
+    lines = ['{} -m pip install {} --upgrade mindsdb --no-warn-script-location']
     lines.append('{} -m mindsdb'.format(PYTHON_EXE))
     f.write('\n'.join(lines))

--- a/mindsdb/interfaces/datastore/datastore.py
+++ b/mindsdb/interfaces/datastore/datastore.py
@@ -5,7 +5,9 @@ import shutil
 import os
 import pickle
 import sys
-import resource
+
+if os.name == 'posix'
+    import resource
 
 import mindsdb
 

--- a/mindsdb/utilities/fs.py
+++ b/mindsdb/utilities/fs.py
@@ -8,11 +8,44 @@ def create_directory(path):
     path = Path(path)
     path.mkdir(mode=0o777, exist_ok=True, parents=True)
 
+
 def get_paths():
     this_file_path = os.path.abspath(inspect.getfile(inspect.currentframe()))
     mindsdb_path = os.path.abspath(Path(this_file_path).parent.parent.parent)
 
-    return [(f'{mindsdb_path}/etc/', f'{mindsdb_path}/var/predictors',f'{mindsdb_path}/var/datastore'),('/etc/mindsdb', '/var/lib/mindsdb/predictors','/var/lib/mindsdb/datastore'),('~/.local/etc/mindsdb','~/.local/var/lib/mindsdb/predictors','~/.local/var/lib/mindsdb/datastore')]
+    tuples = [
+        (
+            f'{mindsdb_path}/etc/',
+            f'{mindsdb_path}/var/predictors',
+            f'{mindsdb_path}/var/datastore'
+        )
+    ]
+
+    # if windows
+    if os.name == 'nt':
+        tuples.extend([
+            (
+                os.path.join(os.environ['APPDATA'], 'mindsdb'),
+                os.path.join(os.environ['APPDATA'], 'mindsdb', 'predictors'),
+                os.path.join(os.environ['APPDATA'], 'mindsdb', 'datastore'),
+            )
+        ])
+    else:
+        tuples.extend([
+            (
+                '/etc/mindsdb',
+                '/var/lib/mindsdb/predictors',
+                '/var/lib/mindsdb/datastore'
+            ),
+            (
+                '~/.local/etc/mindsdb',
+                '~/.local/var/lib/mindsdb/predictors',
+                '~/.local/var/lib/mindsdb/datastore'
+            )
+        ])
+
+    return tuples
+
 
 def get_or_create_dir_struct():
     for tup in get_paths():


### PR DESCRIPTION
Resolves #523 

The server will not run on windows because of scipy DLL loading error (scipy 1.5.0). To solve this we should either change mindsdb requirements (until the dll issue is fixed by scipy) or install scipy==1.4.1 only for windows, in this installer.