### PR TITLE
Use import_model instead of load

### DIFF
--- a/mindsdb/interfaces/native/mindsdb.py
+++ b/mindsdb/interfaces/native/mindsdb.py
@@ -71,7 +71,7 @@ class MindsdbNative():
         self.dbw.register_predictors(new_name)
 
     def load_model(self, fpath):
-        F.load_model(model_archive_path=fpath)
+        F.import_model(model_archive_path=fpath)
         # @TODO How do we figure out the name here ?
         #dbw.register_predictor(...)
 


### PR DESCRIPTION

This PR change uses a new import_model method from functional instead of load fixes Scout upload issue.