### PR TITLE
added a few suggestions from Max and modified tests

### DIFF
--- a/mindsdb/api/http/namespaces/config.py
+++ b/mindsdb/api/http/namespaces/config.py
@@ -14,7 +14,15 @@ from flask_restx import Resource, abort, Namespace
 from flask import current_app as ca
 
 from mindsdb.api.http.namespaces.configs.config import ns_conf
+from mindsdb.interfaces.database.database import DatabaseWrapper
 
+
+@ns_conf.route('/integrations')
+@ns_conf.param('name', 'List all database integration')
+class Integration(Resource):
+    @ns_conf.doc('get_integrations')
+    def get(self):
+        return {'integrations': [k for k in ca.config_obj['integrations']]}
 
 @ns_conf.route('/integrations/<name>')
 @ns_conf.param('name', 'Database integration')
@@ -29,6 +37,7 @@ class Integration(Resource):
         '''return datasource metadata'''
         params = request.json.get('params')
         ca.config_obj.add_db_integration(name, params)
+        DatabaseWrapper(ca.config_obj)
         return 'added'
 
     @ns_conf.doc('delete_integration')
@@ -36,12 +45,10 @@ class Integration(Resource):
         ca.config_obj.remove_db_integration(name)
         return 'deleted'
 
-@ns_conf.route('/integrations/<name>/modify')
-@ns_conf.param('name', 'Modify database integration')
-class Integration(Resource):
     @ns_conf.doc('modify_integration')
-    def put(self, name):
+    def post(self, name):
         '''return datasource metadata'''
         params = request.json.get('params')
         ca.config_obj.modify_db_integration(name, params)
+        DatabaseWrapper(ca.config_obj)
         return 'modified'

--- a/tests/integration_tests/api/test_http.py
+++ b/tests/integration_tests/api/test_http.py
@@ -43,6 +43,11 @@ class HTTPTest(unittest.TestCase):
             pass
 
     def test_1_config(self):
+        res = requests.get(f'{root}/config/integrations')
+        assert res.status_code == 200
+        integration_names = res.json()
+        assert set(integration_names['integrations']) == set(['default_mariadb', 'default_clickhouse'])
+
         test_integration_data = {'enabled': False, 'host':'test'}
         res = requests.put(f'{root}/config/integrations/test_integration', json={'params':test_integration_data})
         assert res.status_code == 200
@@ -72,7 +77,7 @@ class HTTPTest(unittest.TestCase):
                 assert integration[k] is not None
 
             # Modify it
-            res = requests.put(f'{root}/config/integrations/{name}/modify', json={'params':{'password':'test'}})
+            res = requests.post(f'{root}/config/integrations/{name}', json={'params':{'password':'test'}})
 
             res = requests.get(f'{root}/config/integrations/{name}')
             assert res.status_code == 200
@@ -83,7 +88,7 @@ class HTTPTest(unittest.TestCase):
                     assert modified_integration[k] == integration[k]
 
             # Put the original values back in
-            res = requests.put(f'{root}/config/integrations/{name}/modify', json={'params':integration})
+            res = requests.post(f'{root}/config/integrations/{name}', json={'params':integration})
             res = requests.get(f'{root}/config/integrations/{name}')
             assert res.status_code == 200
             modified_integration = res.json()


### PR DESCRIPTION
* Changed the `/modification` endpoint to just be a `POST` call on the normal `/integrations/<name>` endpoint
* Refreshing database integrations when one is added or modified
* Added endpoint to list the name of all integrations.
* Modified tests to account for this.