### PR TITLE
table name escaping

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
+++ b/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
@@ -166,7 +166,7 @@ class SQLQuery():
         fromStatements = self.struct.get('from')
         if isinstance(fromStatements, list) is False:
             fromStatements = [fromStatements]
-        
+
         self.struct['from'] = [self._format_from_statement(x) for x in fromStatements]
 
         orderby = self.struct.get('orderby')

--- a/mindsdb/integrations/clickhouse/clickhouse.py
+++ b/mindsdb/integrations/clickhouse/clickhouse.py
@@ -63,6 +63,9 @@ class Clickhouse():
     def _get_mysql_user(self):
         return f"{self.config['api']['mysql']['user']}_{self.name}"
 
+    def _escape_table_name(self, name):
+        return '`' + name.replace('`', '\\`') + '`'
+
     def setup(self):
         self._query('DROP DATABASE IF EXISTS mindsdb')
 
@@ -94,7 +97,7 @@ class Clickhouse():
 
     def register_predictors(self, model_data_arr):
         for model_meta in model_data_arr:
-            name = model_meta['name']
+            name = self._escape_table_name(model_meta['name'])
             stats = model_meta['data_analysis']
             if 'columns_to_ignore' in stats:
                 del stats['columns_to_ignore']
@@ -121,7 +124,7 @@ class Clickhouse():
 
     def unregister_predictor(self, name):
         q = f"""
-            drop table if exists mindsdb.{name};
+            drop table if exists mindsdb.{self._escape_table_name(name)};
         """
         self._query(q)
 

--- a/mindsdb/integrations/mariadb/mariadb.py
+++ b/mindsdb/integrations/mariadb/mariadb.py
@@ -38,6 +38,9 @@ class Mariadb():
 
         return column_declaration
 
+    def _escape_table_name(self, name):
+        return '`' + name.replace('`', '``') + '`'
+
     def _query(self, query):
         con = mysql.connector.connect(host=self.config['integrations'][self.name]['host'], port=self.config['integrations'][self.name]['port'], user=self.config['integrations'][self.name]['user'], password=self.config['integrations'][self.name]['password'])
 
@@ -112,7 +115,7 @@ class Mariadb():
             connect = self._get_connect_string(name)
 
             q = f"""
-                    CREATE TABLE mindsdb.{name}
+                    CREATE TABLE mindsdb.{self._escape_table_name(name)}
                     ({columns_sql}
                     ) ENGINE=CONNECT TABLE_TYPE=MYSQL CONNECTION='{connect}';
             """
@@ -120,13 +123,18 @@ class Mariadb():
 
     def unregister_predictor(self, name):
         q = f"""
-            drop table if exists mindsdb.{name};
+            drop table if exists mindsdb.{self._escape_table_name(name)};
         """
         self._query(q)
 
     def check_connection(self):
         try:
-            con = mysql.connector.connect(host=self.config['integrations'][self.name]['host'], port=self.config['integrations'][self.name]['port'], user=self.config['integrations'][self.name]['user'], password=self.config['integrations'][self.name]['password'])
+            con = mysql.connector.connect(
+                host=self.config['integrations'][self.name]['host'],
+                port=self.config['integrations'][self.name]['port'],
+                user=self.config['integrations'][self.name]['user'],
+                password=self.config['integrations'][self.name]['password']
+            )
             connected = con.is_connected()
             con.close()
         except Exception:

--- a/mindsdb/interfaces/datastore/datastore.py
+++ b/mindsdb/interfaces/datastore/datastore.py
@@ -91,9 +91,13 @@ class DataStore():
             # TODO add host port params
             ds = ClickhouseDS(query=source, user=user, password=password)
             picklable = {
-                'class': 'ClickhouseDS'
-                ,'args': [source]
-                ,'kwargs': {'user': user,'password': password}
+                'class': 'ClickhouseDS',
+                'args': [],
+                'kwargs': {
+                    'query': source,
+                    'user': user,
+                    'password': password
+                }
             }
         elif source_type == 'mariadb':
             user = self.config['integrations']['default_mariadb']['user']
@@ -102,9 +106,11 @@ class DataStore():
             port = self.config['integrations']['default_mariadb']['port']
             ds = MariaDS(table='', query=source, user=user, password=password, host=host, port=port)
             picklable = {
-                'class': 'MariaDS'
-                ,'args': ['', source]
-                ,'kwargs': {
+                'class': 'MariaDS',
+                'args': [],
+                'kwargs': {
+                    'table': '',
+                    'query': source,
                     'user': user,
                     'password': password,
                     'host': host,

--- a/mindsdb/interfaces/datastore/datastore.py
+++ b/mindsdb/interfaces/datastore/datastore.py
@@ -89,7 +89,7 @@ class DataStore():
             user = self.config['integrations']['default_clickhouse']['user']
             password = self.config['integrations']['default_clickhouse']['password']
             # TODO add host port params
-            ds = ClickhouseDS(source, user=user, password=password)
+            ds = ClickhouseDS(query=source, user=user, password=password)
             picklable = {
                 'class': 'ClickhouseDS'
                 ,'args': [source]
@@ -100,10 +100,10 @@ class DataStore():
             password = self.config['integrations']['default_mariadb']['password']
             host = self.config['integrations']['default_mariadb']['host']
             port = self.config['integrations']['default_mariadb']['port']
-            ds = MariaDS(source, user=user, password=password, host=host, port=port)
+            ds = MariaDS(table='', query=source, user=user, password=password, host=host, port=port)
             picklable = {
                 'class': 'MariaDS'
-                ,'args': [source]
+                ,'args': ['', source]
                 ,'kwargs': {
                     'user': user,
                     'password': password,

--- a/mindsdb/interfaces/datastore/datastore.py
+++ b/mindsdb/interfaces/datastore/datastore.py
@@ -104,12 +104,11 @@ class DataStore():
             password = self.config['integrations']['default_mariadb']['password']
             host = self.config['integrations']['default_mariadb']['host']
             port = self.config['integrations']['default_mariadb']['port']
-            ds = MariaDS(table='', query=source, user=user, password=password, host=host, port=port)
+            ds = MariaDS(query=source, user=user, password=password, host=host, port=port)
             picklable = {
                 'class': 'MariaDS',
                 'args': [],
                 'kwargs': {
-                    'table': '',
                     'query': source,
                     'user': user,
                     'password': password,


### PR DESCRIPTION
close #593 
this fix allow use via sql-interface predictors with names contains 'minus' and 'space' signs (and probably other else supported by current database)