### PR TITLE
make cert if it not specified in config

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
+++ b/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
@@ -10,6 +10,7 @@
 """
 
 
+import os
 import random
 import socketserver as SocketServer
 import ssl
@@ -17,8 +18,11 @@ import re
 import traceback
 import json
 import atexit
+import tempfile
 
 from moz_sql_parser import parse
+
+from mindsdb.utilities.wizards import make_ssl_cert
 
 from mindsdb.api.mysql.mysql_proxy.data_types.mysql_packet import Packet
 from mindsdb.api.mysql.mysql_proxy.controllers.session_controller import SessionController
@@ -903,6 +907,11 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
         HARDCODED_USER = config['api']['mysql']['user']
         HARDCODED_PASSWORD = config['api']['mysql']['password']
         CERT_PATH = config['api']['mysql'].get('certificate_path')
+        if CERT_PATH is None or CERT_PATH == '':
+            CERT_PATH = tempfile.mkstemp(prefix='mindsdb_cert_', text=True)[1]
+            make_ssl_cert(CERT_PATH)
+            atexit.register(lambda: os.remove(CERT_PATH))
+
         default_store = DataStore(config)
         mdb = MindsdbNative(config)
         datahub = init_datahub(config)


### PR DESCRIPTION
Small enhancement: if someone starts mindsb module with --config arg, then he need somehow create ssl-cert before and specify path to it in config. This PR add opportunity remove this key from config, or set it to empty string. In this case temp cert will be created at start.