### PR TITLE
Db improvements

### DIFF
--- a/mindsdb/api/http/namespaces/config.py
+++ b/mindsdb/api/http/namespaces/config.py
@@ -8,10 +8,17 @@ from mindsdb.interfaces.database.database import DatabaseWrapper
 
 @ns_conf.route('/integrations')
 @ns_conf.param('name', 'List all database integration')
-class Integration(Resource):
+class ListIntegration(Resource):
     @ns_conf.doc('get_integrations')
     def get(self):
         return {'integrations': [k for k in ca.config_obj['integrations']]}
+
+@ns_conf.route('/all_integrations')
+@ns_conf.param('name', 'List all database integration')
+class AllIntegration(Resource):
+    @ns_conf.doc('get_all_integrations')
+    def get(self):
+        return ca.config_obj['integrations']
 
 @ns_conf.route('/integrations/<name>')
 @ns_conf.param('name', 'Database integration')

--- a/mindsdb/api/http/namespaces/config.py
+++ b/mindsdb/api/http/namespaces/config.py
@@ -49,8 +49,8 @@ class Check(Resource):
     @ns_conf.doc('check')
     def get(self, name):
         '''return datasource metadata'''
-        dbw = DatabaseWrapper(config_obj)
+        dbw = DatabaseWrapper(ca.config_obj)
         for db_name, connected in dbw.check_connections().items():
             if db_name == name:
-                returne 200, connected
-        return 400, f'Can\'t find database integration: {name}'
+                return connected, 200
+        return f'Can\'t find database integration: {name}', 400

--- a/mindsdb/api/http/namespaces/config.py
+++ b/mindsdb/api/http/namespaces/config.py
@@ -41,3 +41,16 @@ class Integration(Resource):
         ca.config_obj.modify_db_integration(name, params)
         DatabaseWrapper(ca.config_obj)
         return 'modified'
+
+
+@ns_conf.route('/integrations/<name>/check')
+@ns_conf.param('name', 'Database integration checks')
+class Check(Resource):
+    @ns_conf.doc('check')
+    def get(self, name):
+        '''return datasource metadata'''
+        dbw = DatabaseWrapper(config_obj)
+        for db_name, connected in dbw.check_connections().items():
+            if db_name == name:
+                returne 200, connected
+        return 400, f'Can\'t find database integration: {name}'

--- a/mindsdb/api/http/namespaces/datasource.py
+++ b/mindsdb/api/http/namespaces/datasource.py
@@ -67,6 +67,12 @@ class Datasource(Resource):
     @ns_conf.marshal_with(datasource_metadata)
     def put(self, name):
         '''add new datasource'''
+        if 'query' in request.json:
+            query = request.json['query']
+            source_type = request.json['integration_id']
+            ca.default_store.save_datasource(name, source_type, query)
+            return ca.default_store.get_datasource(name)
+
         data = {}
         def on_field(field):
             print(f'\n\n{field}\n\n')
@@ -78,6 +84,7 @@ class Datasource(Resource):
             data['file'] = file.file_name.decode()
 
         temp_dir_path = tempfile.mkdtemp(prefix='datasource_file_')
+
 
         if request.headers['Content-Type'].startswith('multipart/form-data'):
             parser = multipart.create_form_parser(
@@ -110,7 +117,7 @@ class Datasource(Resource):
             file_path = os.path.join(temp_dir_path, data['file'])
         else:
             file_path = None
-        
+
         ca.default_store.save_datasource(ds_name, source_type, source, file_path)
         os.rmdir(temp_dir_path)
 

--- a/mindsdb/interfaces/datastore/datastore.py
+++ b/mindsdb/interfaces/datastore/datastore.py
@@ -144,8 +144,6 @@ class DataStore():
                 'row_count': len(df),
                 'columns': [dict(name=x) for x in list(df.keys())]
             }
-            if source_type in self.config['integrations']:
-                meta['integration_id'] = source_type
             json.dump(meta, fp)
 
         return self.get_datasource_obj(name, raw=True)

--- a/mindsdb/interfaces/datastore/datastore.py
+++ b/mindsdb/interfaces/datastore/datastore.py
@@ -135,7 +135,7 @@ class DataStore():
             pickle.dump(picklable, fp)
 
         with open(os.path.join(ds_dir,'metadata.json'), 'w') as fp:
-            json.dump({
+            meta = {
                 'name': name,
                 'source_type': source_type,
                 'source': source,
@@ -143,7 +143,10 @@ class DataStore():
                 'updated_at': str(datetime.datetime.now()).split('.')[0],
                 'row_count': len(df),
                 'columns': [dict(name=x) for x in list(df.keys())]
-            }, fp)
+            }
+            if source_type in self.config['integrations']:
+                meta['integration_id'] = source_type
+            json.dump(meta, fp)
 
         return self.get_datasource_obj(name, raw=True)
 

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -1,6 +1,7 @@
 import os
 import json
 import hashlib
+import datetime
 
 
 class Config(object):
@@ -113,6 +114,9 @@ class Config(object):
 
     # Higher level interface
     def add_db_integration(self, name, dict):
+        dict['date_last_update'] = str(datetime.datetime.now()).split('.')[0]
+        if 'database_name' not in dict:
+            dict['database_name'] = name
         if 'enabled' not in dict:
             dict['enabled'] = True
 

--- a/tests/integration_tests/api/test_http.py
+++ b/tests/integration_tests/api/test_http.py
@@ -46,7 +46,8 @@ class HTTPTest(unittest.TestCase):
         res = requests.get(f'{root}/config/integrations')
         assert res.status_code == 200
         integration_names = res.json()
-        assert set(integration_names['integrations']) == set(['default_mariadb', 'default_clickhouse', 'default_mysql'])
+        for integration_name in integration_names['integrations']:
+            assert integration_name in ['default_mariadb', 'default_clickhouse', 'default_mysql', 'test_integration']
 
         test_integration_data = {'enabled': False, 'host': 'test', 'type': 'clickhouse'}
         res = requests.put(f'{root}/config/integrations/test_integration', json={'params': test_integration_data})
@@ -55,7 +56,8 @@ class HTTPTest(unittest.TestCase):
         res = requests.get(f'{root}/config/integrations/test_integration')
         assert res.status_code == 200
         test_integration = res.json()
-        assert len(test_integration) == 3
+        print(test_integration, len(test_integration))
+        assert len(test_integration) == 5
 
         res = requests.delete(f'{root}/config/integrations/test_integration')
         assert res.status_code == 200
@@ -105,6 +107,20 @@ class HTTPTest(unittest.TestCase):
         url = f'{root}/datasources/{ds_name}'
         res = requests.put(url, json=params)
         assert res.status_code == 200
+
+        db_ds_name = ds_name + '_db'
+        params = {
+            'name': db_ds_name
+            ,'query': 'SELECT arrayJoin([1,2,3]) as a, arrayJoin([1,2,3,4,5,6,7,8]) as b'
+            ,'integration_id': 'default_clickhouse'
+        }
+
+        url = f'{root}/datasources/{db_ds_name}'
+        res = requests.put(url, json=params)
+        assert res.status_code == 200
+        ds_data = res.json()
+        assert ds_data['source_type'] == 'default_clickhouse'
+        assert ds_data['row_count'] == 3 * 8
 
     def test_3_analyze(self):
         response = requests.get(f'{root}/datasources/{ds_name}/analyze')


### PR DESCRIPTION
1. Added `/config/all_integrations` endpoint that lists all integrations with the full data associated with all of them in a dict keyed on the integration ids

2. Added `/integrations/<name>/check` (where `<name>` is the integration's id) that allows you to check whether an integration is functional (i.e. if mindsdb can connect to the database)

3. Added the ability to add database integration based datasource to the `/datasources/<name> -- PUT` endpoiont:

Simply call the endpoint and replace `<name>` with the name of our datasource then give two parameters in the json post body:

`query` - the sql query to get the actual data
`integration_id` - the id of the database integration

4. To see what database integration a given datasource comes from, simply check the `source_type` parameter of the datasource, if it's not `file` or `url` it means it comes from a database integration and `source_type` is the actual id/name

5. Added `date_last_updated` and `database_name` parameter support to the database integrations under `/config`

6. Added tests for all new features

Should resolve #631 and #630 