### PR TITLE
Add CLA assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,25 @@
+name: "MindsDB CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened,closed,synchronize]
+    
+jobs:
+  CLAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request'
+        # Alpha Release
+        uses: cla-assistant/github-action@v1.4.3-alpha
+        env: 
+          GITHUB_TOKEN: ${{ secrets.CLA_TOKEN }}
+        with: 
+          path-to-signatures: 'assets/contributions-agreement/signatures/cla.json'
+          # Add path to the CLA here
+          path-to-cla-document: 'https://github.com/mindsdb/mindsdb_native/blob/stable/assets/contributions-agreement/individual-contributor.md'
+          branch: 'stable'
+          allowlist: bot*, George3d6, ZoranPandovski, torrmal, Stpmax, maximlopin, paxcema
+          empty-commit-flag: false
+          blockchain-storage-flag: false


### PR DESCRIPTION
This PR automates the CLA signing using Github Actions. The CLA files are referenced in mindsdb_native since it is the same agreement.