### PR TITLE
Datasource analysis in separate thread

### DIFF
--- a/mindsdb/api/http/namespaces/datasource.py
+++ b/mindsdb/api/http/namespaces/datasource.py
@@ -123,6 +123,7 @@ ds_analysis = {}
 
 def analyzing_thread(name, default_store):
     global ds_analysis
+    ds_analysis[name] = None
     ds = default_store.get_datasource(name)
     analysis = default_store.get_analysis(ds['name'])
     ds_analysis[name] = analysis

--- a/mindsdb/api/http/namespaces/datasource.py
+++ b/mindsdb/api/http/namespaces/datasource.py
@@ -126,7 +126,10 @@ def analyzing_thread(name, default_store):
     ds_analysis[name] = None
     ds = default_store.get_datasource(name)
     analysis = default_store.get_analysis(ds['name'])
-    ds_analysis[name] = analysis
+    ds_analysis[name] = {
+        'created_at': datetime.datetime.utcnow(),
+        'data': analysis
+    }
 
 
 @ns_conf.route('/<name>/analyze')
@@ -138,9 +141,10 @@ class Analyze(Resource):
         if name in ds_analysis:
             if ds_analysis[name] is None:
                 return {'status': 'analyzing'}, 200
-            else:
-                analysis = ds_analysis[name]
+            elif (datetime.datetime.utcnow() - ds_analysis[name]['created_at']) > datetime.timedelta(seconds=10):
                 del ds_analysis[name]
+            else:
+                analysis = ds_analysis[name]['data']
                 return analysis, 200
 
         ds = ca.default_store.get_datasource(name)

--- a/mindsdb/api/http/namespaces/datasource.py
+++ b/mindsdb/api/http/namespaces/datasource.py
@@ -148,10 +148,13 @@ class Analyze(Resource):
             print('No valid datasource given')
             abort(400, 'No valid datasource given')
 
-        x = threading.Thread(target=analyzing_thread, args=(name, ca.default_store))
-        x.start()
-
-        return {'status': 'analyzing'}, 200
+        if ds['row_count'] <= 10000:
+            analysis = ca.default_store.get_analysis(ds['name'])
+            return analysis, 200
+        else:
+            x = threading.Thread(target=analyzing_thread, args=(name, ca.default_store))
+            x.start()
+            return {'status': 'analyzing'}, 200
 
 
 @ns_conf.route('/<name>/analyze_subset')

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
 pytest>=3.3.2
 pytest-randomly>=3.3.1
 pytest-ordering>=0.6
-docker>=4.2.2
+docker==4.2.2


### PR DESCRIPTION
Reason: when user push on 'data quality' in gui, it call `/ds_name/analyze` route. This query will be active untill analysis finished. It can take much time for big datasets, query can fail by timeout. As resolve i done this:
1. when first time called `/ds_name/analyze`, analysis starts and returned to user {status: 'analyzing'}
2. {status: 'analyzing'} will be returned each time while analysis not finished
3. then if finished, returned analysis data