### PR TITLE
Read passwords from config as strings

### DIFF
--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -56,6 +56,18 @@ class Config(object):
             version.append(0)
         return version
 
+    def _format(self):
+        ''' changing user input to formalised view
+        '''
+        for integration in self._config.get('integrations', {}).values():
+            password = integration.get('password')
+            password = '' if password is None else str(password)
+            integration['password'] = str(password)
+
+        password = self._config['api']['mysql'].get('password')
+        password = '' if password is None else str(password)
+        self._config['api']['mysql']['password'] = str(password)
+
     def _read(self):
         if isinstance(self.config_path, str) and os.path.isfile(self.config_path):
             with open(self.config_path, 'r') as fp:
@@ -64,6 +76,7 @@ class Config(object):
                     self._migrate()
                     self._save()
                 self._validate()
+                self._format()
         else:
             raise TypeError('`self.config_path` must be a string representing a local file path to a json config')
 


### PR DESCRIPTION
If user specified password in config as int, it followed to errors when connect to DB. Now all passwords will reading as strings, empty or  = null will read as empty string.