### PR TITLE
Fix different storage paths in mindsdb and mindsb_native

### DIFF
--- a/mindsdb/__init__.py
+++ b/mindsdb/__init__.py
@@ -1,18 +1,34 @@
 import os
-import json
 
-from mindsdb.utilities.fs import get_or_create_dir_struct
+from mindsdb.utilities.fs import get_or_create_dir_struct, create_directory
 from mindsdb.utilities.wizards import cli_config
+from mindsdb.utilities.config import Config
+from mindsdb.utilities.functions import args_parse
 
 config_dir, predictor_dir, datasource_dir = get_or_create_dir_struct()
 
-config_path = os.path.join(config_dir,'config.json')
+config_path = os.path.join(config_dir, 'config.json')
 if not os.path.exists(config_path):
-    _ = cli_config(None,None,predictor_dir,datasource_dir,config_dir,use_default=True)
+    _ = cli_config(None, None, predictor_dir, datasource_dir, config_dir, use_default=True)
 
-with open(config_path, 'r') as fp:
-    os.environ['MINDSDB_STORAGE_PATH'] = json.load(fp)['interface']['mindsdb_native']['storage_dir']
+args = args_parse()
+if args.config is not None:
+    config_path = args.config
 
+config = Config(config_path)
+
+try:
+    datasource_dir = config['interface']['datastore']['storage_dir']
+except KeyError:
+    pass
+try:
+    predictor_dir = config['interface']['mindsdb_native']['storage_dir']
+except KeyError:
+    pass
+
+map(create_directory, [datasource_dir, predictor_dir])
+
+os.environ['MINDSDB_STORAGE_PATH'] = datasource_dir
 
 from mindsdb_native import *
 # Figure out how to add this as a module

--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -1,4 +1,3 @@
-import argparse
 import atexit
 import traceback
 import sys
@@ -14,6 +13,7 @@ from mindsdb.api.http.start import start as start_http
 from mindsdb.api.mysql.start import start as start_mysql
 from mindsdb.utilities.fs import get_or_create_dir_struct
 from mindsdb.interfaces.database.database import DatabaseWrapper
+from mindsdb.utilities.functions import args_parse
 
 
 def close_api_gracefully(p_arr):
@@ -27,11 +27,7 @@ def close_api_gracefully(p_arr):
 if __name__ == '__main__':
     mp.freeze_support()
 
-    parser = argparse.ArgumentParser(description='CL argument for mindsdb server')
-    parser.add_argument('--api', type=str, default=None)
-    parser.add_argument('--config', type=str, default=None)
-
-    args = parser.parse_args()
+    args = args_parse()
 
     config_path = args.config
     if config_path is None:
@@ -40,8 +36,6 @@ if __name__ == '__main__':
 
     print(f'Using configuration file: {config_path}')
     config = Config(config_path)
-
-    CONFIG.MINDSDB_STORAGE_PATH = config['interface']['mindsdb_native']['storage_dir']
 
     if args.api is None:
         api_arr = [api for api in config['api']]

--- a/mindsdb/utilities/functions.py
+++ b/mindsdb/utilities/functions.py
@@ -1,0 +1,8 @@
+import argparse
+
+
+def args_parse():
+    parser = argparse.ArgumentParser(description='CL argument for mindsdb server')
+    parser.add_argument('--api', type=str, default=None)
+    parser.add_argument('--config', type=str, default=None)
+    return parser.parse_args()


### PR DESCRIPTION
Fixes #649

In some cases, if user provide in `--config` arg `storage_path` different from `storage_path` in default config, it  may occur bug with different paths in mindsdb and mindsb_native.