### PR TITLE
Update colab example

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,7 +14,7 @@ jobs:
         # Alpha Release
         uses: cla-assistant/github-action@v2.0.0-alpha
         env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}          
+          GITHUB_TOKEN: ${{ secrets.CLA_TOKEN }}          
           PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_TOKEN }}
         with: 
           path-to-signatures: 'assets/contributions-agreement/signatures/cla.json'

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ print('The predicted price is between ${price} with {conf} confidence'.format(pr
 
 Visit the documentation to [learn more](https://docs.mindsdb.com/)
 
-* **Google Colab**: You can also try MindsDB straight here [![Google Colab](https://colab.research.google.com/assets/colab-badge.svg "MindsDB")](https://colab.research.google.com/drive/1qsIkMeAQFE-MOEANd1c6KMyT44OnycSb)
+* **Google Colab**: You can also try MindsDB straight here [![Google Colab](https://colab.research.google.com/assets/colab-badge.svg "MindsDB")](https://colab.research.google.com/drive/1qnH4bhTKvm6mEyV8nAoK9uMZm8HV_gwE?usp=sharing)
 
 
 ## Video Tutorial


### PR DESCRIPTION
The old collab example was using version 1.4 of mindsdb and was outdated and users got errors as #659. In the new example, we are using mindsdb_native.