### PR TITLE
Routes exception handler

### DIFF
--- a/mindsdb/api/http/start.py
+++ b/mindsdb/api/http/start.py
@@ -49,7 +49,7 @@ def start(config, initial=False):
     def handle_exception(e):
         # pass through HTTP errors
         if isinstance(e, HTTPException):
-            return e
+            return {'message': str(e)}, e.code, e.get_response().headers
         name = getattr(type(e), '__name__') or 'Unknown error'
         return {'message': f'{name}: {str(e)}'}, 500
 

--- a/mindsdb/api/http/start.py
+++ b/mindsdb/api/http/start.py
@@ -3,6 +3,8 @@ import mindsdb
 import logging
 import sys
 
+from werkzeug.exceptions import HTTPException
+
 from mindsdb.api.http.namespaces.predictor import ns_conf as predictor_ns
 from mindsdb.api.http.namespaces.datasource import ns_conf as datasource_ns
 from mindsdb.api.http.namespaces.util import ns_conf as utils_ns
@@ -42,6 +44,14 @@ def start(config, initial=False):
     api.add_namespace(datasource_ns)
     api.add_namespace(utils_ns)
     api.add_namespace(conf_ns)
+
+    @api.errorhandler(Exception)
+    def handle_exception(e):
+        # pass through HTTP errors
+        if isinstance(e, HTTPException):
+            return e
+        name = getattr(type(e), '__name__') or 'Unknown error'
+        return {'message': f'{name}: {str(e)}'}, 500
 
     print(f"Start on {config['api']['http']['host']}:{config['api']['http']['port']}")
     app.run(debug=debug, port=config['api']['http']['port'], host=config['api']['http']['host'])


### PR DESCRIPTION
This handler will catch all not-http related errors and return it to user as {message: error} with 500 code.
Example of output if typo in table name when datasource creation:
```
{
    "message": "Exception: Code: 60, e.displayText() = DB::Exception: Table test.home_rental1s doesn't exist. (version 20.6.4.44 (official build))\n"
}
```