### PR TITLE
Update mindsdb.yml

### DIFF
--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -1,7 +1,7 @@
 name: MindsDB workflow
 
 on:
-  pull_request:
+  push:
 
 jobs:
   test:


### PR DESCRIPTION
This PR updates the event of triggering GA instead of pr to push. The deploy job was not triggered after merging [latest version](https://github.com/mindsdb/mindsdb/actions/runs/228758486)