### PR TITLE
Open browser when http-api started

### DIFF
--- a/mindsdb/utilities/ps.py
+++ b/mindsdb/utilities/ps.py
@@ -10,15 +10,19 @@ def is_port_in_use(port_num):
     return int(port_num) in portsinuse
 
 
-def wait_port(port_num, timeout):
+def wait_func_is_true(func, timeout, *args, **kwargs):
     start_time = time.time()
 
-    in_use = is_port_in_use(port_num)
-    while in_use is False and (time.time() - start_time) < timeout:
+    result = func(*args, **kwargs)
+    while result is False and (time.time() - start_time) < timeout:
         time.sleep(2)
-        in_use = is_port_in_use(port_num)
+        result = func(*args, **kwargs)
 
-    return in_use
+    return result
+
+
+def wait_port(port_num, timeout):
+    return wait_func_is_true(func=is_port_in_use, timeout=timeout, port_num=port_num)
 
 
 def get_listen_ports(pid):


### PR DESCRIPTION

After initializing the application, the function of opening the browser with the main link is launched in a separate thread.
This function scans the availability of the api-http port of the service and the browser opens only after the service is started. 
If an error occurs while scanning the port or when opening the browser, then nothing happens, an error log is displayed.
  
-

mindsdb