### PR TITLE
Added correct URL to build-docker.sh

### DIFF
--- a/distributions/docker/build-docker.sh
+++ b/distributions/docker/build-docker.sh
@@ -9,7 +9,7 @@
 
 mkdir mindsdb_docker
 cd mindsdb_docker
-curl https://raw.githubusercontent.com/mindsdb/mindsdb/master/distributions/docker/Dockerfile > Dockerfile
+curl https://raw.githubusercontent.com/mindsdb/mindsdb/staging/distributions/docker/Dockerfile > Dockerfile
 docker build -t mindsdb .
 cd ..
 rm -rf mindsdb_docker > /dev/null 2>&1


### PR DESCRIPTION
Fixes #
Added correct URL in build-docker.sh so proper Dockerfile can be pulled.

## Please describe what changes you made, in as much detail as possible
  - Changed this line:
```
curl https://raw.githubusercontent.com/mindsdb/mindsdb/master/distributions/docker/Dockerfile > Dockerfile
```
To this line:
```
curl https://raw.githubusercontent.com/mindsdb/mindsdb/staging/distributions/docker/Dockerfile > Dockerfile
```
Issue #777 
mindsdb