### PR TITLE
change docker cmd to start mindsdb server

### DIFF
--- a/distributions/docker/Dockerfile
+++ b/distributions/docker/Dockerfile
@@ -2,5 +2,5 @@ FROM mindsdb/mindsdb:latest
 
 RUN pip install --no-cache-dir mindsdb
 
-# Use bash cmd entry point
-CMD ["bash"]
+# Use cmd entry point to start the server
+CMD ["python", "-m", "mindsdb"]


### PR DESCRIPTION
Fixes #772

## Please describe what changes you made, in as much detail as possible
  - Updated the dockerfile `CMD` instruction to start the server

mindsdb