### PR TITLE
Added docker-compose distribution with readme.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ tests/integration_tests/flows/model.py
 tests/integration_tests/flows/my_model.zip
 tests/docker/mongodb/storage_*
 .vscode
+distributions/docker-compose/*/storage
 venv/*

--- a/distributions/docker-compose/README.md
+++ b/distributions/docker-compose/README.md
@@ -1,0 +1,49 @@
+# Introduction
+
+The docker-compose option will build a mindsdb container along with multiple database containers. All containers will be available on the host network.
+
+The databases will retain their data, locally. Feel free to take the containers offline when needed. The next time you start up the containers your data will be utilized in the container.
+
+# Instructions
+
+All commands assume you are in the following directory:
+```mindsdb/distributions/docker-compose/```
+
+1. Open the docker-compose and comment any database block that you don't want to run within a container.
+2. Save the file.
+3. Open a terminal in this directory, where docker-compose.yaml resides.
+4. Run the following: ```docker-compose up```
+   * If you don't want to see the logs streaming, instead run: ```docker-compose up -d```
+5. When you are ready to take the containers offline, run: ```docker-compose down```
+
+# Container Issues
+
+If you find you are having issues with your containers after multiple starts and stops, you can quickly by-pass the issue by removing your docker images.
+
+>Caution: This should be reseved as a last resort
+
+All commands assume you are using a terminal with the following directory:
+```mindsdb/distributions/docker-compose/```
+
+1. Run: ```docker images```
+2. You will see a list of images similar to:
+   * docker-compose_postgres
+   * docker-compose_mariadb
+   * mariadb
+   * mysql
+   * mindsdb/mindsdb
+   * postgres
+   * yandex/clickhouse-server
+3. Delete each image.
+4. Next run: ```docker-compose up```
+5. If you see a message request a yes/no response, asking to overwrite a volume, you can say yes. Your data will be restored from local docker volumes.
+
+# Feature and Bug reports
+We use GitHub issues to track bugs and features. Report them by opening a [new issue](https://github.com/mindsdb/mindsdb/issues/new/choose) and fill out all of the required inputs.
+
+# Code review process
+The Pull Request reviews are done on a regular basis. 
+Please, make sure you respond to our feedback/questions.
+
+# Community
+If you have additional questions or you want to chat with MindsDB core team, you can join our community [![Discourse posts](https://img.shields.io/discourse/posts?server=https%3A%2F%2Fcommunity.mindsdb.com%2F)](https://community.mindsdb.com/). To get updates on MindsDB’s latest announcements, releases, and events, [sign up for our newsletter](https://mindsdb.us20.list-manage.com/subscribe/post?u=5174706490c4f461e54869879&amp;id=242786942a).

--- a/distributions/docker-compose/docker-compose.yaml
+++ b/distributions/docker-compose/docker-compose.yaml
@@ -1,0 +1,64 @@
+# This starts databases for local development or integration tests as if they were launched locally.
+# Run `docker-compose up -d`
+# Shut down and clean up: `docker-compose down`
+
+# Comment out any databases you don't want to run.
+
+version: "3"
+
+services:
+  mindsdb:
+    image: mindsdb/mindsdb:latest
+    container_name: mindsdb_mindsdb
+    command: bash -c "pip install --no-cache-dir mindsdb; python3 -m mindsdb"
+    ports:
+      - 47334:47334
+
+  mariadb:
+    build: mariadb/.
+    container_name: mindsdb_mariadb
+    command: --default-authentication-plugin=caching_sha2_password
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_ROOT_PASSWORD: "root"
+    volumes:
+    - ${PWD}/mariadb/storage:/var/lib/mysql
+    - ${PWD}/mariadb/connect.cnf:/etc/mysql/mariadb.conf.d/connect.cnf
+
+  clickhouse:
+    image: yandex/clickhouse-server:20.1
+    container_name: mindsdb_clickhouse
+    volumes:
+      - ${PWD}/clickhouse/storage:/var/lib/clickhouse
+    ports:
+      - 8123:8123
+      - 9000:9000
+
+  mysql:
+    network_mode: host
+    image: mysql
+    command: --default-authentication-plugin=mysql_native_password
+    container_name: mindsdb_mysql
+    volumes:
+    - ${PWD}/mysql/config.cnf:/etc/mysql/conf.d/config.cnf
+    - ${PWD}/mysql/storage:/var/lib/mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: test
+    ports:
+      - 3307:3307
+
+  postgres:
+    build: postgres/.
+    network_mode: host
+    container_name: mindsdb_postgres
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_PASSWORD: "postgres"
+    volumes:
+    - ${PWD}/postgres/storage:/var/lib/postgresql/data
+    - ${PWD}/postgres/share:/share

--- a/distributions/docker-compose/mariadb/Dockerfile
+++ b/distributions/docker-compose/mariadb/Dockerfile
@@ -1,0 +1,14 @@
+FROM mariadb:10.5
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        mariadb-plugin-connect
+
+RUN chmod 0444 /etc/mysql/mariadb.conf.d/connect.cnf
+
+VOLUME /var/lib/mysql
+
+EXPOSE 3306
+
+CMD ["mysqld"]

--- a/distributions/docker-compose/mariadb/connect.cnf
+++ b/distributions/docker-compose/mariadb/connect.cnf
@@ -1,0 +1,7 @@
+[mariadb]
+plugin-load-add=ha_connect.so
+connect_jvm_path="/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/amd64/server"
+connect_class_path="/usr/lib/mysql/plugin:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/ext/dremio-jdbc-driver.jar"
+wait_timeout=180
+connect_timeout=180
+interactive_timeout=180

--- a/distributions/docker-compose/mongodb/mongos/mongos-dockerfile
+++ b/distributions/docker-compose/mongodb/mongos/mongos-dockerfile
@@ -1,0 +1,4 @@
+# FROM mongo:4.4
+FROM mongo:3.6
+
+CMD mongos --configdb replconf/127.0.0.1:27000 --port 27002

--- a/distributions/docker-compose/mssql/Dockerfile
+++ b/distributions/docker-compose/mssql/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/mssql/server
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        mariadb-plugin-connect
+
+RUN chmod 0444 /etc/mysql/mariadb.conf.d/connect.cnf
+
+VOLUME /var/lib/mysql
+
+EXPOSE 3306
+
+CMD ["mysqld"]

--- a/distributions/docker-compose/mysql/config.cnf
+++ b/distributions/docker-compose/mysql/config.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+federated
+port=3307

--- a/distributions/docker-compose/postgres/Dockerfile
+++ b/distributions/docker-compose/postgres/Dockerfile
@@ -1,0 +1,7 @@
+FROM postgres:12.3
+
+RUN apt-get update && apt-get install -y \
+    postgresql-12-mysql-fdw
+
+RUN mkdir -p /docker-entrypoint-initdb.d && \
+    echo 'CREATE EXTENSION mysql_fdw;' > /docker-entrypoint-initdb.d/init.sql


### PR DESCRIPTION
This is second attempt from [PR 781](https://github.com/mindsdb/mindsdb/pull/781).

---

Add mindsdb docker-compose #780

For early adopters, we need a fast and simple use case to have mindsdb running as well as a flavor of databases.

Create a docker-compose that allows each docker resource to be avilable on the host.

---

I reset my branch, pulled from upstrea staging then readded my code. Hopefully all is well now.