### PR TITLE
Better data sourcing

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -24,7 +24,7 @@ Note: Query parameters should come as top level parameters in the application/js
 * password        [str]
 * host            [str]
 * port            [int]
-* auth_database   [optional - str]
+* database   [optional - str]
 
 #### Query parameters (when generating a dataset)
 * query           [str]

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -1,0 +1,60 @@
+## Parameters
+
+A list of the parameters needed to add and query an integration.
+
+Note: Query parameters should come as top level parameters in the application/json request made to the datasources endpoints (they are accessed via `request.json` inside mindsdb)
+
+
+### Clickhouse
+
+#### Config parameters (when adding a new integration)
+* user            [str]
+* password        [str]
+* host            [str]
+* port            [int]
+
+#### Query parameters (when generating a dataset)
+* query           [str]
+
+
+### Mariadb, Postgres, Mysql, Microsfot SQL Server
+
+#### Config parameters (when adding a new integration)
+* user            [str]
+* password        [str]
+* host            [str]
+* port            [int]
+* auth_database   [optional - str]
+
+#### Query parameters (when generating a dataset)
+* query           [str]
+* database        [optional - str]
+
+
+### Snowflake
+
+#### Config parameters (when adding a new integration)
+* user            [str]
+* password        [str]
+* host            [str]
+* account         [str]
+
+#### Query parameters (when generating a dataset)
+* query           [str]
+* database        [str]
+* warehouse       [str]
+* schema          [str]
+
+
+### Mongodb
+
+#### Config parameters (when adding a new integration)
+* user            [str]
+* password        [str]
+* host            [str]
+* port            [int]
+
+#### Query parameters (when generating a dataset)
+* find            [str]
+* collection        [str]
+* database        [str]

--- a/mindsdb/api/http/namespaces/datasource.py
+++ b/mindsdb/api/http/namespaces/datasource.py
@@ -109,18 +109,8 @@ class Datasource(Resource):
             data = request.json
 
         if 'query' in data:
-            query = request.json['query']
-
-            if 'warehouse' in data:
-                query = {
-                    'query': query
-                    ,'warehouse': request.json['warehouse']
-                    ,'database': request.json['database']
-                    ,'schema': request.json['schema']
-                }
-
             source_type = request.json['integration_id']
-            ca.default_store.save_datasource(name, source_type, query)
+            ca.default_store.save_datasource(name, source_type, request.json)
             os.rmdir(temp_dir_path)
             return ca.default_store.get_datasource(name)
 

--- a/mindsdb/api/http/namespaces/predictor.py
+++ b/mindsdb/api/http/namespaces/predictor.py
@@ -135,9 +135,6 @@ class Predictor(Resource):
         if type(kwargs) != type({}):
             kwargs = {}
 
-        if 'stop_training_in_x_seconds' not in kwargs:
-            kwargs['stop_training_in_x_seconds'] = 100
-
         if 'equal_accuracy_for_all_output_categories' not in kwargs:
             kwargs['equal_accuracy_for_all_output_categories'] = True
 

--- a/mindsdb/api/mongo/op_msg_responders/insert.py
+++ b/mindsdb/api/mongo/op_msg_responders/insert.py
@@ -71,7 +71,7 @@ class Responce(Responder):
                 ds, ds_name = mindsdb_env['data_store'].save_datasource(
                     name=doc['name'],
                     source_type='default_mongodb',
-                    source=doc['select_data_query']
+                    source={'query': doc['select_data_query']}
                 )
             elif is_external_datasource:
                 ds = mindsdb_env['data_store'].get_datasource_obj(doc['external_datasource'], raw=True)

--- a/mindsdb/api/mongo/op_msg_responders/insert.py
+++ b/mindsdb/api/mongo/op_msg_responders/insert.py
@@ -71,7 +71,7 @@ class Responce(Responder):
                 ds, ds_name = mindsdb_env['data_store'].save_datasource(
                     name=doc['name'],
                     source_type='default_mongodb',
-                    source={'query': doc['select_data_query']}
+                    source=doc['select_data_query']
                 )
             elif is_external_datasource:
                 ds = mindsdb_env['data_store'].get_datasource_obj(doc['external_datasource'], raw=True)

--- a/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
+++ b/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
@@ -376,7 +376,7 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
                 ).send()
                 return
             insert['select_data_query'] = insert['select_data_query'].replace(r"\'", "'")
-            ds, ds_name = default_store.save_datasource(insert['name'], integration, insert['select_data_query'])
+            ds, ds_name = default_store.save_datasource(insert['name'], integration, {'query': insert['select_data_query']})
         elif is_external_datasource:
             ds = default_store.get_datasource_obj(insert['external_datasource'], raw=True)
             ds_name = insert['external_datasource']

--- a/mindsdb/interfaces/datastore/datastore.py
+++ b/mindsdb/interfaces/datastore/datastore.py
@@ -132,8 +132,8 @@ class DataStore():
                     }
                 }
 
-                if 'auth_database' in integration:
-                    picklable['kwargs']['database'] = integration['auth_database']
+                if 'database' in integration:
+                    picklable['kwargs']['database'] = integration['database']
 
                 if 'database' in source:
                     picklable['kwargs']['database'] = source['database']


### PR DESCRIPTION
* When creating  a datasource we are now taking into account the `database` parameter in the integration config if it exists, the database which we authenticate against, for postgres, mysql, mariadb and mssql
* Supporting an extra parameter called `database` in datasource creation requests, which indicates that we should authenticate against + get data from another database than the "default" one in the integration config.
* Added docs to help the frontend team
* Simplified datasource creation logic