### PR TITLE
Configurable mindsdb sql database name

### DIFF
--- a/mindsdb/api/mongo/op_msg_responders/find.py
+++ b/mindsdb/api/mongo/op_msg_responders/find.py
@@ -96,9 +96,11 @@ class Responce(Responder):
                         if key in row:
                             del row[key]
 
+        db = mindsdb_env['config']['api']['mongodb']['database']
+
         cursor = {
             'id': Int64(0),
-            'ns': f"mindsdb.$cmd.{query['find']}",
+            'ns': f"{db}.$cmd.{query['find']}",
             'firstBatch': data
         }
         return {

--- a/mindsdb/api/mongo/op_msg_responders/list_databases.py
+++ b/mindsdb/api/mongo/op_msg_responders/list_databases.py
@@ -5,18 +5,21 @@ import mindsdb.api.mongo.functions as helpers
 class Responce(Responder):
     when = {'listDatabases': helpers.is_true}
 
-    result = {
-        'databases': [{
-            'name': 'mindsdb',
-            'sizeOnDisk': 1 << 16,
-            'empty': False
-        }, {
-            'name': 'admin',
-            'sizeOnDisk': 1 << 16,
-            'empty': False
-        }],
-        'ok': 1,
-    }
+    def result(self, query, request_env, mindsdb_env):
+        db = mindsdb_env['config']['api']['mongodb']['database']
+
+        return {
+            'databases': [{
+                'name': db,
+                'sizeOnDisk': 1 << 16,
+                'empty': False
+            }, {
+                'name': 'admin',
+                'sizeOnDisk': 1 << 16,
+                'empty': False
+            }],
+            'ok': 1,
+        }
 
 
 responder = Responce()

--- a/mindsdb/integrations/base/integration.py
+++ b/mindsdb/integrations/base/integration.py
@@ -2,6 +2,11 @@ from abc import ABC, abstractmethod
 
 
 class Integration(ABC):
+    def __init__(self, config, name):
+        self.config = config
+        self.name = name
+        self.mindsdb_database = config['api']['mysql']['database']
+
     @abstractmethod
     def setup(self):
         pass

--- a/mindsdb/integrations/mariadb/mariadb.py
+++ b/mindsdb/integrations/mariadb/mariadb.py
@@ -5,10 +5,6 @@ from mindsdb.integrations.base import Integration
 
 
 class Mariadb(Integration):
-    def __init__(self, config, name):
-        self.config = config
-        self.name = name
-
     def _to_mariadb_table(self, stats, predicted_cols):
         subtype_map = {
             DATA_SUBTYPES.INT: 'int',
@@ -76,29 +72,29 @@ class Mariadb(Integration):
         return connect
 
     def setup(self):
-        self._query('DROP DATABASE IF EXISTS mindsdb')
+        self._query(f'DROP DATABASE IF EXISTS {self.mindsdb_database}')
 
-        self._query('CREATE DATABASE IF NOT EXISTS mindsdb')
+        self._query(f'CREATE DATABASE IF NOT EXISTS {self.mindsdb_database}')
 
         connect = self._get_connect_string('predictors')
 
         q = f"""
-                CREATE TABLE IF NOT EXISTS mindsdb.predictors
-                (name VARCHAR(500),
+            CREATE TABLE IF NOT EXISTS {self.mindsdb_database}.predictors (
+                name VARCHAR(500),
                 status VARCHAR(500),
                 accuracy VARCHAR(500),
                 predict VARCHAR(500),
                 select_data_query VARCHAR(500),
                 external_datasource VARCHAR(500),
                 training_options VARCHAR(500)
-                ) ENGINE=CONNECT TABLE_TYPE=MYSQL CONNECTION='{connect}';
+            ) ENGINE=CONNECT TABLE_TYPE=MYSQL CONNECTION='{connect}';
         """
         self._query(q)
 
         connect = self._get_connect_string('commands')
 
         q = f"""
-            CREATE TABLE IF NOT EXISTS mindsdb.commands (
+            CREATE TABLE IF NOT EXISTS {self.mindsdb_database}.commands (
                 command VARCHAR(500)
             ) ENGINE=CONNECT TABLE_TYPE=MYSQL CONNECTION='{connect}';
         """
@@ -122,7 +118,7 @@ class Mariadb(Integration):
             connect = self._get_connect_string(name)
 
             q = f"""
-                    CREATE TABLE mindsdb.{self._escape_table_name(name)}
+                    CREATE TABLE {self.mindsdb_database}.{self._escape_table_name(name)}
                     ({columns_sql}
                     ) ENGINE=CONNECT TABLE_TYPE=MYSQL CONNECTION='{connect}';
             """
@@ -130,7 +126,7 @@ class Mariadb(Integration):
 
     def unregister_predictor(self, name):
         q = f"""
-            drop table if exists mindsdb.{self._escape_table_name(name)};
+            drop table if exists {self.mindsdb_database}.{self._escape_table_name(name)};
         """
         self._query(q)
 

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -22,7 +22,8 @@ default_config = {
             "host": "127.0.0.1",
             "password": "",
             "port": "47335",
-            "user": "mindsdb"
+            "user": "mindsdb",
+            "database": "mindsdb"
         },
         "mongodb": {
             "host": "127.0.0.1",

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -27,7 +27,8 @@ default_config = {
         },
         "mongodb": {
             "host": "127.0.0.1",
-            "port": "47336"
+            "port": "47336",
+            "database": "mindsdb"
         }
     }
 }


### PR DESCRIPTION
Should work by setting config['api']['mysql']['database'].
Checks:
- [x]  mysql
- [x] mariadb
- [x] postgres
- [x] clickhouse
- [x] mssql

For mongo db name defined by config['api']['mongodb']['database']
- [x] mongodb checked