### PR TITLE
Static file fix(?)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ distributions/docker-compose/*/storage
 venv/*
 root
 static
+tmp
+predictors
+datasources
+.pytest_cache

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ tests/docker/mongodb/storage_*
 .vscode
 distributions/docker-compose/*/storage
 venv/*
+root
+static

--- a/mindsdb/api/http/initialize.py
+++ b/mindsdb/api/http/initialize.py
@@ -184,6 +184,10 @@ def initialize_flask(config):
         static_folder=config.paths['static']
     )
 
+    @app.route('/')
+    def root_index():
+        return app.send_static_file('index.html')
+
     app.config['SWAGGER_HOST'] = 'http://localhost:8000/mindsdb'
     authorizations = {
         'apikey': {
@@ -212,7 +216,8 @@ def initialize_flask(config):
         authorizations=authorizations,
         security=['apikey'],
         url_prefix=':8000',
-        prefix='/api'
+        prefix='/api',
+        doc='/doc/'
     )
 
     # NOTE rewrite it, that hotfix to see GUI link

--- a/mindsdb/api/http/initialize.py
+++ b/mindsdb/api/http/initialize.py
@@ -31,7 +31,7 @@ class Swagger_Api(Api):
 
 
 def initialize_static(config):
-    ''' Update Scout files basing on compatible-config.json content. 
+    ''' Update Scout files basing on compatible-config.json content.
         Files will be downloaded and updated if new version of GUI > current.
         Current GUI version stored in static/version.txt.
     '''
@@ -177,9 +177,10 @@ def initialize_static(config):
 
 
 def initialize_flask(config):
+    # Apparently there's a bug that causes the static path not to work if it's '/' -- https://github.com/pallets/flask/issues/3134, I think '' should achieve the same thing (???)
     app = Flask(
         __name__,
-        static_url_path='/',
+        static_url_path='',
         static_folder=config.paths['static']
     )
 

--- a/mindsdb/api/http/start.py
+++ b/mindsdb/api/http/start.py
@@ -43,7 +43,7 @@ def start(config, verbose=False):
     host = config['api']['http']['host']
 
     server = os.environ.get('MINDSDB_DEFAULT_SERVER', 'waitress')
-
+    
     if server.lower() == 'waitress':
         serve(app, port=port, host=host)
     elif server.lower() == 'flask':


### PR DESCRIPTION
Fix to static file path to be `''` instead of `'/'`. Apparently `'/'` sometimes doesn't work (https://github.com/pallets/flask/issues/3134)... though flask says it should. Maybe it's only an issue with some versions or environments, but if I encountered it chances are other people might, so we might as well use `''` if there is not harm @StpMax , thoughts ?

Also added a few files to the `.gitignore` with this ocassion.