### PR TITLE
Set allow_reuse_address by default for mysql api

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
+++ b/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
@@ -1472,9 +1472,7 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
 
         log.info(f'Starting MindsDB Mysql proxy server on tcp://{host}:{port}')
 
-        # Create the server
-        if config.get('debug') is True:
-            SocketServer.TCPServer.allow_reuse_address = True
+        SocketServer.TCPServer.allow_reuse_address = True
         server = SocketServer.ThreadingTCPServer((host, port), MysqlProxy)
 
         atexit.register(MysqlProxy.server_close, srv=server)


### PR DESCRIPTION
I think it should be by set by default. I looked in 'waitress' sources, they set this option without any conditions. And i dont see any real situation where we need it switched off.