### PR TITLE
Caching data analysis forever

### DIFF
--- a/mindsdb/api/http/namespaces/datasource.py
+++ b/mindsdb/api/http/namespaces/datasource.py
@@ -152,6 +152,8 @@ class Analyze(Resource):
         if name in ds_analysis:
             if ds_analysis[name] is None:
                 return {'status': 'analyzing'}, 200
+            elif (datetime.datetime.utcnow() - ds_analysis[name]['created_at']) > datetime.timedelta(seconds=3600):
+                del ds_analysis[name]
             else:
                 analysis = ds_analysis[name]['data']
                 return analysis, 200

--- a/mindsdb/api/http/namespaces/datasource.py
+++ b/mindsdb/api/http/namespaces/datasource.py
@@ -152,8 +152,6 @@ class Analyze(Resource):
         if name in ds_analysis:
             if ds_analysis[name] is None:
                 return {'status': 'analyzing'}, 200
-            elif (datetime.datetime.utcnow() - ds_analysis[name]['created_at']) > datetime.timedelta(seconds=10):
-                del ds_analysis[name]
             else:
                 analysis = ds_analysis[name]['data']
                 return analysis, 200


### PR DESCRIPTION
Removed the caching refresh limit of 10 seconds for data analysis, due to datasource versioning we can just cache this forever.