### PR TITLE
fixed address already in use when running mindsdb

### DIFF
--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -27,13 +27,15 @@ from mindsdb.utilities.log import initialize_log
 
 
 def close_api_gracefully(apis):
-    for api in apis.values():
-        process = api['process']
-        sys.stdout.flush()
-        process.terminate()
-        process.join()
-        sys.stdout.flush()
-
+    try: 
+        for api in apis.values():
+            process = api['process']
+            sys.stdout.flush()
+            process.terminate()
+            process.join()
+            sys.stdout.flush()
+    except KeyboardInterrupt:
+        sys.exit(0)
 
 if __name__ == '__main__':
     version_error_msg = """


### PR DESCRIPTION
Fixes #823 

## Please describe what changes you made, in as much detail as possible
  - Previously, there was a bug that when interrupting the main process by ctrl-c, all other processes should have stopped too. 
    But sometimes that didn't happen in some cases.
  - In order to solve this issue , this PR is an improvement to the existing code that adds `try - except` to  `close_api_gracefully` 
    function so that the graceful exit can take place.

Changes can be found [here](https://github.com/yash2189/mindsdb/blob/fix%23823/mindsdb/__main__.py)
mindsdb