### PR TITLE
Tests using remote databases

### DIFF
--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
           pip install git+https://github.com/mindsdb/mindsdb_native.git@staging --upgrade --no-cache-dir
           pip install git+https://github.com/mindsdb/lightwood.git@staging --upgrade --no-cache-dir
-    - name: Check copy db file
+    - name: Run integration api and flow tests
       run: |
         if [ "$RUNNER_OS" == "Linux" ]; then
           mkdir -p ~/.ssh/
@@ -36,17 +36,28 @@ jobs:
           scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/db_machine ubuntu@3.220.66.106:/home/ubuntu/mindsdb_server_enterprise/database_testing_env/credentials.json ~/.mindsdb_credentials.json
           sudo chmod 644 ~/.mindsdb_credentials.json
           pip install -r requirements_test.txt
+
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -L 127.0.0.1:5005:127.0.0.1:5005 ubuntu@3.220.66.106
+
+          # MariaDB
+          export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
+          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
+          python tests/integration_tests/flows/test_mariadb.py
+
+          # MySQL
+          export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
+          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
+          python tests/integration_tests/flows/test_mysql.py
 
           # ClickHouse
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
           python tests/integration_tests/flows/test_clickhouse.py
 
-          # MariaDB
+          # PostgreSQL
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
-          python tests/integration_tests/flows/test_mariadb.py
+          python tests/integration_tests/flows/test_postgres.py
         fi
       shell: bash
       env:

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -45,10 +45,10 @@ jobs:
           echo -e "\n=== *** === *** ===\ntest MariaDB, port=$MINDSDB_PORT\n=== *** === *** ===\n"
           python tests/integration_tests/flows/test_mariadb.py
 
-          # # MySQL
-          # export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          # ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
-          # python tests/integration_tests/flows/test_mysql.py
+          # MySQL
+          export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
+          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
+          python tests/integration_tests/flows/test_mysql.py
 
           # ClickHouse
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -35,10 +35,11 @@ jobs:
           sudo chmod 644 ~/.mindsdb_credentials.json
           pip install -r requirements_test.txt
 
-          export USE_EXTERNAL_DB_SERVER="0"
-          python tests/integration_tests/flows/test_mongo.py
-
           export USE_EXTERNAL_DB_SERVER="1"
+
+          # MongoDB
+          echo -e "\n===============\ntest MongoDB\n===============\n"
+          python tests/integration_tests/flows/test_mongo.py
 
           # PostgreSQL
           echo -e "\n===============\ntest PostgreSQL\n===============\n"

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -39,16 +39,17 @@ jobs:
 
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -L 127.0.0.1:5005:127.0.0.1:5005 ubuntu@3.220.66.106
 
+          # MySQL
+          export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
+          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
+          echo -e "\n=== *** === *** ===\ntest MySQL, port=$MINDSDB_PORT\n=== *** === *** ===\n"
+          python tests/integration_tests/flows/test_mysql.py
+
           # MariaDB
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
           echo -e "\n=== *** === *** ===\ntest MariaDB, port=$MINDSDB_PORT\n=== *** === *** ===\n"
           python tests/integration_tests/flows/test_mariadb.py
-
-          # MySQL
-          export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
-          python tests/integration_tests/flows/test_mysql.py
 
           # ClickHouse
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -41,24 +41,24 @@ jobs:
 
           # MariaDB
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
+          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:47335 ubuntu@3.220.66.106
           echo -e "\n=== *** === *** ===\ntest MariaDB, port=$MINDSDB_PORT\n=== *** === *** ===\n"
           python tests/integration_tests/flows/test_mariadb.py
 
           # # MySQL
           # export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          # ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
+          # ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:47335 ubuntu@3.220.66.106
           # python tests/integration_tests/flows/test_mysql.py
 
           # ClickHouse
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
+          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:47335 ubuntu@3.220.66.106
           echo -e "\n=== *** === *** ===\ntest ClickHouse, port=$MINDSDB_PORT\n=== *** === *** ===\n"
           python tests/integration_tests/flows/test_clickhouse.py
 
           # # PostgreSQL
           # export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          # ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
+          # ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:47335 ubuntu@3.220.66.106
           # python tests/integration_tests/flows/test_postgres.py
         fi
       shell: bash

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -39,6 +39,12 @@ jobs:
 
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -L 127.0.0.1:5005:127.0.0.1:5005 ubuntu@3.220.66.106
 
+          # PostgreSQL
+          export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
+          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
+          echo -e "\n=== *** === *** ===\ntest PostgreSQL, port=$MINDSDB_PORT\n=== *** === *** ===\n"
+          python tests/integration_tests/flows/test_postgres.py
+
           # MySQL
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
@@ -56,11 +62,6 @@ jobs:
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
           echo -e "\n=== *** === *** ===\ntest ClickHouse, port=$MINDSDB_PORT\n=== *** === *** ===\n"
           python tests/integration_tests/flows/test_clickhouse.py
-
-          # # PostgreSQL
-          # export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          # ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
-          # python tests/integration_tests/flows/test_postgres.py
         fi
       shell: bash
       env:

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -42,7 +42,7 @@ jobs:
           # MariaDB
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
-          echo -e "\n=== *** === *** ===\ncheck MariaDB, port=$MINDSDB_PORT\n=== *** === *** ===\n"
+          echo -e "\n=== *** === *** ===\ntest MariaDB, port=$MINDSDB_PORT\n=== *** === *** ===\n"
           python tests/integration_tests/flows/test_mariadb.py
 
           # # MySQL
@@ -53,6 +53,7 @@ jobs:
           # ClickHouse
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
+          echo -e "\n=== *** === *** ===\ntest ClickHouse, port=$MINDSDB_PORT\n=== *** === *** ===\n"
           python tests/integration_tests/flows/test_clickhouse.py
 
           # # PostgreSQL

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -41,24 +41,24 @@ jobs:
 
           # MariaDB
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:47335 ubuntu@3.220.66.106
+          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
           echo -e "\n=== *** === *** ===\ntest MariaDB, port=$MINDSDB_PORT\n=== *** === *** ===\n"
           python tests/integration_tests/flows/test_mariadb.py
 
           # # MySQL
           # export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          # ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:47335 ubuntu@3.220.66.106
+          # ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
           # python tests/integration_tests/flows/test_mysql.py
 
           # ClickHouse
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:47335 ubuntu@3.220.66.106
+          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
           echo -e "\n=== *** === *** ===\ntest ClickHouse, port=$MINDSDB_PORT\n=== *** === *** ===\n"
           python tests/integration_tests/flows/test_clickhouse.py
 
           # # PostgreSQL
           # export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          # ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:47335 ubuntu@3.220.66.106
+          # ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
           # python tests/integration_tests/flows/test_postgres.py
         fi
       shell: bash

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -68,6 +68,8 @@ jobs:
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
           echo -e "\n=== *** === *** ===\ntest Cutsom model, port=$MINDSDB_PORT\n=== *** === *** ===\n"
           python tests/integration_tests/flows/test_custom_model.py
+
+          python tests/integration_tests/api/test_http.py
         fi
       shell: bash
       env:

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -45,33 +45,23 @@ jobs:
           export USE_EXTERNAL_DB_SERVER="1"
 
           # PostgreSQL
-          export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
-          echo -e "\n=== *** === *** ===\ntest PostgreSQL, port=$MINDSDB_PORT\n=== *** === *** ===\n"
+          echo -e "\n===============\ntest PostgreSQL\n===============\n"
           python tests/integration_tests/flows/test_postgres.py
 
           # MySQL
-          export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
-          echo -e "\n=== *** === *** ===\ntest MySQL, port=$MINDSDB_PORT\n=== *** === *** ===\n"
+          echo -e "\n===============\ntest MySQL\n===============\n"
           python tests/integration_tests/flows/test_mysql.py
 
           # MariaDB
-          export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
-          echo -e "\n=== *** === *** ===\ntest MariaDB, port=$MINDSDB_PORT\n=== *** === *** ===\n"
+          echo -e "\n===============\ntest MariaDB\n===============\n"
           python tests/integration_tests/flows/test_mariadb.py
 
           # ClickHouse
-          export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
-          echo -e "\n=== *** === *** ===\ntest ClickHouse, port=$MINDSDB_PORT\n=== *** === *** ===\n"
+          echo -e "\n===============\ntest ClickHouse\n===============\n"
           python tests/integration_tests/flows/test_clickhouse.py
 
           # Cutsom model
-          export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
-          echo -e "\n=== *** === *** ===\ntest Cutsom model, port=$MINDSDB_PORT\n=== *** === *** ===\n"
+          echo -e "\n===============\ntest Cutsom model\n===============\n"
           python tests/integration_tests/flows/test_custom_model.py
 
           python tests/integration_tests/api/test_http.py

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -37,9 +37,13 @@ jobs:
           sudo chmod 644 ~/.mindsdb_credentials.json
           pip install -r requirements_test.txt
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -L 127.0.0.1:5005:127.0.0.1:5005 ubuntu@3.220.66.106
-          # export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          # ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
-          # python tests/integration_tests/flows/test_clickhouse.py
+
+          # ClickHouse
+          export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
+          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
+          python tests/integration_tests/flows/test_clickhouse.py
+
+          # MariaDB
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
           python tests/integration_tests/flows/test_mariadb.py

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -37,9 +37,9 @@ jobs:
           sudo chmod 644 ~/.mindsdb_credentials.json
           pip install -r requirements_test.txt
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -L 127.0.0.1:5005:127.0.0.1:5005 ubuntu@3.220.66.106
-          export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
-          python tests/integration_tests/flows/test_clickhouse.py
+          # export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
+          # ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
+          # python tests/integration_tests/flows/test_clickhouse.py
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
           python tests/integration_tests/flows/test_mariadb.py

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -39,7 +39,10 @@ jobs:
 
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -L 127.0.0.1:5005:127.0.0.1:5005 ubuntu@3.220.66.106
 
+          export USE_EXTERNAL_DB_SERVER="0"
           python tests/integration_tests/flows/test_mongo.py
+
+          export USE_EXTERNAL_DB_SERVER="1"
 
           # PostgreSQL
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -36,8 +36,9 @@ jobs:
           scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/db_machine ubuntu@3.220.66.106:/home/ubuntu/mindsdb_server_enterprise/database_testing_env/credentials.json ~/.mindsdb_credentials.json
           sudo chmod 644 ~/.mindsdb_credentials.json
           pip install -r requirements_test.txt
-          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:47335 ubuntu@3.220.66.106
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -L 127.0.0.1:5005:127.0.0.1:5005 ubuntu@3.220.66.106
+          export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
+          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
           python tests/integration_tests/flows/test_clickhouse.py
           python tests/integration_tests/flows/test_mariadb.py
         fi

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -35,10 +35,8 @@ jobs:
           sudo chmod 644 ~/.mindsdb_credentials.json
           pip install -r requirements_test.txt
 
-          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -L 127.0.0.1:5005:127.0.0.1:5005 ubuntu@3.220.66.106
-
           export USE_EXTERNAL_DB_SERVER="0"
-          python tests/integration_tests/flows/test_mongo.py
+          # python tests/integration_tests/flows/test_mongo.py
 
           export USE_EXTERNAL_DB_SERVER="1"
 
@@ -46,23 +44,23 @@ jobs:
           echo -e "\n===============\ntest PostgreSQL\n===============\n"
           python tests/integration_tests/flows/test_postgres.py
 
-          # MySQL
-          echo -e "\n===============\ntest MySQL\n===============\n"
-          python tests/integration_tests/flows/test_mysql.py
+          # # MySQL
+          # echo -e "\n===============\ntest MySQL\n===============\n"
+          # python tests/integration_tests/flows/test_mysql.py
 
-          # MariaDB
-          echo -e "\n===============\ntest MariaDB\n===============\n"
-          python tests/integration_tests/flows/test_mariadb.py
+          # # MariaDB
+          # echo -e "\n===============\ntest MariaDB\n===============\n"
+          # python tests/integration_tests/flows/test_mariadb.py
 
-          # ClickHouse
-          echo -e "\n===============\ntest ClickHouse\n===============\n"
-          python tests/integration_tests/flows/test_clickhouse.py
+          # # ClickHouse
+          # echo -e "\n===============\ntest ClickHouse\n===============\n"
+          # python tests/integration_tests/flows/test_clickhouse.py
 
-          # Cutsom model
-          echo -e "\n===============\ntest Cutsom model\n===============\n"
-          python tests/integration_tests/flows/test_custom_model.py
+          # # Cutsom model
+          # echo -e "\n===============\ntest Cutsom model\n===============\n"
+          # python tests/integration_tests/flows/test_custom_model.py
 
-          python tests/integration_tests/api/test_http.py
+          # python tests/integration_tests/api/test_http.py
         fi
       shell: bash
       env:

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -62,6 +62,12 @@ jobs:
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
           echo -e "\n=== *** === *** ===\ntest ClickHouse, port=$MINDSDB_PORT\n=== *** === *** ===\n"
           python tests/integration_tests/flows/test_clickhouse.py
+
+          # Cutsom model
+          export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
+          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
+          echo -e "\n=== *** === *** ===\ntest Cutsom model, port=$MINDSDB_PORT\n=== *** === *** ===\n"
+          python tests/integration_tests/flows/test_custom_model.py
         fi
       shell: bash
       env:

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -36,7 +36,7 @@ jobs:
           pip install -r requirements_test.txt
 
           export USE_EXTERNAL_DB_SERVER="0"
-          # python tests/integration_tests/flows/test_mongo.py
+          python tests/integration_tests/flows/test_mongo.py
 
           export USE_EXTERNAL_DB_SERVER="1"
 
@@ -44,23 +44,23 @@ jobs:
           echo -e "\n===============\ntest PostgreSQL\n===============\n"
           python tests/integration_tests/flows/test_postgres.py
 
-          # # MySQL
-          # echo -e "\n===============\ntest MySQL\n===============\n"
-          # python tests/integration_tests/flows/test_mysql.py
+          # MySQL
+          echo -e "\n===============\ntest MySQL\n===============\n"
+          python tests/integration_tests/flows/test_mysql.py
 
-          # # MariaDB
-          # echo -e "\n===============\ntest MariaDB\n===============\n"
-          # python tests/integration_tests/flows/test_mariadb.py
+          # MariaDB
+          echo -e "\n===============\ntest MariaDB\n===============\n"
+          python tests/integration_tests/flows/test_mariadb.py
 
-          # # ClickHouse
-          # echo -e "\n===============\ntest ClickHouse\n===============\n"
-          # python tests/integration_tests/flows/test_clickhouse.py
+          # ClickHouse
+          echo -e "\n===============\ntest ClickHouse\n===============\n"
+          python tests/integration_tests/flows/test_clickhouse.py
 
-          # # Cutsom model
-          # echo -e "\n===============\ntest Cutsom model\n===============\n"
-          # python tests/integration_tests/flows/test_custom_model.py
+          # Cutsom model
+          echo -e "\n===============\ntest Cutsom model\n===============\n"
+          python tests/integration_tests/flows/test_custom_model.py
 
-          # python tests/integration_tests/api/test_http.py
+          python tests/integration_tests/api/test_http.py
         fi
       shell: bash
       env:

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -39,6 +39,8 @@ jobs:
 
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -L 127.0.0.1:5005:127.0.0.1:5005 ubuntu@3.220.66.106
 
+          python tests/integration_tests/flows/test_mongo.py
+
           # PostgreSQL
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:$MINDSDB_PORT:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -40,6 +40,8 @@ jobs:
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
           python tests/integration_tests/flows/test_clickhouse.py
+          export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
+          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
           python tests/integration_tests/flows/test_mariadb.py
         fi
       shell: bash

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -31,7 +31,6 @@ jobs:
           echo "$DB_MACHINE_KEY" > ~/.ssh/db_machine
           sudo chmod 600 ~/.ssh/db_machine
           echo "$DATABASE_CREDENTIALS" > ~/.mindsdb_credentials.json
-          # scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/db_machine ubuntu@3.220.66.106:/home/ubuntu/mindsdb_server_enterprise/database_testing_env/credentials.json ~/.mindsdb_credentials.json
           sudo chmod 644 ~/.mindsdb_credentials.json
 
           pip install -r requirements_test.txt

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -30,9 +30,10 @@ jobs:
           mkdir -p ~/.ssh/
           echo "$DB_MACHINE_KEY" > ~/.ssh/db_machine
           sudo chmod 600 ~/.ssh/db_machine
-          # echo "$DATABASE_CREDENTIALS" > ~/.mindsdb_credentials.json
-          scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/db_machine ubuntu@3.220.66.106:/home/ubuntu/mindsdb_server_enterprise/database_testing_env/credentials.json ~/.mindsdb_credentials.json
+          echo "$DATABASE_CREDENTIALS" > ~/.mindsdb_credentials.json
+          # scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/db_machine ubuntu@3.220.66.106:/home/ubuntu/mindsdb_server_enterprise/database_testing_env/credentials.json ~/.mindsdb_credentials.json
           sudo chmod 644 ~/.mindsdb_credentials.json
+
           pip install -r requirements_test.txt
 
           export USE_EXTERNAL_DB_SERVER="1"

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -7,10 +7,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # os: [ubuntu-latest, windows-latest, macos-latest]
-        os: [ubuntu-latest]
-        # python-version: [3.6, 3.7, 3.8]
-        python-version: [3.6]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -68,31 +66,9 @@ jobs:
         fi
       shell: bash
       env:
+        CHECK_FOR_UPDATES: False
         DB_MACHINE_KEY: ${{secrets.DB_MACHINE_KEY}}
         DATABASE_CREDENTIALS: ${{secrets.DATABASE_CREDENTIALS}}
-    # - name: Run integration api and flow tests
-    #   run: |
-    #     if [ "$RUNNER_OS" == "Linux" ]; then
-    #       cd tests/docker
-    #       docker-compose -f docker-compose.yml up -d
-    #       cd ../..
-    #       pip install -r requirements_test.txt
-    #       # maybe use TestSuite addTest
-    #       python tests/integration_tests/flows/test_custom_model.py
-    #       python tests/integration_tests/flows/test_clickhouse.py
-    #       python tests/integration_tests/flows/test_mariadb.py
-    #       python tests/integration_tests/flows/test_mysql.py
-    #       python tests/integration_tests/flows/test_postgres.py
-    #       python tests/integration_tests/flows/test_mongo.py
-    #       sleep 61
-    #       python tests/integration_tests/api/test_http.py
-    #       cd tests/docker
-    #       docker-compose down
-    #     fi
-    #   shell: bash
-    #   env:
-    #     CHECK_FOR_UPDATES: False
-
   deploy_windows_installer:
     runs-on: windows-latest
     needs: test

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -42,22 +42,23 @@ jobs:
           # MariaDB
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
+          echo -e "\n=== *** === *** ===\ncheck MariaDB, port=$MINDSDB_PORT\n=== *** === *** ===\n"
           python tests/integration_tests/flows/test_mariadb.py
 
-          # MySQL
-          export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
-          python tests/integration_tests/flows/test_mysql.py
+          # # MySQL
+          # export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
+          # ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
+          # python tests/integration_tests/flows/test_mysql.py
 
           # ClickHouse
           export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
           ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
           python tests/integration_tests/flows/test_clickhouse.py
 
-          # PostgreSQL
-          export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
-          ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
-          python tests/integration_tests/flows/test_postgres.py
+          # # PostgreSQL
+          # export MINDSDB_PORT=$(curl http://127.0.0.1:5005/port)
+          # ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN -R 127.0.0.1:47335:127.0.0.1:$MINDSDB_PORT ubuntu@3.220.66.106
+          # python tests/integration_tests/flows/test_postgres.py
         fi
       shell: bash
       env:

--- a/mindsdb/api/mysql/mysql_proxy/classes/server_capabilities.py
+++ b/mindsdb/api/mysql/mysql_proxy/classes/server_capabilities.py
@@ -1,0 +1,22 @@
+from mindsdb.api.mysql.mysql_proxy.libs.constants.mysql import DEFAULT_CAPABILITIES
+
+
+class ServerCapabilities():
+    def __init__(self, capabilities):
+        self._capabilities = capabilities
+
+    def has(self, cap):
+        return cap & self._capabilities > 0
+
+    def set(self, cap, value=True):
+        if value:
+            self._capabilities = self._capabilities | cap
+        else:
+            self._capabilities = self._capabilities & (~cap)
+
+    @property
+    def value(self):
+        return self._capabilities
+
+
+server_capabilities = ServerCapabilities(DEFAULT_CAPABILITIES)

--- a/mindsdb/api/mysql/mysql_proxy/data_types/mysql_packets/handshake_packet.py
+++ b/mindsdb/api/mysql/mysql_proxy/data_types/mysql_packets/handshake_packet.py
@@ -13,12 +13,12 @@
 import logging
 from mindsdb.api.mysql.mysql_proxy.data_types.mysql_packet import Packet
 from mindsdb.api.mysql.mysql_proxy.libs.constants.mysql import (
-    DEFAULT_CAPABILITIES,
     DEFAULT_AUTH_METHOD,
     DEFAULT_COALLITION_ID,
     FILLER_FOR_WIRESHARK_DUMP,
     SERVER_STATUS_AUTOCOMMIT
 )
+from mindsdb.api.mysql.mysql_proxy.classes.server_capabilities import server_capabilities
 from mindsdb.api.mysql.mysql_proxy.data_types.mysql_datum import Datum
 
 
@@ -29,15 +29,16 @@ class HandshakePacket(Packet):
     '''
 
     def setup(self):
+        capabilities = server_capabilities.value
         self.protocol_version = Datum('int<1>', 10)
         self.server_version = Datum('string<NUL>', '5.7.1-MindsDB-1.0')
         self.connection_id = Datum('int<4>', self.proxy.connection_id)
         self.scramble_1st_part = Datum('string<8>', self.proxy.salt[:8])
         self.reserved_byte = Datum('string<1>', '')
-        self.server_capabilities_1st_part = Datum('int<2>', DEFAULT_CAPABILITIES)
+        self.server_capabilities_1st_part = Datum('int<2>', capabilities)
         self.server_default_collation = Datum('int<1>', DEFAULT_COALLITION_ID)
         self.status_flags = Datum('int<2>', SERVER_STATUS_AUTOCOMMIT)
-        self.server_capabilities_2nd_part = Datum('int<2>', DEFAULT_CAPABILITIES >> 16)
+        self.server_capabilities_2nd_part = Datum('int<2>', capabilities >> 16)
         self.wireshark_filler = Datum('int<1>', FILLER_FOR_WIRESHARK_DUMP)
         # self.wireshark_filler = Datum('int<1>', len(self.proxy.salt))
         self.reserved_filler1 = Datum('string<6>', '')

--- a/mindsdb/api/mysql/mysql_proxy/data_types/mysql_packets/handshake_response_packet.py
+++ b/mindsdb/api/mysql/mysql_proxy/data_types/mysql_packets/handshake_response_packet.py
@@ -11,14 +11,12 @@
 
 # https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::HandshakeResponse
 
-import traceback
-from pprint import pformat
-
 from mindsdb.api.mysql.mysql_proxy.data_types.mysql_packet import Packet
 from mindsdb.api.mysql.mysql_proxy.data_types.mysql_datum import Datum
 from mindsdb.api.mysql.mysql_proxy.external_libs.mysql_scramble import scramble
 from mindsdb.api.mysql.mysql_proxy.classes.client_capabilities import ClentCapabilities
-from mindsdb.api.mysql.mysql_proxy.libs.constants.mysql import DEFAULT_CAPABILITIES, CAPABILITIES
+from mindsdb.api.mysql.mysql_proxy.libs.constants.mysql import CAPABILITIES
+from mindsdb.api.mysql.mysql_proxy.classes.server_capabilities import server_capabilities
 
 
 class HandshakeResponsePacket(Packet):
@@ -69,12 +67,12 @@ class HandshakeResponsePacket(Packet):
             buffer = self.reserved.setFromBuff(buffer)
             buffer = self.username.setFromBuff(buffer)
 
-            if DEFAULT_CAPABILITIES & CAPABILITIES.CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA > 0 \
-                and capabilities.PLUGIN_AUTH_LENENC_CLIENT_DATA:
+            if server_capabilities.has(CAPABILITIES.CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA) \
+                    and capabilities.PLUGIN_AUTH_LENENC_CLIENT_DATA:
                 self.enc_password = Datum('string<lenenc>')
                 buffer = self.enc_password.setFromBuff(buffer)
-            elif DEFAULT_CAPABILITIES & CAPABILITIES.CLIENT_SECURE_CONNECTION > 0 \
-                and capabilities.SECURE_CONNECTION:
+            elif server_capabilities.has(CAPABILITIES.CLIENT_SECURE_CONNECTION) \
+                    and capabilities.SECURE_CONNECTION:
                 self.auth_resp_len = Datum('int<1>')
                 buffer = self.auth_resp_len.setFromBuff(buffer)
                 self.enc_password = Datum(f'string<{self.auth_resp_len.value}>')

--- a/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
+++ b/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
@@ -30,6 +30,7 @@ from mindsdb.api.mysql.mysql_proxy.data_types.mysql_packet import Packet
 from mindsdb.api.mysql.mysql_proxy.controllers.session_controller import SessionController
 from mindsdb.api.mysql.mysql_proxy.datahub import init_datahub
 from mindsdb.api.mysql.mysql_proxy.classes.client_capabilities import ClentCapabilities
+from mindsdb.api.mysql.mysql_proxy.classes.server_capabilities import server_capabilities
 from mindsdb.api.mysql.mysql_proxy.classes.sql_statement_parser import SqlStatementParser, SQL_PARAMETER, SQL_DEFAULT
 from mindsdb.api.mysql.mysql_proxy.utilities import log
 
@@ -48,7 +49,8 @@ from mindsdb.api.mysql.mysql_proxy.libs.constants.mysql import (
     SERVER_VARIABLES,
     DEFAULT_AUTH_METHOD,
     SERVER_STATUS,
-    FIELD_FLAG
+    FIELD_FLAG,
+    CAPABILITIES
 )
 
 from mindsdb.api.mysql.mysql_proxy.data_types.mysql_packets import (
@@ -1462,6 +1464,11 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
             CERT_PATH = tempfile.mkstemp(prefix='mindsdb_cert_', text=True)[1]
             make_ssl_cert(CERT_PATH)
             atexit.register(lambda: os.remove(CERT_PATH))
+
+        server_capabilities.set(
+            CAPABILITIES.CLIENT_SSL,
+            config['api']['mysql']['ssl']
+        )
 
         default_store = DataStore(config)
         mdb = MindsdbNative(config)

--- a/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
+++ b/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
@@ -193,10 +193,11 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
             log.info('switch to SSL')
             self.session.is_ssl = True
 
-            ssl_socket = ssl.wrap_socket(
+            ssl_context = ssl.SSLContext()
+            ssl_context.load_cert_chain(CERT_PATH)
+            ssl_socket = ssl_context.wrap_socket(
                 self.socket,
                 server_side=True,
-                certfile=CERT_PATH,
                 do_handshake_on_connect=True
             )
 

--- a/mindsdb/integrations/postgres/postgres.py
+++ b/mindsdb/integrations/postgres/postgres.py
@@ -84,19 +84,19 @@ class PostgreSQL(Integration):
 
         self._query(f'DROP SCHEMA IF EXISTS {self.mindsdb_database} CASCADE')
 
-        self._query(f"DROP USER MAPPING IF EXISTS FOR {self.config['integrations'][self.name]['user']} SERVER mindsdb_server")
+        self._query(f"DROP USER MAPPING IF EXISTS FOR {self.config['integrations'][self.name]['user']} SERVER server_{self.mindsdb_database}")
 
-        self._query('DROP SERVER IF EXISTS mindsdb_server CASCADE')
+        self._query(f'DROP SERVER IF EXISTS server_{self.mindsdb_database} CASCADE')
 
         self._query(f'''
-            CREATE SERVER mindsdb_server
+            CREATE SERVER server_{self.mindsdb_database}
                 FOREIGN DATA WRAPPER mysql_fdw
                 OPTIONS (host '{host}', port '{port}');
         ''')
 
         self._query(f'''
            CREATE USER MAPPING FOR {self.config['integrations'][self.name]['user']}
-                SERVER mindsdb_server
+                SERVER server_{self.mindsdb_database}
                 OPTIONS (username '{user}', password '{password}');
         ''')
 
@@ -112,7 +112,7 @@ class PostgreSQL(Integration):
                 external_datasource text,
                 training_options text
             )
-            SERVER mindsdb_server
+            SERVER server_{self.mindsdb_database}
             OPTIONS (dbname 'mindsdb', table_name 'predictors');
         """
         self._query(q)
@@ -120,7 +120,7 @@ class PostgreSQL(Integration):
         q = f"""
             CREATE FOREIGN TABLE IF NOT EXISTS {self.mindsdb_database}.commands (
                 command text
-            ) SERVER mindsdb_server
+            ) SERVER server_{self.mindsdb_database}
             OPTIONS (dbname 'mindsdb', table_name 'commands');
         """
         self._query(q)
@@ -142,7 +142,7 @@ class PostgreSQL(Integration):
             q = f"""
                 CREATE FOREIGN TABLE {self.mindsdb_database}.{self._escape_table_name(name)} (
                     {columns_sql}
-                ) SERVER mindsdb_server
+                ) SERVER server_{self.mindsdb_database}
                 OPTIONS (dbname 'mindsdb', table_name '{name}');
             """
             self._query(q)

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -23,7 +23,8 @@ default_config = {
             "password": "",
             "port": "47335",
             "user": "mindsdb",
-            "database": "mindsdb"
+            "database": "mindsdb",
+            "ssl": True
         },
         "mongodb": {
             "host": "127.0.0.1",

--- a/mindsdb/utilities/functions.py
+++ b/mindsdb/utilities/functions.py
@@ -23,3 +23,9 @@ def cast_row_types(row, field_types):
         elif t == 'Date' and isinstance(row[key], (int, float)):
             timestamp = datetime.datetime.utcfromtimestamp(row[key])
             row[key] = timestamp.strftime('%Y-%m-%d')
+        elif t == 'Int' and isinstance(row[key], (int, float, str)):
+            try:
+                print(f'cast {row[key]} to {int(row[key])}')
+                row[key] = int(row[key])
+            except Exception:
+                pass

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,2 @@
-docker==4.2.2
 pymongo >= 3.10.1
 psutil >= 5.7.2

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,9 @@
+To run test, execute from project root:
+```
+python3 /tests/integration_tests/flows/test_{name}.py
+```
+Integration tests can be run in two modes, defined by env variable USE_EXTERNAL_DB_SERVER:
+1. if USE_EXTERNAL_DB_SERVER="0", than on run test will be runned docker container with target databasde.
+2. if USE_EXTERNAL_DB_SERVER="1", then ssh-tunnels to test database server will be up. For that should exists:  
+* `.mindsdb_credentials.json` file in home dir.
+* `~/.ssh/db_machine` with key for db machine.

--- a/tests/docker/cli.sh
+++ b/tests/docker/cli.sh
@@ -36,6 +36,12 @@ elif [ $1 = "postgres" ]; then
     docker-compose up postgres
 elif [ $1 = "postgres-stop" ]; then
     docker-compose stop postgres
+elif [ $1 = "mongo" ]; then
+    mkdir -p mongodb/storage/
+    docker-compose up mongo
+elif [ $1 = "mongo-stop" ]; then
+    docker-compose stop mongo
+
 elif [ $1 = "mongo-cluster" ]; then
     rm -rf mongodb/storage_config/ mongodb/storage_instance/ mongodb/storage_mongos/
     docker container stop mongo-mongos-test mongo-glue-test mongo-config-test mongo-instance-test
@@ -46,31 +52,22 @@ elif [ $1 = "mongo-cluster-stop" ]; then
     rm -rf mongodb/storage_config/ mongodb/storage_instance/ mongodb/storage_mongos/
     docker container stop mongo-mongos-test mongo-glue-test mongo-config-test mongo-instance-test
     docker container rm mongo-mongos-test mongo-glue-test mongo-config-test mongo-instance-test
-elif [ $1 = "mongo" ]; then
-    mkdir -p mongodb/storage/
-    docker-compose up mongo
-elif [ $1 = "mongo-stop" ]; then
-    docker-compose stop mongo
-
 elif [ $1 = "mongo-config" ]; then
     rm -rf mongodb/storage_config/
     mkdir -p mongodb/storage_config/
     docker-compose -f docker-compose-mongo.yml up mongo-config
 elif [ $1 = "mongo-config-stop" ]; then
     docker-compose -f docker-compose-mongo.yml stop mongo-config
-
 elif [ $1 = "mongo-instance" ]; then
     rm -rf mongodb/storage_instance/
     mkdir -p mongodb/storage_instance/
     docker-compose -f docker-compose-mongo.yml up mongo-instance
 elif [ $1 = "mongo-instance-stop" ]; then
     docker-compose -f docker-compose-mongo.yml stop mongo-instance
-
 elif [ $1 = "mongo-mongos" ]; then
     rm -rf mongodb/storage_mongos/
     mkdir -p mongodb/storage_mongos/
     docker-compose -f docker-compose-mongo.yml up mongo-mongos
 elif [ $1 = "mongo-mongos-stop" ]; then
     docker-compose -f docker-compose-mongo.yml stop mongo-mongos
-
 fi

--- a/tests/docker/cli.sh
+++ b/tests/docker/cli.sh
@@ -36,6 +36,16 @@ elif [ $1 = "postgres" ]; then
     docker-compose up postgres
 elif [ $1 = "postgres-stop" ]; then
     docker-compose stop postgres
+elif [ $1 = "mongo-cluster" ]; then
+    rm -rf mongodb/storage_config/ mongodb/storage_instance/ mongodb/storage_mongos/
+    docker container stop mongo-mongos-test mongo-glue-test mongo-config-test mongo-instance-test
+    docker container rm mongo-mongos-test mongo-glue-test mongo-config-test mongo-instance-test
+    docker-compose -f docker-compose-mongo.yml up
+elif [ $1 = "mongo-cluster-stop" ]; then
+    docker-compose -f docker-compose-mongo.yml stop
+    rm -rf mongodb/storage_config/ mongodb/storage_instance/ mongodb/storage_mongos/
+    docker container stop mongo-mongos-test mongo-glue-test mongo-config-test mongo-instance-test
+    docker container rm mongo-mongos-test mongo-glue-test mongo-config-test mongo-instance-test
 elif [ $1 = "mongo" ]; then
     mkdir -p mongodb/storage/
     docker-compose up mongo

--- a/tests/docker/docker-compose-mongo.yml
+++ b/tests/docker/docker-compose-mongo.yml
@@ -7,7 +7,7 @@ services:
         container_name: mongo-config-test
         ports:
           - 27000:27000
-        command: --configsvr --dbpath /data/db --port 27000 --replSet replconf
+        command: --configsvr --dbpath /data/db --port 27000 --replSet replconf --bind_ip 127.0.0.1
         volumes:
         - ./mongodb/storage_config:/data/db
     mongo-instance:
@@ -17,7 +17,7 @@ services:
         container_name: mongo-instance-test
         ports:
             - 27001:27001
-        command: --dbpath /data/db --port 27001 --shardsvr --replSet replmain --sslMode disabled
+        command: --dbpath /data/db --port 27001 --shardsvr --replSet replmain --sslMode disabled --bind_ip 127.0.0.1
         volumes:
         - ./mongodb/storage_instance:/data/db
     glue:

--- a/tests/docker/docker-compose-mongo.yml
+++ b/tests/docker/docker-compose-mongo.yml
@@ -5,7 +5,6 @@ services:
         image: mongo:3.6
         network_mode: host
         container_name: mongo-config-test
-        user: "${UID}:${GID}"
         ports:
           - 27000:27000
         command: --configsvr --dbpath /data/db --port 27000 --replSet replconf
@@ -16,12 +15,23 @@ services:
         image: mongo:3.6
         network_mode: host
         container_name: mongo-instance-test
-        user: "${UID}:${GID}"
         ports:
             - 27001:27001
         command: --dbpath /data/db --port 27001 --shardsvr --replSet replmain --sslMode disabled
         volumes:
         - ./mongodb/storage_instance:/data/db
+    glue:
+        build:
+            context: mongodb/glue/.
+            dockerfile: Dockerfile
+        image: mongo-glue-test:1.0
+        network_mode: host
+        container_name: mongo-glue-test
+        depends_on:
+            - mongo-config
+            - mongo-instance
+        volumes:
+        - ./mongodb/glue/data:/data
     mongo-mongos:
         build:
             context: mongodb/mongos/.
@@ -31,7 +41,8 @@ services:
         container_name: mongo-mongos-test
         depends_on:
             - mongo-config
-        user: "${UID}:${GID}"
+            - mongo-instance
+            - glue
         ports:
             - 27002:27002
         volumes:

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -52,3 +52,12 @@ services:
     volumes:
     - ./postgres/storage:/var/lib/postgresql/data
     - ./postgres/share:/share
+  mongo-instance:
+    image: mongo:3.6
+    network_mode: host
+    container_name: mongo-alone-test
+    ports:
+      - 27017:27017
+    command: --dbpath /data/db --port 27017
+    volumes:
+    - ./mongodb/storage:/data/db

--- a/tests/docker/mongodb/glue/Dockerfile
+++ b/tests/docker/mongodb/glue/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y wget gnupg2
+
+RUN wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add -
+RUN echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-4.4.list
+
+RUN apt-get update && apt-get install -y mongodb-org-shell
+
+RUN mkdir /waitforit && cd /waitforit && \
+    wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && \
+    chmod +x wait-for-it.sh
+
+VOLUME [ "/data" ]
+
+ENTRYPOINT [ "/data/entrypoint.sh" ]

--- a/tests/docker/mongodb/glue/data/entrypoint.sh
+++ b/tests/docker/mongodb/glue/data/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+echo "INIT TEST DOCKER ENV"
+cd /data
+/waitforit/wait-for-it.sh 127.0.0.1:27000
+/waitforit/wait-for-it.sh 127.0.0.1:27001
+mongo --port 27000 -u root -p 123 --authenticationDatabase admin < init_config_rs.js
+mongo --port 27000 < init_config_rs.js
+mongo --port 27001 < init_db_rs.js
+/waitforit/wait-for-it.sh 127.0.0.1:27002
+mongo --port 27002 < init_mongos.js

--- a/tests/docker/mongodb/glue/data/init_config_rs.js
+++ b/tests/docker/mongodb/glue/data/init_config_rs.js
@@ -1,0 +1,4 @@
+rs.initiate({
+    _id: 'replconf',
+    members: [{_id: 0, host: '127.0.0.1:27000'}]
+});

--- a/tests/docker/mongodb/glue/data/init_db_rs.js
+++ b/tests/docker/mongodb/glue/data/init_db_rs.js
@@ -2,3 +2,8 @@ rs.initiate({
     _id: 'replmain',
     members: [{_id: 0, host: '127.0.0.1:27001'}]
 });
+// we need create test_data db on exactly this shart.
+// instance will think it is 'master' in 2-3 seconds after rs.initiate
+sleep(5000);
+use test_data;
+db.placeholder.insert({x: 1});

--- a/tests/docker/mongodb/glue/data/init_db_rs.js
+++ b/tests/docker/mongodb/glue/data/init_db_rs.js
@@ -1,0 +1,4 @@
+rs.initiate({
+    _id: 'replmain',
+    members: [{_id: 0, host: '127.0.0.1:27001'}]
+});

--- a/tests/docker/mongodb/glue/data/init_mongos.js
+++ b/tests/docker/mongodb/glue/data/init_mongos.js
@@ -1,0 +1,1 @@
+sh.addShard("replmain/127.0.0.1:27001");

--- a/tests/docker/mongodb/mongos/mongos-dockerfile
+++ b/tests/docker/mongodb/mongos/mongos-dockerfile
@@ -1,4 +1,4 @@
 # FROM mongo:4.4
 FROM mongo:3.6
 
-CMD mongos --configdb replconf/127.0.0.1:27000 --port 27002
+CMD mongos --configdb replconf/127.0.0.1:27000 --port 27002 --bind_ip 127.0.0.1

--- a/tests/integration_tests/api/test_http.py
+++ b/tests/integration_tests/api/test_http.py
@@ -29,7 +29,6 @@ class HTTPTest(unittest.TestCase):
         mdb, datastore = common.run_environment(
             config,
             apis=['http'],
-            run_docker_db=[] if common.USE_EXTERNAL_DB_SERVER else ['mariadb', 'clickhouse'],
             override_integration_config={
                 'default_mariadb': {
                     'enabled': True

--- a/tests/integration_tests/api/test_http.py
+++ b/tests/integration_tests/api/test_http.py
@@ -35,7 +35,8 @@ class HTTPTest(unittest.TestCase):
             stdout=None,
             stderr=None
         )
-        for i in range(20):
+        for i in range(60):
+            print(i)
             try:
                 res = requests.get(f'{root}/util/ping')
                 if res.status_code != 200:
@@ -44,7 +45,7 @@ class HTTPTest(unittest.TestCase):
                     break
             except Exception:
                 time.sleep(1)
-                if i == 19:
+                if i == 59:
                     raise Exception("Can't connect!")
 
     @classmethod

--- a/tests/integration_tests/flows/common.py
+++ b/tests/integration_tests/flows/common.py
@@ -56,7 +56,7 @@ def prepare_config(config, enable_dbs=[], mindsdb_database='mindsdb', override_i
         config._config['integrations'][integration].update(override_integration_config[integration])
 
     for api in override_api_config:
-        config._config['api'].update(override_api_config[api])
+        config._config['api'][api].update(override_api_config[api])
 
     config['api']['mysql']['database'] = mindsdb_database
     config['api']['mongodb']['database'] = mindsdb_database

--- a/tests/integration_tests/flows/common.py
+++ b/tests/integration_tests/flows/common.py
@@ -102,6 +102,7 @@ if USE_EXTERNAL_DB_SERVER:
     open_ssh_tunnel(mindsdb_port, 'R')
     print(f'use mindsdb port={mindsdb_port}')
     config._config['api']['mysql']['port'] = mindsdb_port
+    config._config['api']['mongodb']['port'] = mindsdb_port
 
     with open(EXTERNAL_DB_CREDENTIALS, 'rt') as f:
         credentials = json.loads(f.read())

--- a/tests/integration_tests/flows/common.py
+++ b/tests/integration_tests/flows/common.py
@@ -78,9 +78,10 @@ def prepare_config(config, enable_dbs=[], mindsdb_database='mindsdb', override_i
     return temp_config_path
 
 
-def close_ssh_tunnel(sp, port):
+def close_ssh_tunnel(sp):
     sp.kill()
-    sp = subprocess.Popen(f'for pid in $(lsof -i :{port} -t); do kill -9 $pid; done', shell=True)
+    # sp = subprocess.Popen(f'for pid in $(lsof -i :{port} -t); do kill -9 $pid; done', shell=True)
+    sp = subprocess.Popen(f'kill -9 {sp.pid}', shell=True)
     sp.wait()
 
 
@@ -91,7 +92,7 @@ def open_ssh_tunnel(port, direction='R'):
         stdout=OUTPUT,
         stderr=OUTPUT
     )
-    atexit.register(close_ssh_tunnel, sp=sp, port=port)
+    atexit.register(close_ssh_tunnel, sp=sp)
 
 
 if USE_EXTERNAL_DB_SERVER:

--- a/tests/integration_tests/flows/common.py
+++ b/tests/integration_tests/flows/common.py
@@ -39,10 +39,10 @@ TEMP_DIR = Path(__file__).parent.absolute().joinpath('../../temp/').resolve()
 TEMP_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def prepare_config(config, enable_dbs=[], mindsdb_database='mindsdb', override_integration_config={}):
+def prepare_config(config, enable_dbs=[], mindsdb_database='mindsdb', override_integration_config={}, override_api_config={}):
     if isinstance(enable_dbs, list) is False:
         enable_dbs = [enable_dbs]
-    for key in config._config['integrations'].keys():
+    for key in config._config['integrations']:
         config._config['integrations'][key]['enabled'] = key in enable_dbs
 
     if USE_EXTERNAL_DB_SERVER:
@@ -52,8 +52,11 @@ def prepare_config(config, enable_dbs=[], mindsdb_database='mindsdb', override_i
                 if f'default_{key}' in config._config['integrations']:
                     config._config['integrations'][f'default_{key}'].update(cred[key])
 
-    for integration in override_integration_config.keys():
+    for integration in override_integration_config:
         config._config['integrations'][integration].update(override_integration_config[integration])
+
+    for api in override_api_config:
+        config._config['api'].update(override_api_config[api])
 
     config['api']['mysql']['database'] = mindsdb_database
     config['api']['mongodb']['database'] = mindsdb_database
@@ -200,12 +203,12 @@ def stop_mindsdb(sp):
     sp.wait()
 
 
-def run_environment(config, apis=['mysql'], run_docker_db=[], override_integration_config={}, mindsdb_database='mindsdb'):
+def run_environment(config, apis=['mysql'], run_docker_db=[], override_integration_config={}, override_api_config={}, mindsdb_database='mindsdb'):
     ''' services = [mindsdb|]
     '''
 
     default_databases = [f'default_{db}' for db in run_docker_db]
-    temp_config_path = prepare_config(config, default_databases, mindsdb_database, override_integration_config)
+    temp_config_path = prepare_config(config, default_databases, mindsdb_database, override_integration_config, override_api_config)
     config = Config(temp_config_path)
 
     db_ready = True

--- a/tests/integration_tests/flows/common.py
+++ b/tests/integration_tests/flows/common.py
@@ -80,13 +80,14 @@ def prepare_config(config, enable_dbs=[], mindsdb_database='mindsdb', override_i
 
 def close_ssh_tunnel(sp, port):
     sp.kill()
-    sp = subprocess.Popen(f'for pid in $(lsof -i :{port} -t); do kill -9 $pid; done', shell=True)
-    # sp = subprocess.Popen(f'kill -9 {sp.pid}', shell=True)
+    # NOTE line below will close connection in ALL test instances.
+    # sp = subprocess.Popen(f'for pid in $(lsof -i :{port} -t); do kill -9 $pid; done', shell=True)
+    sp = subprocess.Popen(f'ssh -S /tmp/.mindsdb-ssh-ctrl-{port} -O exit ubuntu@3.220.66.106', shell=True)
     sp.wait()
 
 
 def open_ssh_tunnel(port, direction='R'):
-    cmd = f'ssh -i ~/.ssh/db_machine -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fN{direction} 127.0.0.1:{port}:127.0.0.1:{port} ubuntu@3.220.66.106'
+    cmd = f'ssh -i ~/.ssh/db_machine -S /tmp/.mindsdb-ssh-ctrl-{port} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fMN{direction} 127.0.0.1:{port}:127.0.0.1:{port} ubuntu@3.220.66.106'
     sp = subprocess.Popen(
         cmd.split(' '),
         stdout=OUTPUT,

--- a/tests/integration_tests/flows/common.py
+++ b/tests/integration_tests/flows/common.py
@@ -21,8 +21,7 @@ from mindsdb_native import CONFIG
 # USE_EXTERNAL_DB_SERVER = os.getenv('EXTERNAL_DB_SERVER')
 USE_EXTERNAL_DB_SERVER = True
 
-# EXTERNAL_DB_CREDENTIALS = str(Path.home().joinpath('.mindsdb_credentials.json'))
-EXTERNAL_DB_CREDENTIALS = '/home/maxs/dev/mdb/venv_new/sources/mindsdb_server_enterprise/database_testing_env/credentials.json'
+EXTERNAL_DB_CREDENTIALS = str(Path.home().joinpath('.mindsdb_credentials.json'))
 
 MINDSDB_DATABASE = f'mindsdb_{int(time.time()*1000)}' if USE_EXTERNAL_DB_SERVER else 'mindsdb'
 

--- a/tests/integration_tests/flows/common.py
+++ b/tests/integration_tests/flows/common.py
@@ -21,7 +21,8 @@ from mindsdb_native import CONFIG
 # USE_EXTERNAL_DB_SERVER = os.getenv('EXTERNAL_DB_SERVER')
 USE_EXTERNAL_DB_SERVER = True
 
-EXTERNAL_DB_CREDENTIALS = str(Path.home().joinpath('.mindsdb_credentials.json'))
+# EXTERNAL_DB_CREDENTIALS = str(Path.home().joinpath('.mindsdb_credentials.json'))
+EXTERNAL_DB_CREDENTIALS = '/home/maxs/dev/mdb/venv_new/sources/mindsdb_server_enterprise/database_testing_env/credentials.json'
 
 MINDSDB_DATABASE = f'mindsdb_{int(time.time()*1000)}' if USE_EXTERNAL_DB_SERVER else 'mindsdb'
 
@@ -74,12 +75,12 @@ def prepare_config(config, enable_dbs=[], mindsdb_database='mindsdb', override_i
 
 if USE_EXTERNAL_DB_SERVER:
     config = Config(TEST_CONFIG)
-    r = requests.get('http://127.0.0.1:5005/port')
-    if r.status_code != 200:
-        raise Exception('Cant get port to run mindsdb')
-    mindsdb_port = r.content.decode()
-    print(f'use mindsdb port={mindsdb_port}')
-    config._config['api']['mysql']['port'] = mindsdb_port
+    # r = requests.get('http://127.0.0.1:5005/port')
+    # if r.status_code != 200:
+    #     raise Exception('Cant get port to run mindsdb')
+    # mindsdb_port = r.content.decode()
+    # print(f'use mindsdb port={mindsdb_port}')
+    # config._config['api']['mysql']['port'] = mindsdb_port
 
     with open(EXTERNAL_DB_CREDENTIALS, 'rt') as f:
         credentials = json.loads(f.read())

--- a/tests/integration_tests/flows/common.py
+++ b/tests/integration_tests/flows/common.py
@@ -74,12 +74,13 @@ def prepare_config(config, enable_dbs=[], mindsdb_database='mindsdb', override_i
 
 if USE_EXTERNAL_DB_SERVER:
     config = Config(TEST_CONFIG)
+    mindsdb_port = int(os.getenv('MINDSDB_PORT') or 47335)
     # r = requests.get('http://127.0.0.1:5005/port')
     # if r.status_code != 200:
     #     raise Exception('Cant get port to run mindsdb')
     # mindsdb_port = r.content.decode()
     # print(f'use mindsdb port={mindsdb_port}')
-    # config._config['api']['mysql']['port'] = mindsdb_port
+    config._config['api']['mysql']['port'] = mindsdb_port
 
     with open(EXTERNAL_DB_CREDENTIALS, 'rt') as f:
         credentials = json.loads(f.read())

--- a/tests/integration_tests/flows/common.py
+++ b/tests/integration_tests/flows/common.py
@@ -9,6 +9,7 @@ import os
 import socket
 from contextlib import closing
 import asyncio
+import shutil
 
 from mindsdb.utilities.fs import create_dirs_recursive
 from mindsdb.utilities.config import Config
@@ -58,6 +59,8 @@ def prepare_config(config, enable_dbs=[], mindsdb_database='mindsdb', override_i
     config['api']['mongodb']['database'] = mindsdb_database
 
     storage_dir = TEMP_DIR.joinpath('storage')
+    if storage_dir.is_dir():
+        shutil.rmtree(str(storage_dir))
     config._config['storage_dir'] = str(storage_dir)
 
     create_dirs_recursive(config.paths)

--- a/tests/integration_tests/flows/common.py
+++ b/tests/integration_tests/flows/common.py
@@ -206,6 +206,7 @@ def run_environment(config, apis=['mysql'], run_docker_db=[], override_integrati
 
     default_databases = [f'default_{db}' for db in run_docker_db]
     temp_config_path = prepare_config(config, default_databases, mindsdb_database, override_integration_config)
+    config = Config(temp_config_path)
 
     db_ready = True
     for db in run_docker_db:

--- a/tests/integration_tests/flows/common.py
+++ b/tests/integration_tests/flows/common.py
@@ -1,13 +1,10 @@
 import time
 from pathlib import Path
 import json
-import docker
 import requests
 import subprocess
 import atexit
 import os
-import socket
-from contextlib import closing
 import asyncio
 import shutil
 
@@ -15,11 +12,10 @@ from mindsdb.utilities.fs import create_dirs_recursive
 from mindsdb.utilities.config import Config
 from mindsdb.interfaces.native.mindsdb import MindsdbNative
 from mindsdb.interfaces.datastore.datastore import DataStore
-from mindsdb.interfaces.database.database import DatabaseWrapper
 from mindsdb.utilities.ps import wait_port, is_port_in_use
 from mindsdb_native import CONFIG
 
-USE_EXTERNAL_DB_SERVER = bool(int(os.getenv('USE_EXTERNAL_DB_SERVER') or "0"))
+USE_EXTERNAL_DB_SERVER = bool(int(os.getenv('USE_EXTERNAL_DB_SERVER') or "1"))
 
 EXTERNAL_DB_CREDENTIALS = str(Path.home().joinpath('.mindsdb_credentials.json'))
 
@@ -39,11 +35,9 @@ TEMP_DIR = Path(__file__).parent.absolute().joinpath('../../temp/').resolve()
 TEMP_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def prepare_config(config, enable_dbs=[], mindsdb_database='mindsdb', override_integration_config={}, override_api_config={}):
-    if isinstance(enable_dbs, list) is False:
-        enable_dbs = [enable_dbs]
+def prepare_config(config, mindsdb_database='mindsdb', override_integration_config={}, override_api_config={}):
     for key in config._config['integrations']:
-        config._config['integrations'][key]['enabled'] = key in enable_dbs
+        config._config['integrations'][key]['enabled'] = False
 
     if USE_EXTERNAL_DB_SERVER:
         with open(EXTERNAL_DB_CREDENTIALS, 'rt') as f:
@@ -117,45 +111,6 @@ if USE_EXTERNAL_DB_SERVER:
     TEST_CONFIG = prepare_config(config, override_integration_config=override)
 
 
-def is_port_opened(port, host='127.0.0.1'):
-    ''' try connect to host:port, to check it open or not
-    '''
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
-        is_open = sock.connect_ex((host, int(port))) == 0
-    return is_open
-
-
-def wait_api_ready(config, api='mysql'):
-    port_num = config['api'][api]['port']
-    api_ready = wait_port(port_num, START_TIMEOUT)
-    return api_ready
-
-
-def wait_db(config, db_name):
-    m = DatabaseWrapper(config)
-
-    start_time = time.time()
-
-    connected = m.check_connections()[db_name]
-
-    while not connected and (time.time() - start_time) < START_TIMEOUT:
-        time.sleep(2)
-        connected = m.check_connections()[db_name]
-
-    return connected
-
-
-def is_container_run(name):
-    docker_client = docker.from_env()
-    try:
-        containers = docker_client.containers.list()
-    except Exception:
-        # In case docker is running for sudo or another user
-        return True
-    containers = [x.name for x in containers if x.status == 'running']
-    return name in containers
-
-
 def get_test_csv(name, url, lines_count=None, rewrite=False):
     test_csv_path = TESTS_ROOT.joinpath('temp/', name).resolve()
     if not test_csv_path.is_file() or rewrite:
@@ -175,30 +130,6 @@ def get_test_csv(name, url, lines_count=None, rewrite=False):
     return str(test_csv_path)
 
 
-def run_container(name):
-    env = os.environ.copy()
-    env['UID'] = str(os.getuid())
-    env['GID'] = str(os.getgid())
-    subprocess.Popen(
-        ['./cli.sh', name],
-        cwd=TESTS_ROOT.joinpath('docker/').resolve(),
-        stdout=OUTPUT,
-        stderr=OUTPUT,
-        env=env
-    )
-    atexit.register(stop_container, name=name)
-
-
-def stop_container(name):
-    sp = subprocess.Popen(
-        ['./cli.sh', f'{name}-stop'],
-        cwd=TESTS_ROOT.joinpath('docker/').resolve(),
-        stdout=OUTPUT,
-        stderr=OUTPUT
-    )
-    sp.wait()
-
-
 def stop_mindsdb(sp):
     sp.kill()
     sp = subprocess.Popen('kill -9 $(lsof -t -i:47334)', shell=True)
@@ -209,23 +140,9 @@ def stop_mindsdb(sp):
     sp.wait()
 
 
-def run_environment(config, apis=['mysql'], run_docker_db=[], override_integration_config={}, override_api_config={}, mindsdb_database='mindsdb'):
-    ''' services = [mindsdb|]
-    '''
-
-    default_databases = [f'default_{db}' for db in run_docker_db]
-    temp_config_path = prepare_config(config, default_databases, mindsdb_database, override_integration_config, override_api_config)
+def run_environment(config, apis=['mysql'], override_integration_config={}, override_api_config={}, mindsdb_database='mindsdb'):
+    temp_config_path = prepare_config(config, mindsdb_database, override_integration_config, override_api_config)
     config = Config(temp_config_path)
-
-    db_ready = True
-    for db in run_docker_db:
-        if is_container_run(f'{db}-test') is False:
-            run_container(db)
-        db_ready = db_ready and wait_db(config, f'default_{db}')
-
-    if db_ready is False:
-        print('Cant start databases.')
-        raise Exception()
 
     api_str = ','.join(apis)
     sp = subprocess.Popen(

--- a/tests/integration_tests/flows/common.py
+++ b/tests/integration_tests/flows/common.py
@@ -230,6 +230,7 @@ def run_environment(config, apis=['mysql'], run_docker_db=[], override_integrati
     api_str = ','.join(apis)
     sp = subprocess.Popen(
         ['python3', '-m', 'mindsdb', '--api', api_str, '--config', temp_config_path],
+        close_fds=True,
         stdout=OUTPUT,
         stderr=OUTPUT
     )

--- a/tests/integration_tests/flows/common.py
+++ b/tests/integration_tests/flows/common.py
@@ -78,10 +78,10 @@ def prepare_config(config, enable_dbs=[], mindsdb_database='mindsdb', override_i
     return temp_config_path
 
 
-def close_ssh_tunnel(sp):
+def close_ssh_tunnel(sp, port):
     sp.kill()
-    # sp = subprocess.Popen(f'for pid in $(lsof -i :{port} -t); do kill -9 $pid; done', shell=True)
-    sp = subprocess.Popen(f'kill -9 {sp.pid}', shell=True)
+    sp = subprocess.Popen(f'for pid in $(lsof -i :{port} -t); do kill -9 $pid; done', shell=True)
+    # sp = subprocess.Popen(f'kill -9 {sp.pid}', shell=True)
     sp.wait()
 
 
@@ -92,7 +92,7 @@ def open_ssh_tunnel(port, direction='R'):
         stdout=OUTPUT,
         stderr=OUTPUT
     )
-    atexit.register(close_ssh_tunnel, sp=sp)
+    atexit.register(close_ssh_tunnel, sp=sp, port=port)
 
 
 if USE_EXTERNAL_DB_SERVER:

--- a/tests/integration_tests/flows/common.py
+++ b/tests/integration_tests/flows/common.py
@@ -53,7 +53,10 @@ def prepare_config(config, enable_dbs=[], mindsdb_database='mindsdb', override_i
                     config._config['integrations'][f'default_{key}'].update(cred[key])
 
     for integration in override_integration_config:
-        config._config['integrations'][integration].update(override_integration_config[integration])
+        if integration in config._config['integrations']:
+            config._config['integrations'][integration].update(override_integration_config[integration])
+        else:
+            config._config['integrations'][integration] = override_integration_config[integration]
 
     for api in override_api_config:
         config._config['api'][api].update(override_api_config[api])

--- a/tests/integration_tests/flows/common.py
+++ b/tests/integration_tests/flows/common.py
@@ -78,9 +78,9 @@ def prepare_config(config, enable_dbs=[], mindsdb_database='mindsdb', override_i
     return temp_config_path
 
 
-def close_ssh_tunnel(sp):
+def close_ssh_tunnel(sp, port):
     sp.kill()
-    sp = subprocess.Popen(f'kill -9 {sp.pid}', shell=True)
+    sp = subprocess.Popen(f'for pid in $(lsof -i :{port} -t); do kill -9 $pid; done', shell=True)
     sp.wait()
 
 
@@ -91,7 +91,7 @@ def open_ssh_tunnel(port, direction='R'):
         stdout=OUTPUT,
         stderr=OUTPUT
     )
-    atexit.register(close_ssh_tunnel, sp=sp)
+    atexit.register(close_ssh_tunnel, sp=sp, port=port)
 
 
 if USE_EXTERNAL_DB_SERVER:

--- a/tests/integration_tests/flows/config/config.json
+++ b/tests/integration_tests/flows/config/config.json
@@ -68,6 +68,10 @@
             "port": 27001,
             "type": "mongodb",
             "user": ""
+        },
+        "default_snowflake": {
+            "enabled": false,
+            "type": "snowflake"
         }
     },
     "interface": {

--- a/tests/integration_tests/flows/test_clickhouse.py
+++ b/tests/integration_tests/flows/test_clickhouse.py
@@ -72,6 +72,11 @@ class ClickhouseTest(unittest.TestCase):
                     'enabled': True
                 }
             },
+            override_api_config={
+                'mysql': {
+                    'ssl': False
+                }
+            },
             mindsdb_database=MINDSDB_DATABASE
         )
         cls.mdb = mdb

--- a/tests/integration_tests/flows/test_clickhouse.py
+++ b/tests/integration_tests/flows/test_clickhouse.py
@@ -174,7 +174,7 @@ class ClickhouseTest(unittest.TestCase):
             (
                 '{TEST_PREDICTOR_NAME}',
                 'rental_price, location',
-                'select * from test_data.{TEST_DATA_TABLE} limit 100',
+                'select * from test_data.{TEST_DATA_TABLE} limit 400',
                 '{{"join_learn_process": true, "stop_training_in_x_seconds": 3}}'
             );
         """)

--- a/tests/integration_tests/flows/test_clickhouse.py
+++ b/tests/integration_tests/flows/test_clickhouse.py
@@ -7,7 +7,6 @@ from mindsdb.utilities.config import Config
 
 from common import (
     MINDSDB_DATABASE,
-    USE_EXTERNAL_DB_SERVER,
     run_environment,
     get_test_csv,
     TEST_CONFIG
@@ -66,7 +65,6 @@ class ClickhouseTest(unittest.TestCase):
         mdb, datastore = run_environment(
             config,
             apis=['mysql'],
-            run_docker_db=[] if USE_EXTERNAL_DB_SERVER else ['clickhouse'],
             override_integration_config={
                 'default_clickhouse': {
                     'enabled': True

--- a/tests/integration_tests/flows/test_clickhouse.py
+++ b/tests/integration_tests/flows/test_clickhouse.py
@@ -174,7 +174,7 @@ class ClickhouseTest(unittest.TestCase):
             (
                 '{TEST_PREDICTOR_NAME}',
                 'rental_price, location',
-                'select * from test_data.{TEST_DATA_TABLE} limit 400',
+                'select * from test_data.{TEST_DATA_TABLE} limit 800',
                 '{{"join_learn_process": true, "stop_training_in_x_seconds": 3}}'
             );
         """)

--- a/tests/integration_tests/flows/test_custom_model.py
+++ b/tests/integration_tests/flows/test_custom_model.py
@@ -12,7 +12,6 @@ from common import (
     run_environment,
     get_test_csv,
     TEST_CONFIG,
-    USE_EXTERNAL_DB_SERVER,
     MINDSDB_DATABASE
 )
 
@@ -63,7 +62,6 @@ class CustomModelTest(unittest.TestCase):
         mdb, datastore = run_environment(
             config,
             apis=['http', 'mysql'],
-            run_docker_db=[] if USE_EXTERNAL_DB_SERVER else ['mariadb'],
             override_integration_config={
                 'default_mariadb': {
                     'enabled': True
@@ -230,11 +228,10 @@ class Model(ModelInterface):
         self.assertTrue(res[0]['rental_price'] is not None and res[0]['rental_price'] != 'None')
 
     def test_3_retrain_model(self):
-        res = query(f"""
+        query(f"""
             INSERT INTO {MINDSDB_DATABASE}.predictors (name, predict, select_data_query)
-            VALUES ('{PRED_NAME}', 'sqft', 'SELECT * FROM test_data.{TEST_DATA_TABLE}') """
-        )
-        #sqft
+            VALUES ('{PRED_NAME}', 'sqft', 'SELECT * FROM test_data.{TEST_DATA_TABLE}')
+        """)
 
     def test_4_predict_with_retrained_from_sql(self):
         res = fetch(f"""SELECT sqft FROM {MINDSDB_DATABASE}.{PRED_NAME} WHERE initial_price=6000""", as_dict=True)

--- a/tests/integration_tests/flows/test_custom_model.py
+++ b/tests/integration_tests/flows/test_custom_model.py
@@ -233,7 +233,7 @@ class Model(ModelInterface):
     def test_3_retrain_model(self):
         res = query(f"""
             INSERT INTO {MINDSDB_DATABASE}.predictors (name, predict, select_data_query)
-            VALUES ('{PRED_NAME}', 'sqft', 'SELECT * FROM test.{TEST_DATA_TABLE}') """
+            VALUES ('{PRED_NAME}', 'sqft', 'SELECT * FROM test_data.{TEST_DATA_TABLE}') """
         )
         #sqft
 

--- a/tests/integration_tests/flows/test_custom_model.py
+++ b/tests/integration_tests/flows/test_custom_model.py
@@ -249,7 +249,7 @@ class Model(ModelInterface):
             f"""
                 SELECT sqft
                 FROM {MINDSDB_DATABASE}.{PRED_NAME}
-                WHERE select_data_query='SELECT * FROM test.{TEST_DATA_TABLE}'
+                WHERE select_data_query='SELECT * FROM test_data.{TEST_DATA_TABLE}'
             """,
             as_dict=True
         )

--- a/tests/integration_tests/flows/test_custom_model.py
+++ b/tests/integration_tests/flows/test_custom_model.py
@@ -60,7 +60,6 @@ def fetch(q, as_dict=True):
 class CustomModelTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        # mdb, datastore = run_environment('clickhouse', config, run_apis=['mysql', 'http'])
         mdb, datastore = run_environment(
             config,
             apis=['http', 'mysql'],

--- a/tests/integration_tests/flows/test_custom_model.py
+++ b/tests/integration_tests/flows/test_custom_model.py
@@ -4,12 +4,16 @@ import shutil
 import requests
 import os
 
+import mysql.connector
+
 from mindsdb.utilities.config import Config
 
 from common import (
     run_environment,
     get_test_csv,
-    TEST_CONFIG
+    TEST_CONFIG,
+    USE_EXTERNAL_DB_SERVER,
+    MINDSDB_DATABASE
 )
 
 
@@ -26,46 +30,48 @@ config = Config(TEST_CONFIG)
 PRED_NAME = 'this_is_my_custom_sklearnmodel'
 
 
-def query(query):
-    if 'CREATE ' not in query.upper() and 'INSERT ' not in query.upper():
-        query += ' FORMAT JSON'
+config = Config(TEST_CONFIG)
 
-    host = config['integrations']['default_clickhouse']['host']
-    port = config['integrations']['default_clickhouse']['port']
 
-    connect_string = f'http://{host}:{port}'
-
-    params = {'user': 'default'}
-    try:
-        params['user'] = config['integrations']['default_clickhouse']['user']
-    except Exception:
-        pass
-
-    try:
-        params['password'] = config['integrations']['default_clickhouse']['password']
-    except Exception:
-        pass
-
-    res = requests.post(
-        connect_string,
-        data=query,
-        params=params
+def query(q, as_dict=False, fetch=False):
+    con = mysql.connector.connect(
+        host=config['integrations']['default_mariadb']['host'],
+        port=config['integrations']['default_mariadb']['port'],
+        user=config['integrations']['default_mariadb']['user'],
+        passwd=config['integrations']['default_mariadb']['password'],
+        db=MINDSDB_DATABASE,
+        connect_timeout=1000
     )
 
-    if res.status_code != 200:
-        print(f'ERROR: code={res.status_code} msg={res.text}')
-        raise Exception()
-
-    if ' FORMAT JSON' in query:
-        res = res.json()['data']
-
+    cur = con.cursor(dictionary=as_dict)
+    cur.execute(q)
+    res = True
+    if fetch:
+        res = cur.fetchall()
+    con.commit()
+    con.close()
     return res
+
+
+def fetch(q, as_dict=True):
+    return query(q, as_dict, fetch=True)
 
 
 class CustomModelTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        mdb, datastore = run_environment('clickhouse', config, run_apis=['mysql', 'http'])
+        # mdb, datastore = run_environment('clickhouse', config, run_apis=['mysql', 'http'])
+        mdb, datastore = run_environment(
+            config,
+            apis=['http', 'mysql'],
+            run_docker_db=[] if USE_EXTERNAL_DB_SERVER else ['mariadb'],
+            override_integration_config={
+                'default_mariadb': {
+                    'enabled': True
+                }
+            },
+            mindsdb_database=MINDSDB_DATABASE
+        )
         cls.mdb = mdb
 
         models = cls.mdb.get_models()
@@ -73,28 +79,25 @@ class CustomModelTest(unittest.TestCase):
         if TEST_PREDICTOR_NAME in models:
             cls.mdb.delete_model(TEST_PREDICTOR_NAME)
 
-        query('create database if not exists test')
-        test_tables = query('show tables from test')
-        test_tables = [x['name'] for x in test_tables]
+        query('create database if not exists test_data')
+        test_tables = fetch('show tables from test_data', as_dict=False)
+        test_tables = [x[0] for x in test_tables]
 
         test_csv_path = get_test_csv(TEST_CSV['name'], TEST_CSV['url'])
 
         if TEST_DATA_TABLE not in test_tables:
             print('creating test data table...')
             query(f'''
-                CREATE TABLE test.{TEST_DATA_TABLE} (
-                    id Int16,
-                    number_of_rooms Int8,
-                    number_of_bathrooms Int8,
-                    sqft Int32,
-                    location String,
-                    days_on_market Int16,
-                    initial_price Int32,
-                    neighborhood String,
-                    rental_price Int32
-                ) ENGINE = MergeTree()
-                ORDER BY id
-                PARTITION BY location
+                CREATE TABLE test_data.{TEST_DATA_TABLE} (
+                    number_of_rooms int,
+                    number_of_bathrooms int,
+                    sqft int,
+                    location varchar(100),
+                    days_on_market int,
+                    initial_price int,
+                    neighborhood varchar(100),
+                    rental_price int
+                )
             ''')
 
             with open(test_csv_path) as f:
@@ -110,8 +113,7 @@ class CustomModelTest(unittest.TestCase):
                         initial_price = int(row[5])
                         neighborhood = str(row[6])
                         rental_price = int(float(row[7]))
-                        query(f'''INSERT INTO test.{TEST_DATA_TABLE} VALUES (
-                            {i},
+                        query(f'''INSERT INTO test_data.{TEST_DATA_TABLE} VALUES (
                             {number_of_rooms},
                             {number_of_bathrooms},
                             {sqft},
@@ -127,7 +129,7 @@ class CustomModelTest(unittest.TestCase):
         ds = datastore.get_datasource(EXTERNAL_DS_NAME)
         if ds is not None:
             datastore.delete_datasource(EXTERNAL_DS_NAME)
-        short_csv_file_path = get_test_csv(f'{EXTERNAL_DS_NAME}.csv', TEST_CSV['url'], lines_count=300, rewrite=True)
+        short_csv_file_path = get_test_csv(f'{EXTERNAL_DS_NAME}.csv', TEST_CSV['url'], lines_count=30, rewrite=True)
         datastore.save_datasource(EXTERNAL_DS_NAME, 'file', 'test.csv', short_csv_file_path)
 
     def test_1_simple_model_upload(self):
@@ -135,7 +137,7 @@ class CustomModelTest(unittest.TestCase):
 
         try:
             os.mkdir(dir_name)
-        except:
+        except Exception:
             pass
 
         with open(dir_name + '/model.py', 'w') as fp:
@@ -176,7 +178,7 @@ class Model(ModelInterface):
         shutil.make_archive(base_name='my_model', format='zip', root_dir=dir_name)
 
         # Upload the model (new endpoint)
-        res = requests.put(f'{root}/predictors/custom/{PRED_NAME}', files=dict(file=open('my_model.zip','rb')), json={
+        res = requests.put(f'{root}/predictors/custom/{PRED_NAME}', files=dict(file=open('my_model.zip', 'rb')), json={
             'trained_status': 'untrained'
         })
         print(res.status_code)
@@ -211,29 +213,46 @@ class Model(ModelInterface):
         res = requests.post(url, json=params)
 
         assert res.status_code == 200
-        assert(len(res.json()) == 299)
+        assert(len(res.json()) == 29)
         for pred in res.json():
             assert isinstance(pred['rental_price']['predicted_value'], float)
 
     def test_2_db_predict_from_external_datasource(self):
-        res = query(f"""SELECT rental_price FROM mindsdb.{PRED_NAME} WHERE external_datasource='{EXTERNAL_DS_NAME}'""")
+        res = fetch(
+            f"""
+                SELECT rental_price
+                FROM {MINDSDB_DATABASE}.{PRED_NAME}
+                WHERE external_datasource='{EXTERNAL_DS_NAME}'
+            """,
+            as_dict=True
+        )
 
         self.assertTrue(len(res) > 0)
         self.assertTrue(res[0]['rental_price'] is not None and res[0]['rental_price'] != 'None')
 
     def test_3_retrain_model(self):
-        res = query(f""" INSERT INTO mindsdb.predictors (name, predict, select_data_query) VALUES ('{PRED_NAME}', 'sqft', 'SELECT * FROM test.{TEST_DATA_TABLE}') """)
+        res = query(f"""
+            INSERT INTO {MINDSDB_DATABASE}.predictors (name, predict, select_data_query)
+            VALUES ('{PRED_NAME}', 'sqft', 'SELECT * FROM test.{TEST_DATA_TABLE}') """
+        )
         #sqft
 
     def test_4_predict_with_retrained_from_sql(self):
-        res = query(f"""SELECT sqft FROM mindsdb.{PRED_NAME} WHERE initial_price=6000""")
+        res = fetch(f"""SELECT sqft FROM {MINDSDB_DATABASE}.{PRED_NAME} WHERE initial_price=6000""", as_dict=True)
 
         self.assertTrue(len(res) > 0)
         print(res)
         self.assertTrue(res[0]['sqft'] is not None and res[0]['sqft'] != 'None')
 
     def test_5_predict_with_retrained_from_select(self):
-        res = query(f"""SELECT sqft FROM mindsdb.{PRED_NAME} WHERE select_data_query='SELECT * FROM test.{TEST_DATA_TABLE}'""")
+        res = fetch(
+            f"""
+                SELECT sqft
+                FROM {MINDSDB_DATABASE}.{PRED_NAME}
+                WHERE select_data_query='SELECT * FROM test.{TEST_DATA_TABLE}'
+            """,
+            as_dict=True
+        )
 
         self.assertTrue(len(res) > 0)
         print(res)
@@ -255,7 +274,7 @@ class Model(ModelInterface):
         res = requests.post(url, json=params)
 
         assert res.status_code == 200
-        assert(len(res.json()) == 299)
+        assert(len(res.json()) == 29)
         for pred in res.json():
             assert isinstance(pred['sqft']['predicted_value'], float)
 
@@ -266,18 +285,19 @@ class Model(ModelInterface):
         for ele in res.json():
             print(ele)
             if ele['name'] == PRED_NAME:
-                assert ele['is_custom'] == True
+                assert ele['is_custom'] is True
 
         res = requests.get(f'{root}/predictors/{PRED_NAME}')
         assert res.status_code == 200
         assert res.json()['name'] == PRED_NAME
-        assert res.json()['is_custom'] == True
+        assert res.json()['is_custom'] is True
 
     def test_8_delete_from_http_api(self):
         res = requests.delete(f'{root}/predictors/{PRED_NAME}')
         assert res.status_code == 200
         res = requests.get(f'{root}/predictors')
         assert PRED_NAME not in [x['name'] for x in res.json()]
+
 
 if __name__ == "__main__":
     unittest.main(failfast=True)

--- a/tests/integration_tests/flows/test_mariadb.py
+++ b/tests/integration_tests/flows/test_mariadb.py
@@ -8,7 +8,6 @@ from mindsdb.utilities.config import Config
 
 from common import (
     MINDSDB_DATABASE,
-    USE_EXTERNAL_DB_SERVER,
     run_environment,
     get_test_csv,
     TEST_CONFIG
@@ -55,7 +54,6 @@ class MariaDBTest(unittest.TestCase):
         mdb, datastore = run_environment(
             config,
             apis=['mysql'],
-            run_docker_db=[] if USE_EXTERNAL_DB_SERVER else ['mariadb'],
             override_integration_config={
                 'default_mariadb': {
                     'enabled': True

--- a/tests/integration_tests/flows/test_mariadb.py
+++ b/tests/integration_tests/flows/test_mariadb.py
@@ -131,7 +131,7 @@ class MariaDBTest(unittest.TestCase):
         self.assertTrue(TEST_PREDICTOR_NAME not in models)
 
         print('Test datasource exists')
-        test_tables = fetch('show tables from test', as_dict=False)
+        test_tables = fetch('show tables from test_data', as_dict=False)
         test_tables = [x[0] for x in test_tables]
         self.assertTrue(TEST_DATA_TABLE in test_tables)
 

--- a/tests/integration_tests/flows/test_mongo.py
+++ b/tests/integration_tests/flows/test_mongo.py
@@ -7,7 +7,6 @@ from mindsdb.utilities.config import Config
 from common import (
     run_environment,
     get_test_csv,
-    run_container,
     TEST_CONFIG,
     USE_EXTERNAL_DB_SERVER,
     open_ssh_tunnel
@@ -53,9 +52,6 @@ class MongoTest(unittest.TestCase):
         if USE_EXTERNAL_DB_SERVER:
             open_ssh_tunnel(27002, direction='L')   # 27002 - mongos port
             wait_port(27002, timeout=10)
-        else:
-            run_container('mongo-cluster')
-            wait_port(config['api']['mongodb']['port'], timeout=90)
 
         cls.mongos_client = MongoClient('mongodb://127.0.0.1:27002/')
         mdb_shard = f"127.0.0.1:{config['api']['mongodb']['port']}"

--- a/tests/integration_tests/flows/test_mongo.py
+++ b/tests/integration_tests/flows/test_mongo.py
@@ -149,7 +149,7 @@ class MongoTest(unittest.TestCase):
     def test_4_remove(self):
         mindsdb = self.mongos_client[MINDSDB_DATABASE]
 
-        mindsdb.predictors.remove({'name': TEST_PREDICTOR_NAME})
+        mindsdb.predictors.delete_one({'name': TEST_PREDICTOR_NAME})
 
         predictors = list(mindsdb.predictors.find())
         self.assertTrue(TEST_PREDICTOR_NAME not in [x['name'] for x in predictors])

--- a/tests/integration_tests/flows/test_mongo.py
+++ b/tests/integration_tests/flows/test_mongo.py
@@ -1,6 +1,5 @@
 import unittest
 import csv
-import time
 
 from pymongo import MongoClient
 
@@ -12,6 +11,8 @@ from common import (
     TEST_CONFIG,
     MINDSDB_DATABASE
 )
+
+from mindsdb.utilities.ps import wait_port
 
 TEST_CSV = {
     'name': 'home_rentals.csv',
@@ -42,7 +43,7 @@ class MongoTest(unittest.TestCase):
         cls.mdb = mdb
 
         run_container('mongo-cluster')
-        time.sleep(40)
+        wait_port(config['api']['mongodb']['port'], timeout=90)
 
         cls.mongos_client = MongoClient('mongodb://localhost:27002/')
         mdb_shard = f"127.0.0.1:{config['api']['mongodb']['port']}"

--- a/tests/integration_tests/flows/test_mongo.py
+++ b/tests/integration_tests/flows/test_mongo.py
@@ -9,7 +9,6 @@ from common import (
     get_test_csv,
     run_container,
     TEST_CONFIG,
-    MINDSDB_DATABASE,
     USE_EXTERNAL_DB_SERVER,
     open_ssh_tunnel
 )
@@ -27,6 +26,8 @@ EXTERNAL_DS_NAME = 'test_external'
 
 config = Config(TEST_CONFIG)
 
+MINDSDB_DATABASE = f"mindsdb_{config['api']['mongodb']['port']}" if USE_EXTERNAL_DB_SERVER else 'mindsdb'
+
 
 class MongoTest(unittest.TestCase):
     @classmethod
@@ -37,7 +38,12 @@ class MongoTest(unittest.TestCase):
             run_docker_db=[],
             override_integration_config={
                 'default_mongodb': {
-                    'enabled': True
+                    'enabled': True,
+                    'port': 27002,
+                    'host': '127.0.0.1',
+                    'type': 'mongodb',
+                    'user': '',
+                    'password': ''
                 }
             },
             mindsdb_database=MINDSDB_DATABASE
@@ -107,7 +113,7 @@ class MongoTest(unittest.TestCase):
 
     def test_2_learn_predictor(self):
         mindsdb = self.mongos_client[MINDSDB_DATABASE]
-        mindsdb.predictors.insert({
+        mindsdb.predictors.insert_one({
             'name': TEST_PREDICTOR_NAME,
             'predict': 'rental_price',
             'select_data_query': {

--- a/tests/integration_tests/flows/test_mongo.py
+++ b/tests/integration_tests/flows/test_mongo.py
@@ -34,7 +34,6 @@ class MongoTest(unittest.TestCase):
         mdb, datastore = run_environment(
             config,
             apis=['mongodb'],
-            run_docker_db=[],
             override_integration_config={
                 'default_mongodb': {
                     'enabled': True,

--- a/tests/integration_tests/flows/test_mongo.py
+++ b/tests/integration_tests/flows/test_mongo.py
@@ -92,11 +92,6 @@ class MongoTest(unittest.TestCase):
         cls.mongos_client.admin.command('addShard', mdb_shard)
 
     def test_1_entitys_exists(self):
-        # we cant check databases exists, becaus in remote db can be many old shards
-        # databases = self.mongos_client.list_database_names()
-        # self.assertTrue('test_data' in databases)
-        # self.assertTrue('mindsdb' in databases)
-
         mindsdb = self.mongos_client[MINDSDB_DATABASE]
         mindsdb_collections = mindsdb.list_collection_names()
         self.assertTrue('predictors' in mindsdb_collections)

--- a/tests/integration_tests/flows/test_mongo.py
+++ b/tests/integration_tests/flows/test_mongo.py
@@ -42,7 +42,7 @@ class MongoTest(unittest.TestCase):
         cls.mdb = mdb
 
         run_container('mongo-cluster')
-        time.sleep(20)
+        time.sleep(40)
 
         cls.mongos_client = MongoClient('mongodb://localhost:27002/')
         mdb_shard = f"127.0.0.1:{config['api']['mongodb']['port']}"

--- a/tests/integration_tests/flows/test_mssql.py
+++ b/tests/integration_tests/flows/test_mssql.py
@@ -54,7 +54,6 @@ class MSSQLTest(unittest.TestCase):
         mdb, datastore = run_environment(
             config,
             apis=['mysql'],
-            run_docker_db=[],   # NOTE ds should be already runned
             override_integration_config={
                 'default_mssql': {
                     'enabled': True

--- a/tests/integration_tests/flows/test_mssql.py
+++ b/tests/integration_tests/flows/test_mssql.py
@@ -9,7 +9,8 @@ from mindsdb.utilities.config import Config
 from common import (
     run_environment,
     get_test_csv,
-    TEST_CONFIG
+    TEST_CONFIG,
+    MINDSDB_DATABASE
 )
 
 TEST_CSV = {
@@ -50,7 +51,17 @@ def query(query, fetch=False, as_dict=True, db='mindsdb_test'):
 class MSSQLTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        mdb, datastore = run_environment('mssql', config)
+        mdb, datastore = run_environment(
+            config,
+            apis=['mysql'],
+            run_docker_db=[],   # NOTE ds should be already runned
+            override_integration_config={
+                'default_mssql': {
+                    'enabled': True
+                }
+            },
+            mindsdb_database=MINDSDB_DATABASE
+        )
         cls.mdb = mdb
 
         models = cls.mdb.get_models()

--- a/tests/integration_tests/flows/test_mysql.py
+++ b/tests/integration_tests/flows/test_mysql.py
@@ -8,7 +8,6 @@ from mindsdb.utilities.config import Config
 
 from common import (
     MINDSDB_DATABASE,
-    USE_EXTERNAL_DB_SERVER,
     run_environment,
     get_test_csv,
     TEST_CONFIG
@@ -53,7 +52,6 @@ class MariaDBTest(unittest.TestCase):
         mdb, datastore = run_environment(
             config,
             apis=['mysql'],
-            run_docker_db=[] if USE_EXTERNAL_DB_SERVER else ['mysql'],
             override_integration_config={
                 'default_mysql': {
                     'enabled': True

--- a/tests/integration_tests/flows/test_postgres.py
+++ b/tests/integration_tests/flows/test_postgres.py
@@ -8,7 +8,6 @@ from mindsdb.utilities.config import Config
 
 from common import (
     MINDSDB_DATABASE,
-    USE_EXTERNAL_DB_SERVER,
     run_environment,
     get_test_csv,
     TEST_CONFIG
@@ -57,7 +56,6 @@ class PostgresTest(unittest.TestCase):
         mdb, datastore = run_environment(
             config,
             apis=['mysql'],
-            run_docker_db=[] if USE_EXTERNAL_DB_SERVER else ['postgres'],
             override_integration_config={
                 'default_postgres': {
                     'enabled': True

--- a/tests/integration_tests/flows/test_postgres.py
+++ b/tests/integration_tests/flows/test_postgres.py
@@ -51,7 +51,7 @@ def query(query, fetch=False):
     return res
 
 
-class ClickhouseTest(unittest.TestCase):
+class PostgresTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         mdb, datastore = run_environment(


### PR DESCRIPTION
Integration tests can be run in two modes, defined by env variable USE_EXTERNAL_DB_SERVER:
1. if USE_EXTERNAL_DB_SERVER="0", than on run test will be runned docker container with target databasde.
2. if USE_EXTERNAL_DB_SERVER="1", then ssh-tunnels to test database server will be up. For that should exists:  
* `.mindsdb_credentials.json` file in home dir.
* `~/.ssh/db_machine` with key for db machine.