### PR TITLE
Changes in model view

### DIFF
--- a/mindsdb/api/http/namespaces/predictor.py
+++ b/mindsdb/api/http/namespaces/predictor.py
@@ -99,7 +99,7 @@ class Predictor(Resource):
             if is_custom(name):
                 model = ca.custom_models.get_model_data(name)
             else:
-                model = ca.mindsdb_native.get_model_data(name)
+                model = ca.mindsdb_native.get_model_data(name, native_view=True)
         except Exception as e:
             abort(404, "")
 
@@ -205,7 +205,7 @@ class PredictorColumns(Resource):
             if is_custom(name):
                 model = ca.custom_models.get_model_data(name)
             else:
-                model = ca.mindsdb_native.get_model_data(name)
+                model = ca.mindsdb_native.get_model_data(name, native_view=True)
         except Exception:
             abort(404, 'Invalid predictor name')
 

--- a/mindsdb/interfaces/datastore/sqlite_helpers.py
+++ b/mindsdb/interfaces/datastore/sqlite_helpers.py
@@ -43,12 +43,9 @@ def cast_df_columns_types(df, stats):
     for column in columns:
         try:
             name = column['name']
-            if stats[name].get('empty', {}).get('is_empty', False):
-                new_type = types_map[DATA_TYPES.NUMERIC][DATA_SUBTYPES.INT]
-            else:
-                col_type = stats[name]['typing']['data_type']
-                col_subtype = stats[name]['typing']['data_subtype']
-                new_type = types_map[col_type][col_subtype]
+            col_type = stats[name]['typing']['data_type']
+            col_subtype = stats[name]['typing']['data_subtype']
+            new_type = types_map[col_type][col_subtype]
             if new_type == 'int64' or new_type == 'float64':
                 df[name] = df[name].apply(lambda x: x.replace(',', '.') if isinstance(x, str) else x)
             if new_type == 'int64':

--- a/mindsdb/interfaces/native/mindsdb.py
+++ b/mindsdb/interfaces/native/mindsdb.py
@@ -7,6 +7,7 @@ from dateutil.parser import parse as parse_datetime
 import mindsdb_native
 from mindsdb_native import F
 from mindsdb.utilities.fs import create_directory
+from mindsdb_native.libs.constants.mindsdb import DATA_SUBTYPES
 from mindsdb.interfaces.native.predictor_process import PredictorProcess
 from mindsdb.interfaces.database.database import DatabaseWrapper
 
@@ -54,8 +55,21 @@ class MindsdbNative():
     def analyse_dataset(self, ds):
         return F.analyse_dataset(ds)
 
-    def get_model_data(self, name):
-        return F.get_model_data(name)
+    def get_model_data(self, name, native_view=False):
+        model = F.get_model_data(name)
+        if native_view:
+            return model
+
+        data_analysis = model['data_analysis_v2']
+        for column in data_analysis['columns']:
+            if len(data_analysis[column]) == 0:
+                data_analysis[column] = {
+                    'typing': {
+                        'data_subtype': DATA_SUBTYPES.INT
+                    }
+                }
+
+        return model
 
     def get_models(self, status='any'):
         models = F.get_models()

--- a/mindsdb/interfaces/native/mindsdb.py
+++ b/mindsdb/interfaces/native/mindsdb.py
@@ -62,11 +62,9 @@ class MindsdbNative():
 
         data_analysis = model['data_analysis_v2']
         for column in data_analysis['columns']:
-            if len(data_analysis[column]) == 0:
-                data_analysis[column] = {
-                    'typing': {
-                        'data_subtype': DATA_SUBTYPES.INT
-                    }
+            if len(data_analysis[column]) == 0 or data_analysis[column].get('empty', {}).get('is_empty', False):
+                data_analysis[column]['typing'] = {
+                    'data_subtype': DATA_SUBTYPES.INT
                 }
 
         return model

--- a/mindsdb/utilities/functions.py
+++ b/mindsdb/utilities/functions.py
@@ -50,6 +50,7 @@ def get_all_models_meta_data(mindsdb_native, custom_models):
 
     return model_data_arr
 
+
 def is_notebook():
     try:
         shell = get_ipython().__class__.__name__


### PR DESCRIPTION
Fixes #928
Reason of error - is no 'type' for column, specified in 'ignore_columns' on model training.
It can be fixed by adding `if len(data_analysis[column]) == 0` to each place, where used `data_analysis`, or by changing `data_analysis` view when we get data from mindsdb_native. Here is second way.