### PR TITLE
Changes in static routing

### DIFF
--- a/mindsdb/api/http/initialize.py
+++ b/mindsdb/api/http/initialize.py
@@ -180,14 +180,11 @@ def initialize_flask(config):
     # Apparently there's a bug that causes the static path not to work if it's '/' -- https://github.com/pallets/flask/issues/3134, I think '' should achieve the same thing (???)
     app = Flask(
         __name__,
-        static_url_path='',
-        static_folder=config.paths['static']
+        static_url_path='/static',
+        static_folder=os.path.join(config.paths['static'], 'static/')
     )
 
-    @app.route('/')
-    def root_index():
-        return app.send_static_file('index.html')
-
+    app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 60
     app.config['SWAGGER_HOST'] = 'http://localhost:8000/mindsdb'
     authorizations = {
         'apikey': {

--- a/mindsdb/api/http/initialize.py
+++ b/mindsdb/api/http/initialize.py
@@ -219,7 +219,7 @@ def initialize_flask(config):
 
     # NOTE rewrite it, that hotfix to see GUI link
     log = logging.getLogger('mindsdb.http')
-    url = f'http://{host}:{port}/index.html'
+    url = f'http://{host}:{port}/'
     log.error(f' - GUI available at {url}')
 
     pid = os.getpid()

--- a/tests/integration_tests/api/test_http.py
+++ b/tests/integration_tests/api/test_http.py
@@ -179,7 +179,7 @@ class HTTPTest(unittest.TestCase):
         Call unexisting datasource
         then check the response is NOT FOUND
         """
-        response = requests.get(f'{root}/datasource/dummy_source')
+        response = requests.get(f'{root}/datasources/dummy_source')
         assert response.status_code == 404
 
     def test_6_ping(self):


### PR DESCRIPTION
1. for any route, except starts from `api/` or `static/`, will be returned file from `static` folder (if exists), or `index.html`
2. decreased cache timeout to 60 seconds (by default 12 hours). 