### PR TITLE
Install mindsdb from pypi in deploy step

### DIFF
--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -68,6 +68,11 @@ jobs:
         CHECK_FOR_UPDATES: False
         DB_MACHINE_KEY: ${{secrets.DB_MACHINE_KEY}}
         DATABASE_CREDENTIALS: ${{secrets.DATABASE_CREDENTIALS}}
+    - name: Install latest version from pypi (just testing)
+      run: |
+        sleep 20
+        pip install mindsdb
+        pip show mindsdb
   deploy_windows_installer:
     runs-on: windows-latest
     needs: test
@@ -123,6 +128,11 @@ jobs:
       run: |
         python setup.py sdist
         twine upload dist/*
+
+    - name: Install latest version from pypi
+      run: |
+        sleep 20
+        pip install mindsdb
 
     - name: Build and push mindsdb Docker image
       uses: docker/build-push-action@v1

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -68,11 +68,6 @@ jobs:
         CHECK_FOR_UPDATES: False
         DB_MACHINE_KEY: ${{secrets.DB_MACHINE_KEY}}
         DATABASE_CREDENTIALS: ${{secrets.DATABASE_CREDENTIALS}}
-    - name: Install latest version from pypi (just testing)
-      run: |
-        sleep 20
-        pip install mindsdb
-        pip show mindsdb
   deploy_windows_installer:
     runs-on: windows-latest
     needs: test


### PR DESCRIPTION
Fixes #804 

Release image (which created in a `deploy` step) needs to contain MindsDB version installed from PyPi repository (not from local source files) In this case we ensure that release image and PyPi have same version.