### PR TITLE
Report UUID endpoint

### DIFF
--- a/mindsdb/api/http/namespaces/util.py
+++ b/mindsdb/api/http/namespaces/util.py
@@ -1,5 +1,6 @@
 from flask import request
 from flask_restx import Resource, abort
+from flask import current_app as ca
 
 from mindsdb.api.http.namespaces.configs.util import ns_conf
 from mindsdb import __about__
@@ -25,11 +26,20 @@ class Shutdown(Resource):
             return '', 200
         abort(403, "")
 
-                
+
 @ns_conf.route('/util/version')
 class Version(Resource):
     @ns_conf.doc('get_endpoint')
     def get(self):
         '''Check endpoint'''
         return {'mindsdb': "{__about__.__version__}"}
-    
+
+@ns_conf.route('/report_uuid')
+class ReportUUID(Resource):
+    @ns_conf.doc('get_report_uuid')
+    def get(self):
+        metamodel_name = '___monitroing_metamodel___'
+        predictor = ca.mindsdb_native.create(metamodel_name)
+        return {
+            'report_uuid': predictor.report_uuid
+        }

--- a/mindsdb/api/http/namespaces/util.py
+++ b/mindsdb/api/http/namespaces/util.py
@@ -12,28 +12,6 @@ class Ping(Resource):
         '''Checks server avaliable'''
         return {'status': 'ok'}
 
-
-@ns_conf.route('/shutdown')
-class Shutdown(Resource):
-    @ns_conf.doc('get_shutdown')
-    def get(self):
-        '''Shutdown server'''
-        if request.host.startswith('127.0.0.1') or request.host.startswith('localhost'):
-            func = request.environ.get('werkzeug.server.shutdown')
-            if func is None:
-                return '', 500
-            func()
-            return '', 200
-        abort(403, "")
-
-
-@ns_conf.route('/util/version')
-class Version(Resource):
-    @ns_conf.doc('get_endpoint')
-    def get(self):
-        '''Check endpoint'''
-        return {'mindsdb': "{__about__.__version__}"}
-
 @ns_conf.route('/report_uuid')
 class ReportUUID(Resource):
     @ns_conf.doc('get_report_uuid')

--- a/mindsdb/interfaces/native/mindsdb.py
+++ b/mindsdb/interfaces/native/mindsdb.py
@@ -17,16 +17,24 @@ class MindsdbNative():
         self.config = config
         self.dbw = DatabaseWrapper(self.config)
 
+    def _setup_for_creation(self, name):
+            predictor_dir = Path(self.config.paths['predictors']).joinpath(name)
+            create_directory(predictor_dir)
+            versions_file_path = predictor_dir.joinpath('versions.json')
+            with open(str(versions_file_path), 'wt') as f:
+                json.dump(self.config.versions, f, indent=4, sort_keys=True)
+
+    def create(self, name):
+        self._setup_for_creation(name)
+        predictor = mindsdb_native.Predictor(name=name)
+        return predictor
+    
     def learn(self, name, from_data, to_predict, kwargs={}):
         join_learn_process = kwargs.get('join_learn_process', False)
         if 'join_learn_process' in kwargs:
             del kwargs['join_learn_process']
 
-        predictor_dir = Path(self.config.paths['predictors']).joinpath(name)
-        create_directory(predictor_dir)
-        versions_file_path = predictor_dir.joinpath('versions.json')
-        with open(str(versions_file_path), 'wt') as f:
-            json.dump(self.config.versions, f, indent=4, sort_keys=True)
+        self._setup_for_creation(name)
 
         p = PredictorProcess(name, from_data, to_predict, kwargs, self.config.get_all(), 'learn')
         p.start()

--- a/mindsdb/interfaces/native/mindsdb.py
+++ b/mindsdb/interfaces/native/mindsdb.py
@@ -26,9 +26,9 @@ class MindsdbNative():
 
     def create(self, name):
         self._setup_for_creation(name)
-        predictor = mindsdb_native.Predictor(name=name)
+        predictor = mindsdb_native.Predictor(name=name, run_env={'trigger': 'mindsdb'})
         return predictor
-    
+
     def learn(self, name, from_data, to_predict, kwargs={}):
         join_learn_process = kwargs.get('join_learn_process', False)
         if 'join_learn_process' in kwargs:
@@ -51,7 +51,7 @@ class MindsdbNative():
         p.start()
         predictions = p.join()
         '''
-        mdb = mindsdb_native.Predictor(name=name)
+        mdb = mindsdb_native.Predictor(name=name, run_env={'trigger': 'mindsdb'})
 
         predictions = mdb.predict(
             when_data=when_data,

--- a/mindsdb/interfaces/native/predictor_process.py
+++ b/mindsdb/interfaces/native/predictor_process.py
@@ -22,7 +22,7 @@ class PredictorProcess(ctx.Process):
 
         name, from_data, to_predict, kwargs, config, trx_type = self._args
 
-        mdb = mindsdb_native.Predictor(name=name)
+        mdb = mindsdb_native.Predictor(name=name, run_env={'trigger': 'mindsdb'})
 
         if trx_type == 'learn':
             to_predict = to_predict if isinstance(to_predict, list) else [to_predict]

--- a/tests/docker/postgres/Dockerfile
+++ b/tests/docker/postgres/Dockerfile
@@ -3,5 +3,6 @@ FROM postgres:12.3
 RUN apt-get update && apt-get install -y \
     postgresql-12-mysql-fdw
 
+
 RUN mkdir -p /docker-entrypoint-initdb.d && \
     echo 'CREATE EXTENSION mysql_fdw;' > /docker-entrypoint-initdb.d/init.sql

--- a/tests/integration_tests/api/test_http.py
+++ b/tests/integration_tests/api/test_http.py
@@ -182,13 +182,34 @@ class HTTPTest(unittest.TestCase):
         response = requests.get(f'{root}/datasource/dummy_source')
         assert response.status_code == 404
 
-    def test_6_ping(self):
+    def test_6_utils(self):
         """
         Call utilities ping endpoint
         THEN check the response is success
+
+        Call utilities ping version
+        THEN check the response is success
+
+        Call utilities report_uuid endpoint
+        THEN check the response is success
+        THEN check if the report_uuid is present in the report json and well fromated
+        THEN Call the endpoint again and check that the two report_uuids returned match
         """
+
         response = requests.get(f'{root}/util/ping')
         assert response.status_code == 200
+
+        response = requests.get(f'{root}/util/util/version')
+        assert response.status_code == 200
+
+        response = requests.get(f'{root}/util/report_uuid')
+        assert response.status_code == 200
+        report_uuid = response.json()['report_uuid']
+        assert report_uuid == 'no_report'
+
+        # Make sure the uuid doesn't change on subsequent requests
+        response = requests.get(f'{root}/util/report_uuid')
+        assert report_uuid == response.json()['report_uuid']
 
     def test_7_predictors(self):
         """

--- a/tests/integration_tests/api/test_http.py
+++ b/tests/integration_tests/api/test_http.py
@@ -187,9 +187,6 @@ class HTTPTest(unittest.TestCase):
         Call utilities ping endpoint
         THEN check the response is success
 
-        Call utilities ping version
-        THEN check the response is success
-
         Call utilities report_uuid endpoint
         THEN check the response is success
         THEN check if the report_uuid is present in the report json and well fromated
@@ -197,9 +194,6 @@ class HTTPTest(unittest.TestCase):
         """
 
         response = requests.get(f'{root}/util/ping')
-        assert response.status_code == 200
-
-        response = requests.get(f'{root}/util/util/version')
         assert response.status_code == 200
 
         response = requests.get(f'{root}/util/report_uuid')

--- a/tests/integration_tests/flows/config/config.json
+++ b/tests/integration_tests/flows/config/config.json
@@ -16,7 +16,7 @@
             "user": "mindsdb"
         }
     },
-    "config_version": "1.2",
+    "config_version": "1.3",
     "debug": true,
     "integrations": {
         "default_clickhouse": {
@@ -35,22 +35,13 @@
             "type": "mariadb",
             "user": "root"
         },
-        "default_mysql": {
-            "enabled": true,
-            "host": "localhost",
-            "password": "root",
-            "port": 3307,
-            "type": "mysql",
-            "user": "root"
-        },
-        "default_postgres": {
-            "enabled": true,
-            "host": "localhost",
-            "user": "postgres",
+        "default_mongodb": {
+            "enabled": false,
+            "host": "127.0.0.1",
             "password": "",
-            "database": "postgres",
-            "port": 5432,
-            "type": "postgres"
+            "port": 27001,
+            "type": "mongodb",
+            "user": ""
         },
         "default_mssql": {
             "enabled": true,
@@ -61,31 +52,26 @@
             "type": "mssql",
             "user": "sa"
         },
-        "default_mongodb": {
-            "enabled": false,
-            "host": "127.0.0.1",
+        "default_mysql": {
+            "enabled": true,
+            "host": "localhost",
+            "password": "root",
+            "port": 3307,
+            "type": "mysql",
+            "user": "root"
+        },
+        "default_postgres": {
+            "database": "postgres",
+            "enabled": true,
+            "host": "localhost",
             "password": "",
-            "port": 27001,
-            "type": "mongodb",
-            "user": ""
+            "port": 5432,
+            "type": "postgres",
+            "user": "postgres"
         },
         "default_snowflake": {
             "enabled": false,
             "type": "snowflake"
-        }
-    },
-    "interface": {
-        "dataskillet": {
-            "enabled": false
-        },
-        "datastore": {
-            "enabled": true
-        },
-        "lightwood": {
-            "enabled": true
-        },
-        "mindsdb_native": {
-            "enabled": true
         }
     },
     "log": {
@@ -94,7 +80,5 @@
             "file": "ERROR"
         }
     },
-    "pip_path": null,
-    "python_interpreter": null,
     "storage_dir": "/tmp/mindsdb_storage"
 }


### PR DESCRIPTION
Resolves #941 

The endpoint ended up being `/api/util/report_uuid`

Example of what it returns: `{"report_uuid": "820e08b3-dafb-42f6-bfcd-bc51a6dee472"}`

The impl was a bit more complicated and will fail until the changes in https://github.com/mindsdb/mindsdb_native/pull/303 are merged