### PR TITLE
946: Fix 'storage' folder path definition

### DIFF
--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -57,7 +57,7 @@ class Config(object):
         self._config_hash = None
         self._config = None
         if isinstance(config_path, str):
-            self.config_path = config_path
+            self.config_path = os.path.abspath(config_path)
             self._read()
             self._config_hash = self._gen_hash()
 
@@ -65,7 +65,7 @@ class Config(object):
             if os.path.isabs(storage_dir) is False:
                 storage_dir = os.path.normpath(
                     os.path.join(
-                        os.path.dirname(config_path),
+                        os.path.dirname(self.config_path),
                         storage_dir
                     )
                 )


### PR DESCRIPTION
Fixes #946 

Issue happens in case then relative path to config.json located in a custom directory provided.