### PR TITLE
Migration for config 1.3 -> 1.4

### DIFF
--- a/distributions/docker/Dockerfile
+++ b/distributions/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
 ENV PYTHONUNBUFFERED=1
 
 RUN echo '{' \
-    '"config_version":"1.3",' \
+    '"config_version":"1.4",' \
     '"storage_dir": "/root/mdb_storage",' \
     '"log": {' \
         '"level": {' \

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -173,13 +173,13 @@ class Config(object):
             return config
 
         def m1_3(config):
-            ''' rename integration['enabled'] to integration['published']
+            ''' rename integration['enabled'] to integration['publish']
             '''
-            for integration in config.get('integrations', []):
+            for integration in config.get('integrations', []).values():
                 if 'enabled' in integration:
                     enabled = integration['enabled']
                     del integration['enabled']
-                    integration['published'] = enabled
+                    integration['publish'] = enabled
 
             config['config_version'] = '1.4'
             return config

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -35,8 +35,9 @@ default_config = {
     }
 }
 
+
 class Config(object):
-    current_version = '1.3'
+    current_version = '1.4'
     _config = {}
     paths = {
         'root': '',
@@ -171,10 +172,23 @@ class Config(object):
             config['config_version'] = '1.3'
             return config
 
+        def m1_3(config):
+            ''' rename integration['enabled'] to integration['published']
+            '''
+            for integration in config.get('integrations', []):
+                if 'enabled' in integration:
+                    enabled = integration['enabled']
+                    del integration['enabled']
+                    integration['published'] = enabled
+
+            config['config_version'] = '1.4'
+            return config
+
         migrations = {
             '1.0': m1_0,
             '1.1': m1_1,
-            '1.2': m1_2
+            '1.2': m1_2,
+            '1.3': m1_3
         }
 
         current_version = self._parse_version(self._config['config_version'])

--- a/mindsdb/utilities/wizards.py
+++ b/mindsdb/utilities/wizards.py
@@ -23,7 +23,7 @@ def _in(ask, default, use_default):
 def auto_config(python_path, pip_path, storage_dir):
     config = {
         "debug": False,
-        "config_version": "1.3",
+        "config_version": "1.4",
         "api": {
         },
         "integrations": {
@@ -195,7 +195,6 @@ def cli_config(python_path, pip_path, storage_dir, config_dir, use_default=False
     for db_name in list(config['integrations'].keys()):
         if not config['integrations'][db_name]['publish']:
             del config['integrations'][db_name]
-
 
     config_path = os.path.join(config_dir, 'config.json')
     with open(config_path, 'w') as fp:


### PR DESCRIPTION
After renaming 'enabled' to 'publish' in config['integrations'] an error may appear, because in user config integrations still have 'enabled' keys. That migration will change it.