### PR TITLE
Issue986: specify home dir properly

### DIFF
--- a/mindsdb/utilities/fs.py
+++ b/mindsdb/utilities/fs.py
@@ -40,8 +40,8 @@ def get_paths():
                 '/var/lib/mindsdb'
             ),
             (
-                '~/.local/etc/mindsdb',
-                '~/.local/var/lib/mindsdb'
+                '{}/.local/etc/mindsdb'.format(os.environ["HOME"]),
+                '{}/.local/var/lib/mindsdb'.format(os.environ["HOME"])
             )
         ])
 
@@ -51,9 +51,9 @@ def get_paths():
 def get_or_create_dir_struct():
     for tup in get_paths():
         try:
-            for dir in tup:
-                assert(os.path.exists(dir))
-                assert(os.access(dir, os.W_OK) is True)
+            for _dir in tup:
+                assert os.path.exists(_dir)
+                assert os.access(_dir, os.W_OK) is True
 
             config_dir = tup[0]
             if 'DEV_CONFIG_PATH' in os.environ:
@@ -65,9 +65,9 @@ def get_or_create_dir_struct():
 
     for tup in get_paths():
         try:
-            for dir in tup:
-                create_directory(dir)
-                assert(os.access(dir, os.W_OK) is True)
+            for _dir in tup:
+                create_directory(_dir)
+                assert os.access(_dir, os.W_OK) is True
 
             config_dir = tup[0]
             if 'DEV_CONFIG_PATH' in os.environ:

--- a/mindsdb/utilities/fs.py
+++ b/mindsdb/utilities/fs.py
@@ -40,8 +40,8 @@ def get_paths():
                 '/var/lib/mindsdb'
             ),
             (
-                '{}/.local/etc/mindsdb'.format(os.environ["HOME"]),
-                '{}/.local/var/lib/mindsdb'.format(os.environ["HOME"])
+                '{}/.local/etc/mindsdb'.format(Path.home()),
+                '{}/.local/var/lib/mindsdb'.format(Path.home())
             )
         ])
 


### PR DESCRIPTION
Fixes #986 
Issue has detailed description. No sense to duplicate it here

```
(mindsdb_venv) ~/repos/MindsDB/mindsdb itsyplen$ python -m mindsdb
Athena Datasource is not available by default. If you wish to use it, please install mindsdb_native[extra_data_sources]
SnowflakeDS Datasource is not available by default. If you wish to use it, please install mindsdb_native[snowflake]
Google Cloud Storage Datasource is not available by default. If you wish to use it, please install mindsdb_native[extra_data_sources]
Configuration file:
   /Users/itsyplen/.local/etc/mindsdb/config.json
Storage path:
   /Users/itsyplen/.local/var/lib/mindsdb
```