### PR TITLE
username/password auth for MongoDB api

### DIFF
--- a/mindsdb/api/mongo/classes/__init__.py
+++ b/mindsdb/api/mongo/classes/__init__.py
@@ -1,4 +1,5 @@
 from .responder_collection import RespondersCollection
 from .responder import Responder
+from .session import Session
 
-__all__ = ['RespondersCollection', 'Responder']
+__all__ = ['RespondersCollection', 'Responder', 'Session']

--- a/mindsdb/api/mongo/classes/responder.py
+++ b/mindsdb/api/mongo/classes/responder.py
@@ -29,16 +29,17 @@ class Responder():
         else:
             return self.when(query)
 
-    def handle(self, query, args, env):
+    def handle(self, query, args, env, session):
         """ making answer based on params:
 
         query (dict): document(s) from request
         args (dict): all other significant information from request: flags, collection name, rows to return, etc
         env (dict): config, mindsdb_native instance, and other mindsdb related stuff
+        session (object): current session
 
         returns documents as dict or list of dicts
         """
         if isinstance(self.result, dict):
             return self.result
         else:
-            return self.result(query, args, env)
+            return self.result(query, args, env, session)

--- a/mindsdb/api/mongo/classes/scram.py
+++ b/mindsdb/api/mongo/classes/scram.py
@@ -1,0 +1,60 @@
+# https://stackoverflow.com/questions/29298346/xmpp-sasl-scram-sha1-authentication
+# https://tools.ietf.org/html/rfc5802
+
+import base64
+import hashlib
+import hmac
+import os
+
+from pymongo.auth import _password_digest
+
+
+class Scram():
+    ''' implementation of server-side SCRAM-SHA-1 auth of mongodb
+        TODO add SCRAM-SHA-256 auth
+    '''
+
+    def __init__(self, user, password):
+        self.user = user
+        self.password = password
+        self.snonce = base64.b64encode(os.urandom(24)).decode()
+        self.salt = base64.b64encode(os.urandom(16))
+        self.iterations = 4096
+        self.messages = []
+
+    def process_client_first_message(self, payload):
+        payload = payload[3:]
+        payload_parts = self._split_payload(payload)
+        self.client_user = payload_parts['n']
+        self.unonce = payload_parts['r']
+        self.messages.append(payload)
+
+        responce_msg = f"r={self.unonce}{self.snonce},s={self.salt.decode()},i={self.iterations}"
+        self.messages.append(responce_msg)
+        return responce_msg
+
+    def process_client_second_message(self, payload):
+        self.messages.append(payload[:payload.rfind(',p=')])    # without 'p' part
+
+        # TODO add user password check here
+
+        messages = ','.join(self.messages)
+        salted_password = self._salt_password()
+        server_key = self._sha1_hmac(salted_password, b'Server Key')
+        server_signature = self._sha1_hmac(server_key, messages.encode('utf-8'))
+        return f'v={base64.b64encode(server_signature).decode()}'
+
+    def _sha1_hmac(self, key, msg):
+        return hmac.new(key, msg, digestmod=hashlib.sha1).digest()
+
+    def _salt_password(self):
+        password = _password_digest(self.user, self.password).encode("utf-8")
+        return hashlib.pbkdf2_hmac(
+            'sha1', password, base64.b64decode(self.salt), self.iterations
+        )
+
+    def _split_payload(self, payload):
+        parts = {}
+        for part in [x for x in payload.split(',') if len(x) > 0]:
+            parts[part[0]] = part[2:]
+        return parts

--- a/mindsdb/api/mongo/classes/session.py
+++ b/mindsdb/api/mongo/classes/session.py
@@ -1,0 +1,11 @@
+from .scram import Scram
+
+
+class Session():
+    def __init__(self, config):
+        self.config = config
+
+    def init_scram(self):
+        user = self.config['api']['mongodb'].get('user', '')
+        password = self.config['api']['mongodb'].get('password', '')
+        self.scram = Scram(user, password)

--- a/mindsdb/api/mongo/op_msg_responders/__init__.py
+++ b/mindsdb/api/mongo/op_msg_responders/__init__.py
@@ -7,7 +7,15 @@ from .getlog import responder as responder_getlog
 from .add_shard import responder as responder_add_shard
 from .update_range_deletions import responder as responder_update_range_deletions
 from .recv_chunk_start import responder as responder_recv_chunk_start
+from .connection_status import responder as responder_connection_status
+from .get_cmd_line_opts import responder as responder_get_cmd_line_opts
+from .host_info import responder as responder_host_info
+from .db_stats import responder as responder_db_stats
+from .coll_stats import responder as responder_coll_stats
+from .count import responder as responder_count
+from .aggregate import responder as responder_aggregate
 
+from .list_indexes import responder as responder_list_indexes
 from .list_collections import responder as responder_list_collections
 from .list_databases import responder as responder_list_databases
 
@@ -29,7 +37,15 @@ responders = [
     responder_add_shard,                # 4.4
     responder_update_range_deletions,   # 4.4
     responder_recv_chunk_start,         # 4.4
+    responder_connection_status,
+    responder_get_cmd_line_opts,
+    responder_host_info,
+    responder_db_stats,
+    responder_coll_stats,
+    responder_count,
+    responder_aggregate,
     # user queries
+    responder_list_indexes,
     responder_list_collections,
     responder_list_databases,
     responder_find,

--- a/mindsdb/api/mongo/op_msg_responders/__init__.py
+++ b/mindsdb/api/mongo/op_msg_responders/__init__.py
@@ -15,6 +15,9 @@ from .find import responder as responder_find
 from .insert import responder as responder_insert
 from .delete import responder as responder_delete
 
+from .sasl_start import responder as sasl_start
+from .sasl_continue import responder as sasl_continue
+
 responders = [
     # service queries
     responder_whatsmyuri,
@@ -31,5 +34,8 @@ responders = [
     responder_list_databases,
     responder_find,
     responder_insert,
-    responder_delete
+    responder_delete,
+    # auth
+    sasl_start,
+    sasl_continue
 ]

--- a/mindsdb/api/mongo/op_msg_responders/add_shard.py
+++ b/mindsdb/api/mongo/op_msg_responders/add_shard.py
@@ -1,38 +1,11 @@
 from mindsdb.api.mongo.classes import Responder
 import mindsdb.api.mongo.functions as helpers
 
-# GET OpMSG=OrderedDict([('_addShard', 1), ('shardIdentity', OrderedDict([('shardName', 'shard0000'), ('clusterId', ObjectId('5f6c7d3e4bf2f9c3da4dc92f')), ('configsvrConnectionString', 'replconf/127.0.0.1:27000')])), ('$db', 'admin')])
-# real full response for v4.4 = {
-#     "ok": 1,
-#     "$gleStats": {
-#         "lastOpTime": {
-#             "ts": 6876008835761307649,
-#             "t": 1
-#         }
-#         "electionId": ObjectId(7f:ff:ff:ff:00:00:00:00:00:00:00:01)
-#     },
-#     "lastCommittedOpTime": 6876008835761307649,
-#     "$configServerState": {
-#         "opTime": {
-#             "ts": 6876008831466340353,
-#             "t": 1
-#         }
-#     },
-#     "$clusterTime": {
-#         "clusterTime": 6876008835761307650,
-#         "signature": {
-#             "hash": 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00,
-#             "keyId": 0
-#         }
-#     },
-#     "operationTime": 6876008835761307649
-# }
-
 
 class Responce(Responder):
     when = {'_addShard': helpers.is_true}
 
-    result = response = {
+    result = {
         "ok": 1
     }
 

--- a/mindsdb/api/mongo/op_msg_responders/aggregate.py
+++ b/mindsdb/api/mongo/op_msg_responders/aggregate.py
@@ -1,0 +1,23 @@
+from mindsdb.api.mongo.classes import Responder
+import mindsdb.api.mongo.functions as helpers
+
+
+class Responce(Responder):
+    when = {'aggregate': helpers.is_true}
+
+    def result(self, query, request_env, mindsdb_env, session):
+        db = query['$db']
+        collection = query['aggregate']
+
+        count = 0
+        if db == 'mindsdb' and collection == 'predictors':
+            count = len(mindsdb_env['mindsdb_native'].get_models())
+
+        return {
+            'count': count,
+            'maxTimeMs': 5000,
+            '$db': db
+        }
+
+
+responder = Responce()

--- a/mindsdb/api/mongo/op_msg_responders/buildinfo.py
+++ b/mindsdb/api/mongo/op_msg_responders/buildinfo.py
@@ -11,7 +11,7 @@ class Responce(Responder):
         )
 
     result = {
-        'version': f'MindsDB {mindsdb_version}',   # TODO set real
+        'version': f'MindsDB {mindsdb_version}',
         'ok': 1
     }
 

--- a/mindsdb/api/mongo/op_msg_responders/coll_stats.py
+++ b/mindsdb/api/mongo/op_msg_responders/coll_stats.py
@@ -1,0 +1,39 @@
+from mindsdb.api.mongo.classes import Responder
+import mindsdb.api.mongo.functions as helpers
+
+
+class Responce(Responder):
+    when = {'collStats': helpers.is_true}
+
+    def result(self, query, request_env, mindsdb_env, session):
+        db = query['$db']
+        collection = query['collStats']
+
+        # NOTE real answer is huge, i removed most data from it.
+        res = {
+            'ns': "db.collection",
+            'size': 1,
+            'count': 0,
+            'avgObjSize': 1,
+            'storageSize': 16384,
+            'capped': False,
+            'wiredTiger': {
+            },
+            'nindexes': 1,
+            'indexDetails': {
+            },
+            'totalIndexSize': 16384,
+            'indexSizes': {
+                '_id_': 16384
+            },
+            'ok': 1
+        }
+
+        res['ns'] = f"{db}.{collection}"
+        if db == 'mindsdb' and collection == 'predictors':
+            res['count'] = len(mindsdb_env['mindsdb_native'].get_models())
+
+        return res
+
+
+responder = Responce()

--- a/mindsdb/api/mongo/op_msg_responders/connection_status.py
+++ b/mindsdb/api/mongo/op_msg_responders/connection_status.py
@@ -1,0 +1,22 @@
+from mindsdb.api.mongo.classes import Responder
+import mindsdb.api.mongo.functions as helpers
+
+
+class Responce(Responder):
+    when = {'connectionStatus': helpers.is_true}
+
+    def result(self, query, request_env, mindsdb_env, session):
+        res = {
+            'authInfo': {
+                'authenticatedUsers': [],
+                'authenticatedUserRoles': []
+            },
+            'ok': 1
+        }
+        if helpers.is_true(query.get('showPrivileges')):
+            res['authInfo']['authenticatedUserPrivileges'] = []
+
+        return res
+
+
+responder = Responce()

--- a/mindsdb/api/mongo/op_msg_responders/count.py
+++ b/mindsdb/api/mongo/op_msg_responders/count.py
@@ -1,0 +1,21 @@
+from mindsdb.api.mongo.classes import Responder
+import mindsdb.api.mongo.functions as helpers
+
+
+class Responce(Responder):
+    when = {'count': helpers.is_true}
+
+    def result(self, query, request_env, mindsdb_env, session):
+        collection = query['count']
+
+        count = 0
+        if collection == 'predictors':
+            count = len(mindsdb_env['mindsdb_native'].get_models())
+
+        return {
+            'n': count,
+            'ok': 1
+        }
+
+
+responder = Responce()

--- a/mindsdb/api/mongo/op_msg_responders/db_stats.py
+++ b/mindsdb/api/mongo/op_msg_responders/db_stats.py
@@ -1,0 +1,31 @@
+from mindsdb.api.mongo.classes import Responder
+import mindsdb.api.mongo.functions as helpers
+
+
+class Responce(Responder):
+    when = {'dbStats': helpers.is_true}
+
+    def result(self, query, request_env, mindsdb_env, session):
+        db = query['$db']
+        collections = 0
+        if db == 'mindsdb':
+            collections = 2 + len(mindsdb_env['mindsdb_native'].get_models())
+        return {
+            'db': db,
+            'collections': collections,
+            'views': 0,
+            'objects': 0,
+            'avgObjSize': 0,
+            'dataSize': 0,
+            'storageSize': 0,
+            'numExtents': 0,
+            'indexes': 0,
+            'indexSize': 0,
+            'fileSize': 0,
+            'fsUsedSize': 0,
+            'fsTotalSize': 0,
+            'ok': 1
+        }
+
+
+responder = Responce()

--- a/mindsdb/api/mongo/op_msg_responders/delete.py
+++ b/mindsdb/api/mongo/op_msg_responders/delete.py
@@ -5,7 +5,7 @@ import mindsdb.api.mongo.functions as helpers
 class Responce(Responder):
     when = {'delete': helpers.is_true}
 
-    def result(self, query, request_env, mindsdb_env):
+    def result(self, query, request_env, mindsdb_env, session):
         try:
             res = self._result(query, request_env, mindsdb_env)
         except Exception as e:

--- a/mindsdb/api/mongo/op_msg_responders/find.py
+++ b/mindsdb/api/mongo/op_msg_responders/find.py
@@ -7,7 +7,7 @@ import mindsdb.api.mongo.functions as helpers
 class Responce(Responder):
     when = {'find': helpers.is_true}
 
-    def result(self, query, request_env, mindsdb_env):
+    def result(self, query, request_env, mindsdb_env, session):
         models = mindsdb_env['mindsdb_native'].get_models()
         model_names = [x['name'] for x in models]
         table = query['find']

--- a/mindsdb/api/mongo/op_msg_responders/get_cmd_line_opts.py
+++ b/mindsdb/api/mongo/op_msg_responders/get_cmd_line_opts.py
@@ -3,10 +3,15 @@ import mindsdb.api.mongo.functions as helpers
 
 
 class Responce(Responder):
-    when = {'_recvChunkStart': helpers.is_true}
+    when = {'getCmdLineOpts': helpers.is_true}
 
     result = {
-        "ok": 0
+        'argv': [
+            'mongod'
+        ],
+        'parsed': {
+        },
+        'ok': 1
     }
 
 

--- a/mindsdb/api/mongo/op_msg_responders/host_info.py
+++ b/mindsdb/api/mongo/op_msg_responders/host_info.py
@@ -1,0 +1,28 @@
+from mindsdb.api.mongo.classes import Responder
+import mindsdb.api.mongo.functions as helpers
+
+
+class Responce(Responder):
+    when = {'hostInfo': helpers.is_true}
+
+    # NOTE answer is not full, but looks like this info is enough
+    result = {
+        'system': {
+            'cpuAddrSize': 64,
+            'memSizeMB': 15951,
+            'numCores': 4,
+            'cpuArch': "x86_64",
+            'numaEnabled': False
+        },
+        'os': {
+            'type': "Linux",
+            'name': "Ubuntu",
+            'version': "20.04"
+        },
+        'extra': {
+        },
+        'ok': 1
+    }
+
+
+responder = Responce()

--- a/mindsdb/api/mongo/op_msg_responders/insert.py
+++ b/mindsdb/api/mongo/op_msg_responders/insert.py
@@ -5,7 +5,7 @@ import mindsdb.api.mongo.functions as helpers
 class Responce(Responder):
     when = {'insert': helpers.is_true}
 
-    def result(self, query, request_env, mindsdb_env):
+    def result(self, query, request_env, mindsdb_env, session):
         try:
             res = self._result(query, request_env, mindsdb_env)
         except Exception as e:

--- a/mindsdb/api/mongo/op_msg_responders/is_master.py
+++ b/mindsdb/api/mongo/op_msg_responders/is_master.py
@@ -5,7 +5,7 @@ import mindsdb.api.mongo.functions as helpers
 class Responce(Responder):
     when = {'isMaster': helpers.is_true}
 
-    result = response = {
+    result = {
         "ismaster": True,
         "minWireVersion": 0,
         "maxWireVersion": 9,

--- a/mindsdb/api/mongo/op_msg_responders/is_master_lower.py
+++ b/mindsdb/api/mongo/op_msg_responders/is_master_lower.py
@@ -5,7 +5,7 @@ import mindsdb.api.mongo.functions as helpers
 class Responce(Responder):
     when = {'ismaster': helpers.is_true}
 
-    result = response = {
+    result = {
         "ismaster": True,
         "minWireVersion": 0,
         "maxWireVersion": 9,

--- a/mindsdb/api/mongo/op_msg_responders/list_collections.py
+++ b/mindsdb/api/mongo/op_msg_responders/list_collections.py
@@ -9,7 +9,7 @@ import mindsdb.api.mongo.functions as helpers
 class Responce(Responder):
     when = {'listCollections': helpers.is_true}
 
-    def result(self, query, request_env, mindsdb_env):
+    def result(self, query, request_env, mindsdb_env, session):
         models = mindsdb_env['mindsdb_native'].get_models()
         models = [x['name'] for x in models if x['status'] == 'complete']
         models += ['predictors', 'commands']

--- a/mindsdb/api/mongo/op_msg_responders/list_databases.py
+++ b/mindsdb/api/mongo/op_msg_responders/list_databases.py
@@ -5,7 +5,7 @@ import mindsdb.api.mongo.functions as helpers
 class Responce(Responder):
     when = {'listDatabases': helpers.is_true}
 
-    def result(self, query, request_env, mindsdb_env):
+    def result(self, query, request_env, mindsdb_env, session):
         db = mindsdb_env['config']['api']['mongodb']['database']
 
         return {

--- a/mindsdb/api/mongo/op_msg_responders/list_indexes.py
+++ b/mindsdb/api/mongo/op_msg_responders/list_indexes.py
@@ -1,0 +1,22 @@
+from mindsdb.api.mongo.classes import Responder
+import mindsdb.api.mongo.functions as helpers
+
+
+class Responce(Responder):
+    when = {'listIndexes': helpers.is_true}
+
+    def result(self, query, request_env, mindsdb_env, session):
+        return {
+            'cursor': [{
+                'v': 2,
+                'key': {
+                    '_id': 1
+                },
+                'name': '_id_',
+                'ns': f"{query['$db']}.{query['listIndexes']}"
+            }],
+            'ok': 1,
+        }
+
+
+responder = Responce()

--- a/mindsdb/api/mongo/op_msg_responders/sasl_continue.py
+++ b/mindsdb/api/mongo/op_msg_responders/sasl_continue.py
@@ -1,0 +1,33 @@
+from mindsdb.api.mongo.classes import Responder
+import mindsdb.api.mongo.functions as helpers
+
+
+class Responce(Responder):
+    when = {'saslContinue': helpers.is_true}
+
+    def result(self, query, request_env, mindsdb_env, session):
+        try:
+            payload = query['payload'].decode()
+
+            if len(payload) > 0:
+                responce = session.scram.process_client_second_message(payload)
+                responce = responce.encode()
+                done = False
+            else:
+                responce = None
+                done = True
+
+            res = {
+                'conversationId': 1,
+                'done': done,
+                'payload': responce,
+                'ok': 1
+            }
+        except Exception:
+            res = {
+                'ok': 0
+            }
+        return res
+
+
+responder = Responce()

--- a/mindsdb/api/mongo/op_msg_responders/sasl_start.py
+++ b/mindsdb/api/mongo/op_msg_responders/sasl_start.py
@@ -1,0 +1,27 @@
+from mindsdb.api.mongo.classes import Responder
+import mindsdb.api.mongo.functions as helpers
+
+
+class Responce(Responder):
+    when = {'saslStart': helpers.is_true}
+
+    def result(self, query, request_env, mindsdb_env, session):
+        try:
+            payload = query['payload'].decode()
+            session.init_scram()
+            responce = session.scram.process_client_first_message(payload)
+
+            res = {
+                'conversationId': 1,
+                'done': False,
+                'payload': responce.encode(),
+                'ok': 1
+            }
+        except Exception:
+            res = {
+                'ok': 0
+            }
+        return res
+
+
+responder = Responce()

--- a/mindsdb/api/mongo/op_msg_responders/update_range_deletions.py
+++ b/mindsdb/api/mongo/op_msg_responders/update_range_deletions.py
@@ -4,7 +4,7 @@ from mindsdb.api.mongo.classes import Responder
 class Responce(Responder):
     when = {'update': 'rangeDeletions'}
 
-    result = response = {
+    result = {
         "ok": 1
     }
 

--- a/mindsdb/api/mongo/op_msg_responders/whatsmyuri.py
+++ b/mindsdb/api/mongo/op_msg_responders/whatsmyuri.py
@@ -5,7 +5,7 @@ import mindsdb.api.mongo.functions as helpers
 class Responce(Responder):
     when = {'whatsmyuri': helpers.is_true}
 
-    def result(self, query, request_env, mindsdb_env):
+    def result(self, query, request_env, mindsdb_env, session):
         mongodb_config = mindsdb_env['config']['api']['mongodb']
         host = mongodb_config['host']
         port = mongodb_config['port']

--- a/mindsdb/api/mongo/op_query_responders/is_master.py
+++ b/mindsdb/api/mongo/op_query_responders/is_master.py
@@ -5,7 +5,7 @@ import mindsdb.api.mongo.functions as helpers
 class Responce(Responder):
     when = {'isMaster': helpers.is_true}
 
-    result = response = {
+    result = {
         "ismaster": True,
         "minWireVersion": 0,
         "maxWireVersion": 9,  # 6 - 3.6, 9 - 4.4


### PR DESCRIPTION
This is base implementation of 'SCRAM-SHA-1' auth in MongoDB. That ahould allow connect to mindsdb 'mongo api' using name/password:
`mongo --port 47337 -u "user" -p "password" --authenticationDatabase "admin"`
To do it, first need to add 'user' and 'password' fields in `config['api']['mongodb']`. If any of this fields is empty, then is no possible to connect as above.
Connection without user/password still allowed (even if 'user' and 'password' in config).

Added ssl socket wrapp dor mongo api. Now possible connect with and without ssl:
`mongo --port 47337`
`mongo --port 47337 --ssl --sslAllowInvalidCertificates`
`sslAllowInvalidCertificates` need because mongodb dont allow self signed certs.

Added processing of packages to mongo api (need for work thorough Compass):
```
connection_status
get_cmd_line_opts
host_info
db_stats
coll_stats
count
aggregate
list_indexes
```