### PR TITLE
install pywin32 before winshell to build windows installer

### DIFF
--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -107,6 +107,7 @@ jobs:
     - name: Build windows installer
       run: |
         pip install pyinstaller
+        pip install pywin32
         pip install winshell
         python distributions/windows/build_installers.py beta
 

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -109,6 +109,7 @@ jobs:
         pip install pyinstaller
         pip install pywin32
         pip install winshell
+        pip install requests
         python distributions/windows/build_installers.py beta
 
     - name: Sync windows installer to s3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Build windows installer
       run: |
         pip install pyinstaller
+        pip install pywin32
         pip install winshell
         python distributions/windows/build_installers.py release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         pip install pyinstaller
         pip install pywin32
         pip install winshell
+        pip install requests
         python distributions/windows/build_installers.py release
 
     - name: Sync windows installer to s3


### PR DESCRIPTION
a bug in the winshell module:
https://stackoverflow.com/a/45929866/8841831

so pywin32 has to be installed for winshell to work (otherwise there is a `ModuleNotFoundError` when importing winshell)