### PR TITLE
run as admin by default

### DIFF
--- a/distributions/windows/build_installers.py
+++ b/distributions/windows/build_installers.py
@@ -21,5 +21,5 @@ with open('distributions/windows/latest.py', 'w+') as f:
 with open('distributions/windows/fixed.py', 'w+') as f:
     f.write(install_py.replace('$name', FIXED_NAME).replace('$version', about['__version__']))
 
-os.system('cd distributions/windows && pyinstaller latest.py -F --onefile -n {}-Setup.exe'.format(LATEST_NAME))
-os.system('cd distributions/windows && pyinstaller fixed.py -F --onefile -n {}-Setup.exe'.format(FIXED_NAME))
+os.system('cd distributions/windows && pyinstaller latest.py -F --onefile --uac-admin -n {}-Setup.exe'.format(LATEST_NAME))
+os.system('cd distributions/windows && pyinstaller fixed.py -F --onefile --uac-admin -n {}-Setup.exe'.format(FIXED_NAME))


### PR DESCRIPTION
Closes https://github.com/mindsdb/mindsdb/issues/964

Use `--uac-admin` flag when building windows installers with pyinstaller so the executable is run as admin when double-clicked