### PR TITLE
Error while delete predictor from not valid integration

### DIFF
--- a/mindsdb/interfaces/database/database.py
+++ b/mindsdb/interfaces/database/database.py
@@ -64,7 +64,7 @@ class DatabaseWrapper():
             if integration.check_connection():
                 integration.unregister_predictor(name)
             else:
-                logger.warning(f"There is not connection to {integration.name}. predictor wouldn't be unregisted")
+                logger.warning(f"There is no connection to {integration.name}. predictor wouldn't be unregisted")
 
     def check_connections(self):
         connections = {}

--- a/mindsdb/interfaces/database/database.py
+++ b/mindsdb/interfaces/database/database.py
@@ -64,7 +64,7 @@ class DatabaseWrapper():
             if integration.check_connection():
                 integration.unregister_predictor(name)
             else:
-                logger.warning(f"There is no connection to {integration.name}. predictor wouldn't be unregisted")
+                logger.warning(f"There is no connection to {integration.name}. predictor wouldn't be unregistred")
 
     def check_connections(self):
         connections = {}

--- a/mindsdb/interfaces/database/database.py
+++ b/mindsdb/interfaces/database/database.py
@@ -4,6 +4,8 @@ from mindsdb.integrations.mariadb.mariadb import Mariadb
 from mindsdb.integrations.mysql.mysql import MySQL
 from mindsdb.integrations.mssql.mssql import MSSQL
 
+from mindsdb.utilities.log import log as logger
+
 
 class DatabaseWrapper():
 
@@ -50,13 +52,19 @@ class DatabaseWrapper():
             if setup:
                 register = self._setup_integration(integration)
             if register:
-                integration.register_predictors(model_data_arr)
+                if integration.check_connection():
+                    integration.register_predictors(model_data_arr)
+                else:
+                    logger.warning(f"There is no connection to {integration.name}. predictor wouldn't be registred.")
 
             integration = [integration]
 
     def unregister_predictor(self, name):
         for integration in self._get_integrations():
-            integration.unregister_predictor(name)
+            if integration.check_connection():
+                integration.unregister_predictor(name)
+            else:
+                logger.warning(f"There is not connection to {integration.name}. predictor wouldn't be unregisted")
 
     def check_connections(self):
         connections = {}


### PR DESCRIPTION
Fixes #1007

- **What**
  - When predictor is creating and any integration with third-party database is already exists, mindsdb creates a table object in each existing integration for new predictor
  - When predictor is deleting, mindsdb removes all tables related to this predictor in each integration
  - If integration created with invalid credentials or connection couldn't be estalished, user receives 500 error on deleting predictor event and backend also raises exception on create/delete predictor in this case (see details in original issue)

 - **How**
   - check connection before each register/unregister predictor action
