### PR TITLE
enable/disable telemetry endpoint

### DIFF
--- a/mindsdb/api/http/namespaces/util.py
+++ b/mindsdb/api/http/namespaces/util.py
@@ -1,9 +1,12 @@
+import os
 from flask import request
 from flask_restx import Resource, abort
 from flask import current_app as ca
 
 from mindsdb.api.http.namespaces.configs.util import ns_conf
 from mindsdb import __about__
+
+TELEMETRY_FILE = 'telemetry.lock'
 
 @ns_conf.route('/ping')
 class Ping(Resource):
@@ -21,3 +24,34 @@ class ReportUUID(Resource):
         return {
             'report_uuid': predictor.report_uuid
         }
+
+@ns_conf.route('/telemetry')
+class Telemetry(Resource):
+    @ns_conf.doc('get_telemetry_status')
+    def get(self):
+        status = "enabled" if is_telemetry_active() else "disabled"
+        return {"status": status}
+
+    @ns_conf.doc('set_telemetry')
+    def post(self):
+        data = request.json
+        action = data['action']
+        if str(action).lower() in ["true", "enable", "on"]:
+            enable_telemetry()
+        else:
+            disable_telemetry()
+
+
+def disable_telemetry():
+    path = os.path.join(ca.config_obj['storage_dir'], TELEMETRY_FILE)
+    if os.path.exists(path):
+        os.remove(path)
+
+def enable_telemetry():
+    path = os.path.join(ca.config_obj['storage_dir'], TELEMETRY_FILE)
+    with open(path, 'w') as _:
+        pass
+
+def is_telemetry_active():
+    path = os.path.join(ca.config_obj['storage_dir'], TELEMETRY_FILE)
+    return os.path.exists(path)

--- a/mindsdb/api/http/namespaces/util.py
+++ b/mindsdb/api/http/namespaces/util.py
@@ -42,16 +42,16 @@ class Telemetry(Resource):
             disable_telemetry()
 
 
-def disable_telemetry():
+def enable_telemetry():
     path = os.path.join(ca.config_obj['storage_dir'], TELEMETRY_FILE)
     if os.path.exists(path):
         os.remove(path)
 
-def enable_telemetry():
+def disable_telemetry():
     path = os.path.join(ca.config_obj['storage_dir'], TELEMETRY_FILE)
     with open(path, 'w') as _:
         pass
 
 def is_telemetry_active():
     path = os.path.join(ca.config_obj['storage_dir'], TELEMETRY_FILE)
-    return os.path.exists(path)
+    return not os.path.exists(path)


### PR DESCRIPTION
Fixes #993

Closes #993

- **What**
   - Need ability to turn telemetry (like check for updates) on/off via API
- **How**
   - Created a separate endpoint
   - Changed check_for_updates condition. see - [mindsdb_native](https://github.com/mindsdb/mindsdb_native/pull/357)
   - Telemetry moves to disabled state when telemetry.lock file is created in storage dir. It is enabled otherwise
   - It looks a little bit strage, that needs to create smth to disable telemetry. But otherwise (when needs to create lock file on filesystem to enable it) CHECK_FOR_UPDATE=1 value doesn't make any affect by default.