### PR TITLE
Gayatri.api endpoint changes

### DIFF
--- a/mindsdb/api/http/namespaces/config.py
+++ b/mindsdb/api/http/namespaces/config.py
@@ -2,8 +2,8 @@ import copy
 import traceback
 
 from flask import request
-from flask_restx import Resource, abort
 from flask import current_app as ca
+from flask_restx import Resource, abort
 
 from mindsdb.api.http.namespaces.configs.config import ns_conf
 from mindsdb.interfaces.database.database import DatabaseWrapper
@@ -135,6 +135,7 @@ class ToggleTelemetry(Resource):
     def get(self, flag):
         if flag in ["True", "true", "t"]:
             return 'Enabled telemetry', 200
-        elif flag in ["False", "false", "f"]:
+        if flag in ["False", "false", "f"]:
             return 'Disabled telemetry', 200
         abort(404, f'Flag not recognized: {flag}')
+        return '', 200

--- a/mindsdb/api/http/namespaces/config.py
+++ b/mindsdb/api/http/namespaces/config.py
@@ -135,5 +135,6 @@ class ToggleTelemetry(Resource):
     def get(self, flag):
         if flag in ["True", "true", "t"]:
             return 'Enabled telemetry', 200
-        else:
+        elif flag in ["False", "false", "f"]:
             return 'Disabled telemetry', 200
+        abort(404, f'Flag not recognized: {flag}')

--- a/tests/integration_tests/api/test_http.py
+++ b/tests/integration_tests/api/test_http.py
@@ -246,6 +246,9 @@ class HTTPTest(unittest.TestCase):
         for flag in ["False", "false", "f"]:
             response = requests.get(f'{root}/config/telemetry/{flag}')
             assert response.status_code == 200
+        flag = "error"
+        response = requests.get(f'{root}/config/telemetry/{flag}')
+        assert response.status_code == 404
 
 if __name__ == '__main__':
     unittest.main(failfast=True)

--- a/tests/integration_tests/api/test_http.py
+++ b/tests/integration_tests/api/test_http.py
@@ -240,8 +240,12 @@ class HTTPTest(unittest.TestCase):
         Call telemetry enabled
         then check the response is status 200
         """
-        response = requests.get(f'{root}/config/telemetry/true')
-        assert response.status_code == 200
+        for flag in ["True", "true", "t"]:
+            response = requests.get(f'{root}/config/telemetry/{flag}')
+            assert response.status_code == 200
+        for flag in ["False", "false", "f"]:
+            response = requests.get(f'{root}/config/telemetry/{flag}')
+            assert response.status_code == 200
 
 if __name__ == '__main__':
     unittest.main(failfast=True)


### PR DESCRIPTION
Fixes #1008 

## Please describe what changes you made, in as much detail as possible
  - Small change to telemetry endpoint to make it more robust to flags that are not recognized
  - Will now abort with a 404 with an unrecognized flag
  - HTTP tests are updated to test this functionality

mindsdb