### PR TITLE
Receive DataSource instance to Predictor instead of object_info dict

### DIFF
--- a/mindsdb/api/http/namespaces/predictor.py
+++ b/mindsdb/api/http/namespaces/predictor.py
@@ -266,28 +266,27 @@ class PredictorPredictFromDataSource(Resource):
     def post(self, name):
         data = request.json
 
-        from_data = ca.default_store.get_datasource_obj(data.get('data_source_name'), raw=True)
+        from_data = ca.default_store.get_datasource_obj(data.get('data_source_name'))
         if from_data is None:
             abort(400, 'No valid datasource given')
 
         try:
             format_flag = data.get('format_flag')
-        except:
+        except Exception:
             format_flag = 'explain'
 
         try:
             kwargs = data.get('kwargs')
-        except:
+        except Exception:
             kwargs = {}
 
-        if type(kwargs) != type({}):
+        if not isinstance(kwargs, dict):
             kwargs = {}
 
         if is_custom(name):
             return ca.custom_models.predict(name, from_data=from_data, **kwargs)
-        else:
-            results = ca.mindsdb_native.predict(name, when_data=from_data, **kwargs)
 
+        results = ca.mindsdb_native.predict(name, when_data=from_data, **kwargs)
         return preparse_results(results, format_flag)
 
 

--- a/mindsdb/interfaces/custom/custom_models.py
+++ b/mindsdb/interfaces/custom/custom_models.py
@@ -82,9 +82,16 @@ class CustomModels():
         self.dbw.unregister_predictor(name)
         self.dbw.register_predictors([self.get_model_data(name)], setup=False)
 
-    def predict(self, name, when_data=None, from_data=None, kwargs={}):
+    def predict(self, name, when_data=None, from_data=None, kwargs=None):
+        if kwargs is None:
+            kwargs = {}
         if from_data is not None:
-            data_source = getattr(mindsdb_native, from_data['class'])(*from_data['args'], **from_data['kwargs'])
+            if isinstance(from_data, dict):
+                data_source = getattr(mindsdb_native, from_data['class'])(*from_data['args'],
+                                                                          **from_data['kwargs'])
+            # assume that particular instance of any DataSource class is provided
+            else:
+                data_source = from_data
             data_frame = data_source.df
         elif when_data is not None:
             if isinstance(when_data, dict):


### PR DESCRIPTION
Fixes #994

**What**:
  - `predict_datasource` endpoint send to native Predictor dict with pickle DataSource info which doesn't support my native Predictor

**How**
  - Sending particular DataSource instance instead for data about this one