### PR TITLE
Error to create datasource from fake integration

### DIFF
--- a/mindsdb/api/http/namespaces/datasource.py
+++ b/mindsdb/api/http/namespaces/datasource.py
@@ -129,6 +129,10 @@ class Datasource(Resource):
 
         if 'query' in data:
             source_type = request.json['integration_id']
+            if source_type not in ca.default_store.config['integrations']:
+                # integration doens't exist
+                abort(400, f"{source_type} integration doesn't exist")
+
             ca.default_store.save_datasource(name, source_type, request.json)
             os.rmdir(temp_dir_path)
             return ca.default_store.get_datasource(name)

--- a/tests/integration_tests/api/test_http.py
+++ b/tests/integration_tests/api/test_http.py
@@ -246,7 +246,7 @@ class HTTPTest(unittest.TestCase):
                 "name": ds_name,
                 "query": "select * from test_data.any_data limit 100;"}
         response = requests.put(f'{root}/api/datasources/{ds_name}', json=data)
-        assert response.status_code == 400, "expected 400 but got " + response.status_code + ", " + response.json()
+        assert response.status_code == 400, "expected 400 but got " + str(response.status_code) + ", " + str(response.json())
 
 if __name__ == '__main__':
     unittest.main(failfast=True)

--- a/tests/integration_tests/api/test_http.py
+++ b/tests/integration_tests/api/test_http.py
@@ -246,7 +246,7 @@ class HTTPTest(unittest.TestCase):
                 "name": ds_name,
                 "query": "select * from test_data.any_data limit 100;"}
         response = requests.put(f'{root}/api/datasources/{ds_name}', json=data)
-        assert response.status_code == 400, "expected 400 but got " + str(response.status_code) + ", " + str(response.json())
+        assert response.status_code == 400, "expected 400 but got " + str(response.status_code) + ", " + str(response.text)
 
 if __name__ == '__main__':
     unittest.main(failfast=True)

--- a/tests/integration_tests/api/test_http.py
+++ b/tests/integration_tests/api/test_http.py
@@ -246,7 +246,7 @@ class HTTPTest(unittest.TestCase):
                 "name": ds_name,
                 "query": "select * from test_data.any_data limit 100;"}
         response = requests.put(f'{root}/api/datasources/{ds_name}', json=data)
-        assert response.status_code == 400, f"expected 400 but got {response.status_code}, {response.json()}"
+        assert response.status_code == 400, "expected 400 but got " + response.status_code + ", " + response.json()
 
 if __name__ == '__main__':
     unittest.main(failfast=True)

--- a/tests/integration_tests/api/test_http.py
+++ b/tests/integration_tests/api/test_http.py
@@ -245,8 +245,8 @@ class HTTPTest(unittest.TestCase):
         data = {"integration_id": f'unexists_integration_{uuid1()}',
                 "name": ds_name,
                 "query": "select * from test_data.any_data limit 100;"}
-        response = requests.put(f'{root}/api/datasources/{ds_name}', json=data)
-        assert response.status_code == 400, "expected 400 but got " + str(response.status_code) + ", " + str(response.text)
+        response = requests.put(f'{root}/datasources/{ds_name}', json=data)
+        assert response.status_code == 400, f"expected 400 but got {response.status_code}, {response.text}"
 
 if __name__ == '__main__':
     unittest.main(failfast=True)

--- a/tests/integration_tests/api/test_http.py
+++ b/tests/integration_tests/api/test_http.py
@@ -1,15 +1,16 @@
 import os
+import time
+import unittest
+import importlib.util
 from random import randint
 from pathlib import Path
-import unittest
-import requests
-import time
+from uuid import uuid1
 
+import requests
 import psutil
 
 from mindsdb.utilities.config import Config
 
-import importlib.util
 common_path = Path(__file__).parent.parent.absolute().joinpath('flows/common.py').resolve()
 spec = importlib.util.spec_from_file_location("common", str(common_path))
 common = importlib.util.module_from_spec(spec)
@@ -235,13 +236,17 @@ class HTTPTest(unittest.TestCase):
         assert response.status_code == 200
         assert response.content.decode().find('<head>') > 0
 
-    def test_10_telemetry_enabled(self):
+    def test_10_ds_from_unexist_integration(self):
         """
         Call telemetry enabled
         then check the response is status 200
         """
-        response = requests.get(f'{root}/config/telemetry/true')
-        assert response.status_code == 200
+        ds_name = f"ds_{uuid1()}"
+        data = {"integration_id": f'unexists_integration_{uuid1()}',
+                "name": ds_name,
+                "query": "select * from test_data.any_data limit 100;"}
+        response = requests.put(f'{root}/api/datasources/{ds_name}', json=data)
+        assert response.status_code == 400
 
 if __name__ == '__main__':
     unittest.main(failfast=True)

--- a/tests/integration_tests/api/test_http.py
+++ b/tests/integration_tests/api/test_http.py
@@ -246,7 +246,7 @@ class HTTPTest(unittest.TestCase):
                 "name": ds_name,
                 "query": "select * from test_data.any_data limit 100;"}
         response = requests.put(f'{root}/api/datasources/{ds_name}', json=data)
-        assert response.status_code == 400
+        assert response.status_code == 400, f"expected 400 but got {response.status_code}, {response.json()}"
 
 if __name__ == '__main__':
     unittest.main(failfast=True)


### PR DESCRIPTION
Fixes #945

**What**
  - Error(namely error loop) happened while user try to create datasource form non existing integration (see details into related issue).
  - Root cause of it - native receives original data dictionary as File DataSource info

**How**
  - By checking that provided integration exists in API endpoint

mindsdb