### PR TITLE
improve port forwarding closing

### DIFF
--- a/tests/integration_tests/flows/common.py
+++ b/tests/integration_tests/flows/common.py
@@ -182,15 +182,16 @@ if USE_EXTERNAL_DB_SERVER:
 
     close_all_ssh_tunnels()
 
-    port_forwarding_status = 1
-    i = 10
-    while port_forwarding_status != 0 and i > 0:
-        i = i - 1
+    for _ in range(10):
         r = requests.get('http://127.0.0.1:5005/port')
         if r.status_code != 200:
             raise Exception('Cant get port to run mindsdb')
         mindsdb_port = r.content.decode()
-        port_forwarding_status = open_ssh_tunnel(mindsdb_port, 'R')
+        status = open_ssh_tunnel(mindsdb_port, 'R')
+        if status == 0:
+            break
+    else:
+        raise Exception('Cant get empty port to run mindsdb')
 
     print(f'use mindsdb port={mindsdb_port}')
     config._config['api']['mysql']['port'] = mindsdb_port

--- a/tests/integration_tests/flows/common.py
+++ b/tests/integration_tests/flows/common.py
@@ -6,6 +6,7 @@ import atexit
 import asyncio
 import shutil
 import csv
+import re
 from pathlib import Path
 
 import requests
@@ -136,33 +137,61 @@ def prepare_config(config, mindsdb_database='mindsdb', override_integration_conf
     return temp_config_path
 
 
+def close_all_ssh_tunnels():
+    RE_PORT_CONTROL = re.compile(r'^\.mindsdb-ssh-ctrl-\d+$')
+    for p in Path('/tmp/mindsdb').iterdir():
+        if p.is_socket() and p.name != '.mindsdb-ssh-ctrl-5005' and RE_PORT_CONTROL.match(p.name):
+            sp = subprocess.Popen(f'ssh -S /tmp/mindsdb/{p.name} -O exit ubuntu@3.220.66.106', shell=True)
+            sp.wait()
+
+
 def close_ssh_tunnel(sp, port):
     sp.kill()
     # NOTE line below will close connection in ALL test instances.
     # sp = subprocess.Popen(f'for pid in $(lsof -i :{port} -t); do kill -9 $pid; done', shell=True)
-    sp = subprocess.Popen(f'ssh -S /tmp/.mindsdb-ssh-ctrl-{port} -O exit ubuntu@3.220.66.106', shell=True)
+    sp = subprocess.Popen(f'ssh -S /tmp/mindsdb/.mindsdb-ssh-ctrl-{port} -O exit ubuntu@3.220.66.106', shell=True)
     sp.wait()
 
 
 def open_ssh_tunnel(port, direction='R'):
-    cmd = f'ssh -i ~/.ssh/db_machine -S /tmp/.mindsdb-ssh-ctrl-{port} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fMN{direction} 127.0.0.1:{port}:127.0.0.1:{port} ubuntu@3.220.66.106'
+    path = Path('/tmp/mindsdb')
+    if not path.is_dir():
+        path.mkdir(mode=0o777, exist_ok=True, parents=True)
+
+    cmd = f'ssh -i ~/.ssh/db_machine -S /tmp/mindsdb/.mindsdb-ssh-ctrl-{port} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -fMN{direction} 127.0.0.1:{port}:127.0.0.1:{port} ubuntu@3.220.66.106'
     sp = subprocess.Popen(
         cmd.split(' '),
         stdout=OUTPUT,
         stderr=OUTPUT
     )
-    atexit.register(close_ssh_tunnel, sp=sp, port=port)
+    try:
+        status = sp.wait(5)
+    except subprocess.TimeoutExpired:
+        status = 1
+        sp.kill()
+
+    if status == 0:
+        atexit.register(close_ssh_tunnel, sp=sp, port=port)
+    return status
 
 
 if USE_EXTERNAL_DB_SERVER:
     config = Config(TEST_CONFIG)
     open_ssh_tunnel(5005, 'L')
     wait_port(5005, timeout=10)
-    r = requests.get('http://127.0.0.1:5005/port')
-    if r.status_code != 200:
-        raise Exception('Cant get port to run mindsdb')
-    mindsdb_port = r.content.decode()
-    open_ssh_tunnel(mindsdb_port, 'R')
+
+    close_all_ssh_tunnels()
+
+    port_forwarding_status = 1
+    i = 10
+    while port_forwarding_status != 0 and i > 0:
+        i = i - 1
+        r = requests.get('http://127.0.0.1:5005/port')
+        if r.status_code != 200:
+            raise Exception('Cant get port to run mindsdb')
+        mindsdb_port = r.content.decode()
+        port_forwarding_status = open_ssh_tunnel(mindsdb_port, 'R')
+
     print(f'use mindsdb port={mindsdb_port}')
     config._config['api']['mysql']['port'] = mindsdb_port
     config._config['api']['mongodb']['port'] = mindsdb_port


### PR DESCRIPTION
**why**

Sometimes error appears on test start: `mysql cant connect to 127.0.0.1 bla bla bla`. The reason is unsuccessful port forwarding before. My guess, that can happens if someone other used same port before and dont close forwarding properly (if, for example, exception raised during test). 

**how**

1. closing all current port-forwarding on test start (need comment this if several tests will be ran in same time)
2. trying open port forwarding in cycle, untill success (no more 10 times)