### PR TITLE
fix ignored column in data analisys

### DIFF
--- a/mindsdb/interfaces/native/mindsdb.py
+++ b/mindsdb/interfaces/native/mindsdb.py
@@ -70,7 +70,8 @@ class MindsdbNative():
 
         data_analysis = model['data_analysis_v2']
         for column in data_analysis['columns']:
-            if len(data_analysis[column]) == 0 or data_analysis[column].get('empty', {}).get('is_empty', False):
+            analysis = data_analysis.get(column)
+            if isinstance(analysis, dict) and (len(analysis) == 0 or analysis.get('empty', {}).get('is_empty', False)):
                 data_analysis[column]['typing'] = {
                     'data_subtype': DATA_SUBTYPES.INT
                 }


### PR DESCRIPTION
**why**

if predictor trained with ignore_column, then that columns will be in `data_analysis['columns']`, but will be missed in `data_analysis` and data_analysis['columns_to_ignore']. That follow to error on mindsdb start up.

**how**

add check