### PR TITLE
Disable frontend telemetry

### DIFF
--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -24,6 +24,8 @@ from mindsdb.utilities.ps import is_pid_listen_port
 from mindsdb.interfaces.database.database import DatabaseWrapper
 from mindsdb.utilities.functions import args_parse, get_all_models_meta_data
 from mindsdb.utilities.log import initialize_log
+from mindsdb.utilities.telemetry import is_telemetry_file_exists, disable_telemetry
+
 
 def close_api_gracefully(apis):
     try:
@@ -44,9 +46,17 @@ if __name__ == '__main__':
 
     config = Config(os.environ['MINDSDB_CONFIG_PATH'])
 
-    disable_telemetry = os.getenv('CHECK_FOR_UPDATES').lower() in ['0', 'false']
-    if disable_telemetry:
-        print('\n ✓ telemetry is disabled \n')
+    telemetry_disabled = False
+    storage_dir = config['storage_dir']
+    if is_telemetry_file_exists(storage_dir):
+        os.environ['CHECK_FOR_UPDATES'] = '0'
+        telemetry_disabled = True
+    elif os.getenv('CHECK_FOR_UPDATES').lower() in ['0', 'false']:
+        disable_telemetry(storage_dir)
+        telemetry_disabled = True
+
+    if telemetry_disabled:
+        print('\n ✓ telemetry disabled \n')
 
     if args.verbose is True:
         config['log']['level']['console'] = 'DEBUG'

--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -44,6 +44,10 @@ if __name__ == '__main__':
 
     config = Config(os.environ['MINDSDB_CONFIG_PATH'])
 
+    disable_telemetry = os.getenv('CHECK_FOR_UPDATES').lower() in ['0', 'false']
+    if disable_telemetry:
+        print('\n ✓ telemetry is disabled \n')
+
     if args.verbose is True:
         config['log']['level']['console'] = 'DEBUG'
     os.environ['DEFAULT_LOG_LEVEL'] = config['log']['level']['console']

--- a/mindsdb/api/http/namespaces/util.py
+++ b/mindsdb/api/http/namespaces/util.py
@@ -1,12 +1,15 @@
-import os
 from flask import request
-from flask_restx import Resource, abort
+from flask_restx import Resource
 from flask import current_app as ca
 
 from mindsdb.api.http.namespaces.configs.util import ns_conf
-from mindsdb import __about__
+from mindsdb.utilities.telemetry import (
+    enable_telemetry,
+    disable_telemetry,
+    is_telemetry_file_exists,
+    inject_telemetry_to_static
+)
 
-TELEMETRY_FILE = 'telemetry.lock'
 
 @ns_conf.route('/ping')
 class Ping(Resource):
@@ -29,29 +32,18 @@ class ReportUUID(Resource):
 class Telemetry(Resource):
     @ns_conf.doc('get_telemetry_status')
     def get(self):
-        status = "enabled" if is_telemetry_active() else "disabled"
+        storage_dir = ca.config_obj['storage_dir']
+        status = "enabled" if is_telemetry_file_exists(storage_dir) else "disabled"
         return {"status": status}
 
     @ns_conf.doc('set_telemetry')
     def post(self):
         data = request.json
         action = data['action']
+        storage_dir = ca.config_obj['storage_dir']
         if str(action).lower() in ["true", "enable", "on"]:
-            enable_telemetry()
+            enable_telemetry(storage_dir)
         else:
-            disable_telemetry()
-
-
-def enable_telemetry():
-    path = os.path.join(ca.config_obj['storage_dir'], TELEMETRY_FILE)
-    if os.path.exists(path):
-        os.remove(path)
-
-def disable_telemetry():
-    path = os.path.join(ca.config_obj['storage_dir'], TELEMETRY_FILE)
-    with open(path, 'w') as _:
-        pass
-
-def is_telemetry_active():
-    path = os.path.join(ca.config_obj['storage_dir'], TELEMETRY_FILE)
-    return not os.path.exists(path)
+            disable_telemetry(storage_dir)
+        inject_telemetry_to_static(ca.config_obj.paths['static'])
+        return '', 200

--- a/mindsdb/api/http/start.py
+++ b/mindsdb/api/http/start.py
@@ -28,7 +28,7 @@ def start(config, verbose=False):
     init_static_thread = threading.Thread(target=initialize_static, args=(config,))
     init_static_thread.start()
 
-    app, api = initialize_flask(config)
+    app, api = initialize_flask(config, init_static_thread)
     initialize_interfaces(config, app)
 
     static_root = Path(config.paths['static'])

--- a/mindsdb/utilities/telemetry.py
+++ b/mindsdb/utilities/telemetry.py
@@ -1,0 +1,44 @@
+import os
+from pathlib import Path
+
+TELEMETRY_FILE = 'telemetry.lock'
+
+
+def enable_telemetry(storage_dir):
+    os.environ['CHECK_FOR_UPDATES'] = '1'
+    path = os.path.join(storage_dir, TELEMETRY_FILE)
+    if os.path.exists(path):
+        os.remove(path)
+
+
+def disable_telemetry(storage_dir):
+    os.environ['CHECK_FOR_UPDATES'] = '0'
+    path = os.path.join(storage_dir, TELEMETRY_FILE)
+    with open(path, 'w') as _:
+        pass
+
+
+def is_telemetry_file_exists(storage_dir):
+    path = os.path.join(storage_dir, TELEMETRY_FILE)
+    return os.path.exists(path)
+
+
+def inject_telemetry_to_static(static_folder):
+    TEXT = '<script>localStorage.isTestUser = true;</script>'
+    index = Path(static_folder).joinpath('index.html')
+    disable_telemetry = os.getenv('CHECK_FOR_UPDATES').lower() in ['0', 'false']
+    if index.is_file():
+        with open(str(index), 'rt') as f:
+            content = f.read()
+        script_index = content.find('<script>')
+        need_update = True
+        if TEXT not in content and disable_telemetry:
+            content = content[:script_index] + TEXT + content[script_index:]
+        elif not disable_telemetry and TEXT in content:
+            content = content.replace(TEXT, '')
+        else:
+            need_update = False
+
+        if need_update:
+            with open(str(index), 'wt') as f:
+                f.write(content)


### PR DESCRIPTION
**why**

At this moment to disable telemetry need do two things: enter konami code at frontend and set env variable at backend. That can be simplified

**how**

At http api start we can inject to index.html code to disable telemetry, if it disabled for backend. 
Additionally, at backend start will be console output if telemetry is disabled