### PR TITLE
Fix for checking connection to atlas data lake

### DIFF
--- a/mindsdb/integrations/mongodb/mongodb.py
+++ b/mindsdb/integrations/mongodb/mongodb.py
@@ -1,3 +1,6 @@
+import re
+
+import certifi
 from pymongo import MongoClient
 
 from mindsdb.integrations.base import Integration
@@ -19,12 +22,35 @@ class MongoDB(Integration):
     def check_connection(self):
         try:
             integration = self.config['integrations'][self.name]
+            host = integration['host']
+            user = integration['user']
+            password = integration['password']
+
+            kwargs = {}
+
+            if isinstance(user, str) and len(user) > 0:
+                kwargs['username'] = user
+
+            if isinstance(password, str) and len(password) > 0:
+                kwargs['password'] = password
+
+            if re.match(r'\/\?.*tls=true', host.lower()):
+                kwargs['tls'] = True
+
+            if re.match(r'\/\?.*tls=false', host.lower()):
+                kwargs['tls'] = False
+
+            if re.match(r'.*\.mongodb.net', host.lower()) and kwargs.get('tls', None) is None:
+                kwargs['tlsCAFile'] = certifi.where()
+                if kwargs.get('tls', None) is None:
+                    kwargs['tls'] = True
+
             server = MongoClient(
-                integration['host'],
+                host,
                 port=integration.get('port', 27017),
-                username=integration['user'],
-                password=integration['password'],
-                serverSelectionTimeoutMS=5000
+                serverSelectionTimeoutMS=5000,
+                tlsCAFile=certifi.where(),
+                **kwargs
             )
             server.server_info()
             connected = True

--- a/mindsdb/integrations/mongodb/mongodb.py
+++ b/mindsdb/integrations/mongodb/mongodb.py
@@ -49,7 +49,6 @@ class MongoDB(Integration):
                 host,
                 port=integration.get('port', 27017),
                 serverSelectionTimeoutMS=5000,
-                tlsCAFile=certifi.where(),
                 **kwargs
             )
             server.server_info()


### PR DESCRIPTION
**why**

Checking connection to data lake always failed. That, probably, because connection to data lake should be with `tls=true`.

**how**

if `mongo.net` in connection sting, then we set that option. Also, for `mongo.net` set `tlsCAFile=certifi.where()` since Alejo cant connect without it.