### PR TITLE
Allow dot in mongo find

### DIFF
--- a/mindsdb/api/mongo/responders/find.py
+++ b/mindsdb/api/mongo/responders/find.py
@@ -40,9 +40,7 @@ class Responce(Responder):
 
             for key in where_data:
                 if key not in columns:
-                    sub_key = key[:key.find('.')] if '.' in key else key
-                    if sub_key not in columns:
-                        raise Exception(f"Unknown column '{key}'. Only columns from this list can be used in query: {', '.join(columns)}")
+                    columns.append(key)
 
             prediction = mindsdb_env['mindsdb_native'].predict(name=table, when_data=where_data)
 

--- a/mindsdb/api/mongo/responders/find.py
+++ b/mindsdb/api/mongo/responders/find.py
@@ -40,7 +40,9 @@ class Responce(Responder):
 
             for key in where_data:
                 if key not in columns:
-                    raise Exception(f"Unknown column '{key}'. Only columns from this list can be used in query: {', '.join(columns)}")
+                    sub_key = key[:key.find('.')] if '.' in key else key
+                    if sub_key not in columns:
+                        raise Exception(f"Unknown column '{key}'. Only columns from this list can be used in query: {', '.join(columns)}")
 
             prediction = mindsdb_env['mindsdb_native'].predict(name=table, when_data=where_data)
 


### PR DESCRIPTION
**why**

to allow use 'dot' notation in mongo `find`: db.predictor.find({'a.b': 1})

**how**

added additional check for field exists