### PR TITLE
Better mongo fields list

### DIFF
--- a/mindsdb/api/mongo/responders/find.py
+++ b/mindsdb/api/mongo/responders/find.py
@@ -38,9 +38,12 @@ class Responce(Responder):
 
             columns += ['when_data', 'select_data_query', 'external_datasource']
 
-            for key in where_data:
-                if key not in columns:
-                    columns.append(key)
+            where_data_list = where_data if isinstance(where_data, list) else [where_data]
+            for statement in where_data_list:
+                if isinstance(statement, dict):
+                    for key in statement:
+                        if key not in columns:
+                            columns.append(key)
 
             if 'select_data_query' in where_data:
                 integrations = mindsdb_env['config']['integrations'].keys()


### PR DESCRIPTION
**why**

if user execute `.find` with list as argument, then fields will be missed in result

**how**

added keys from each element of `find` argument to result list.