### PR TITLE
Allow listen any http addres

### DIFF
--- a/mindsdb/api/http/initialize.py
+++ b/mindsdb/api/http/initialize.py
@@ -227,7 +227,10 @@ def initialize_flask(config, init_static_thread):
 
     # NOTE rewrite it, that hotfix to see GUI link
     log = logging.getLogger('mindsdb.http')
-    url = f'http://{host}:{port}/'
+    if host in ('', '0.0.0.0'):
+        url = f'http://127.0.0.1:{port}/'
+    else:
+        url = f'http://{host}:{port}/'
     log.error(f' - GUI available at {url}')
 
     pid = os.getpid()

--- a/mindsdb/api/http/start.py
+++ b/mindsdb/api/http/start.py
@@ -64,7 +64,10 @@ def start(verbose=False):
     # waiting static initialization
     init_static_thread.join()
     if server.lower() == 'waitress':
-        serve(app, port=port, host=host)
+        if host in ('', '0.0.0.0'):
+            serve(app, port=port, host='*')
+        else:
+            serve(app, port=port, host=host)
     elif server.lower() == 'flask':
         # that will 'disable access' log in console
         log = logging.getLogger('werkzeug')


### PR DESCRIPTION
**why**

It was no possible listen connections from any address and serv GUI at Windows.

**how**

Added check for host is equal to empty string or `0.0.0.0`. In that case connections from any address will be listen and GUI will be open at `127.0.0.1`.