### PR TITLE
no_studio flag

### DIFF
--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -106,7 +106,10 @@ if __name__ == '__main__':
     for api_name, api_data in apis.items():
         print(f'{api_name} API: starting...')
         try:
-            p = ctx.Process(target=start_functions[api_name], args=(args.verbose,))
+            if api_name == 'http':
+                p = ctx.Process(target=start_functions[api_name], args=(args.verbose,args.no_studio))
+            else:
+                p = ctx.Process(target=start_functions[api_name], args=(args.verbose,))
             p.start()
             api_data['process'] = p
         except Exception as e:

--- a/mindsdb/utilities/functions.py
+++ b/mindsdb/utilities/functions.py
@@ -7,6 +7,7 @@ def args_parse():
     parser.add_argument('--api', type=str, default=None)
     parser.add_argument('--config', type=str, default=None)
     parser.add_argument('--verbose', action='store_true')
+    parser.add_argument('--no_studio', action='store_true')
     parser.add_argument('-v', '--version', action='store_true')
     return parser.parse_args()
 


### PR DESCRIPTION
## Why

Studio  takes a long time to download and run, this is not necessary when launching certain instance

## How

Added a ` --no_studio` flag, when specified Studio will not be downloaded or launched