### PR TITLE
Datasource id for predictors

### DIFF
--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -106,7 +106,10 @@ if __name__ == '__main__':
     for api_name, api_data in apis.items():
         print(f'{api_name} API: starting...')
         try:
-            p = ctx.Process(target=start_functions[api_name], args=(args.verbose,))
+            if api_name == 'http':
+                p = ctx.Process(target=start_functions[api_name], args=(args.verbose,args.no_studio))
+            else:
+                p = ctx.Process(target=start_functions[api_name], args=(args.verbose,))
             p.start()
             api_data['process'] = p
         except Exception as e:

--- a/mindsdb/api/http/namespaces/predictor.py
+++ b/mindsdb/api/http/namespaces/predictor.py
@@ -143,7 +143,7 @@ class Predictor(Resource):
             original_name = name
             name = name + '_retrained'
 
-        ca.mindsdb_native.learn(name, from_data, to_predict, default_store.get_datasource(ds_name).id, kwargs)
+        ca.mindsdb_native.learn(name, from_data, to_predict, ca.default_store.get_datasource(ds_name).id, kwargs)
         for i in range(20):
             try:
                 # Dirty hack, we should use a messaging queue between the predictor process and this bit of the code
@@ -179,7 +179,7 @@ class PredictorLearn(Resource):
         ds_name = data.get('data_source_name') if data.get('data_source_name') is not None else data.get('from_data')
         from_data = ca.default_store.get_datasource_obj(ds_name, raw=True)
 
-        ca.custom_models.learn(name, from_data, to_predict, default_store.get_datasource(ds_name).id, kwargs)
+        ca.custom_models.learn(name, from_data, to_predict, ca.default_store.get_datasource(ds_name).id, kwargs)
 
         return '', 200
 

--- a/mindsdb/api/http/namespaces/predictor.py
+++ b/mindsdb/api/http/namespaces/predictor.py
@@ -143,7 +143,7 @@ class Predictor(Resource):
             original_name = name
             name = name + '_retrained'
 
-        ca.mindsdb_native.learn(name, from_data, to_predict, kwargs)
+        ca.mindsdb_native.learn(name, from_data, to_predict, default_store.get_datasource(ds_name).id, kwargs)
         for i in range(20):
             try:
                 # Dirty hack, we should use a messaging queue between the predictor process and this bit of the code
@@ -179,7 +179,7 @@ class PredictorLearn(Resource):
         ds_name = data.get('data_source_name') if data.get('data_source_name') is not None else data.get('from_data')
         from_data = ca.default_store.get_datasource_obj(ds_name, raw=True)
 
-        ca.custom_models.learn(name, from_data, to_predict, kwargs)
+        ca.custom_models.learn(name, from_data, to_predict, default_store.get_datasource(ds_name).id, kwargs)
 
         return '', 200
 

--- a/mindsdb/api/http/namespaces/predictor.py
+++ b/mindsdb/api/http/namespaces/predictor.py
@@ -143,7 +143,7 @@ class Predictor(Resource):
             original_name = name
             name = name + '_retrained'
 
-        ca.mindsdb_native.learn(name, from_data, to_predict, ca.default_store.get_datasource(ds_name).id, kwargs)
+        ca.mindsdb_native.learn(name, from_data, to_predict, ca.default_store.get_datasource(ds_name)['id'], kwargs)
         for i in range(20):
             try:
                 # Dirty hack, we should use a messaging queue between the predictor process and this bit of the code
@@ -179,7 +179,7 @@ class PredictorLearn(Resource):
         ds_name = data.get('data_source_name') if data.get('data_source_name') is not None else data.get('from_data')
         from_data = ca.default_store.get_datasource_obj(ds_name, raw=True)
 
-        ca.custom_models.learn(name, from_data, to_predict, ca.default_store.get_datasource(ds_name).id, kwargs)
+        ca.custom_models.learn(name, from_data, to_predict, ca.default_store.get_datasource(ds_name)['id'], kwargs)
 
         return '', 200
 

--- a/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
+++ b/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
@@ -386,7 +386,8 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
 
         insert['predict'] = [x.strip() for x in insert['predict'].split(',')]
 
-        ds_columns = [x['name'] for x in default_store.get_datasource(ds_name)['columns']]
+        ds_data = default_store.get_datasource(ds_name)
+        ds_columns = [x['name'] for x in ds_data['columns']]
         for col in insert['predict']:
             if col not in ds_columns:
                 if is_select_data_query:
@@ -394,9 +395,9 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
                 raise Exception(f"Column '{col}' not exists")
 
         if insert['name'] in [x['name'] for x in custom_models.get_models()]:
-            custom_models.learn(insert['name'], ds, insert['predict'], kwargs)
+            custom_models.learn(insert['name'], ds, insert['predict'], ds_data.id, kwargs)
         else:
-            mdb.learn(insert['name'], ds, insert['predict'], kwargs)
+            mdb.learn(insert['name'], ds, insert['predict'], ds_data.id, kwargs)
 
         self.packet(OkPacket).send()
 

--- a/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
+++ b/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
@@ -395,9 +395,9 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
                 raise Exception(f"Column '{col}' not exists")
 
         if insert['name'] in [x['name'] for x in custom_models.get_models()]:
-            custom_models.learn(insert['name'], ds, insert['predict'], ds_data.id, kwargs)
+            custom_models.learn(insert['name'], ds, insert['predict'], ds_data['id'], kwargs)
         else:
-            mdb.learn(insert['name'], ds, insert['predict'], ds_data.id, kwargs)
+            mdb.learn(insert['name'], ds, insert['predict'], ds_data['id'], kwargs)
 
         self.packet(OkPacket).send()
 

--- a/mindsdb/interfaces/custom/custom_models.py
+++ b/mindsdb/interfaces/custom/custom_models.py
@@ -46,7 +46,7 @@ class CustomModels():
 
         return model
 
-    def learn(self, name, from_data, to_predict, kwargs={}):
+    def learn(self, name, from_data, to_predict, datasource_id, kwargs={}):
         model_data = self.get_model_data(name)
         model_data['status'] = 'training'
         self.save_model_data(name, model_data)

--- a/mindsdb/interfaces/native/learn_process.py
+++ b/mindsdb/interfaces/native/learn_process.py
@@ -29,11 +29,12 @@ class LearnProcess(ctx.Process):
         fs_store = FsSotre()
         config = Config()
         company_id = os.environ.get('MINDSDB_COMPANY_ID', None)
-        name, from_data, to_predict, kwargs, _ = self._args
+        name, from_data, to_predict, kwargs, datasource_id = self._args
 
         mdb = mindsdb_native.Predictor(name=name, run_env={'trigger': 'mindsdb'})
 
         predictor_record = Predictor.query.filter_by(company_id=company_id, name=name).first()
+        predictor_record.datasource_id = datasource_id
         predictor_record.to_predict = to_predict
         predictor_record.version = mindsdb_native.__version__
         predictor_record.data = {

--- a/mindsdb/interfaces/native/native.py
+++ b/mindsdb/interfaces/native/native.py
@@ -48,14 +48,14 @@ class NativeInterface():
         predictor = mindsdb_native.Predictor(name=name, run_env={'trigger': 'mindsdb'})
         return predictor
 
-    def learn(self, name, from_data, to_predict, kwargs={}):
+    def learn(self, name, from_data, to_predict, datasource_id, kwargs={}):
         join_learn_process = kwargs.get('join_learn_process', False)
         if 'join_learn_process' in kwargs:
             del kwargs['join_learn_process']
 
         self._setup_for_creation(name)
 
-        p = LearnProcess(name, from_data, to_predict, kwargs, self.config.get_all())
+        p = LearnProcess(name, from_data, to_predict, kwargs, datasource_id)
         p.start()
         if join_learn_process is True:
             p.join()

--- a/mindsdb/utilities/functions.py
+++ b/mindsdb/utilities/functions.py
@@ -7,6 +7,7 @@ def args_parse():
     parser.add_argument('--api', type=str, default=None)
     parser.add_argument('--config', type=str, default=None)
     parser.add_argument('--verbose', action='store_true')
+    parser.add_argument('--no_studio', action='store_true')
     parser.add_argument('-v', '--version', action='store_true')
     return parser.parse_args()
 


### PR DESCRIPTION
## Why

In order to move to an ID-based schema we need to start  linking stuff by id.
In order to move to a model where predictors are linked with datasources we need to, well, link them

## How

Pass datasource id to all calls to `.learn()` in order to provide the predictor with the id of the datasource it's usign.
In the future we can make the predictor get the datasource based on this ID, but not a priority.