### PR TITLE
close learn process gracefully

### DIFF
--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -23,12 +23,13 @@ from mindsdb.utilities.log import log
 
 
 def close_api_gracefully(apis, config):
-    learning_pids_dir = config['paths']['in_learing']
+    # gracefully stop learning process which are currently in progress.
+    learning_pids_dir = config['paths']['in_learning']
     pids = [int(x) for x in os.listdir(learning_pids_dir) if x.isdigit()]
     for pid in pids:
         try:
             os.kill(pid, signal.SIGTERM)
-            os.remove(os.path.join(learning_pids_dir, pid))
+            os.remove(os.path.join(learning_pids_dir, str(pid)))
         except FileNotFoundError:
             pass
     try:
@@ -119,10 +120,10 @@ if __name__ == '__main__':
             api_data['process'] = p
         except Exception as e:
             log.error(f'Failed to start {api_name} API with exception {e}\n{traceback.format_exc()}')
-            close_api_gracefully(apis)
+            close_api_gracefully(apis, config)
             raise e
 
-    atexit.register(close_api_gracefully, apis=apis)
+    atexit.register(close_api_gracefully, apis=apis, config=config)
 
     async def wait_api_start(api_name, pid, port):
         timeout = 60

--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -5,7 +5,7 @@ import os
 import time
 import asyncio
 import datetime
-import platform
+import signal
 
 import torch.multiprocessing as mp
 
@@ -22,7 +22,15 @@ from mindsdb.utilities.functions import args_parse, get_all_models_meta_data
 from mindsdb.utilities.log import log
 
 
-def close_api_gracefully(apis):
+def close_api_gracefully(apis, config):
+    learning_pids_dir = config['paths']['in_learing']
+    pids = [int(x) for x in os.listdir(learning_pids_dir) if x.isdigit()]
+    for pid in pids:
+        try:
+            os.kill(pid, signal.SIGTERM)
+            os.remove(os.path.join(learning_pids_dir, pid))
+        except FileNotFoundError:
+            pass
     try:
         for api in apis.values():
             process = api['process']

--- a/mindsdb/interfaces/native/learn_process.py
+++ b/mindsdb/interfaces/native/learn_process.py
@@ -26,8 +26,9 @@ class LearnProcess(ctx.Process):
         '''
         import mindsdb_native
 
-        fs_store = FsSotre()
         config = Config()
+        self._store_your_pid(config['paths']['in_learning'])
+        fs_store = FsSotre()
         company_id = os.environ.get('MINDSDB_COMPANY_ID', None)
         name, from_data, to_predict, kwargs, datasource_id = self._args
 
@@ -64,3 +65,16 @@ class LearnProcess(ctx.Process):
         session.commit()
 
         DatabaseWrapper().register_predictors([model_data])
+        self._remove_your_pid(config['paths']['in_learning'])
+
+    @staticmethod
+    def _store_your_pid(store_path):
+        with open(os.path.join(store_path, str(os.P_PID)), "w") as _:
+            pass
+
+    @staticmethod
+    def _remove_your_pid(store_path):
+        try:
+            os.remove(os.path.join(store_path, str(os.P_PID)))
+        except FileNotFoundError:
+            pass

--- a/mindsdb/interfaces/native/learn_process.py
+++ b/mindsdb/interfaces/native/learn_process.py
@@ -69,12 +69,14 @@ class LearnProcess(ctx.Process):
 
     @staticmethod
     def _store_your_pid(store_path):
-        with open(os.path.join(store_path, str(os.P_PID)), "w") as _:
+        """Store pid of lerning process on a filesystem as emtpy file."""
+        with open(os.path.join(store_path, str(os.getpid())), "w") as _:
             pass
 
     @staticmethod
     def _remove_your_pid(store_path):
+        """Remove pid file from filesystem."""
         try:
-            os.remove(os.path.join(store_path, str(os.P_PID)))
+            os.remove(os.path.join(store_path, str(os.getpid())))
         except FileNotFoundError:
             pass

--- a/mindsdb/interfaces/native/learn_process.py
+++ b/mindsdb/interfaces/native/learn_process.py
@@ -27,7 +27,6 @@ class LearnProcess(ctx.Process):
         import mindsdb_native
 
         config = Config()
-        self._store_your_pid(config['paths']['in_learning'])
         fs_store = FsSotre()
         company_id = os.environ.get('MINDSDB_COMPANY_ID', None)
         name, from_data, to_predict, kwargs, datasource_id = self._args
@@ -65,18 +64,3 @@ class LearnProcess(ctx.Process):
         session.commit()
 
         DatabaseWrapper().register_predictors([model_data])
-        self._remove_your_pid(config['paths']['in_learning'])
-
-    @staticmethod
-    def _store_your_pid(store_path):
-        """Store pid of lerning process on a filesystem as emtpy file."""
-        with open(os.path.join(store_path, str(os.getpid())), "w") as _:
-            pass
-
-    @staticmethod
-    def _remove_your_pid(store_path):
-        """Remove pid file from filesystem."""
-        try:
-            os.remove(os.path.join(store_path, str(os.getpid())))
-        except FileNotFoundError:
-            pass

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -98,7 +98,6 @@ class Config():
             self._db_config['paths']['tmp'] = os.path.join(self._db_config['paths']['root'], 'tmp')
             self._db_config['paths']['log'] = os.path.join(self._db_config['paths']['root'], 'log')
             self._db_config['paths']['storage_dir'] = self._db_config['paths']['root']
-            self._db_config['paths']['in_learning'] = os.path.join(self._db_config['paths']['root'], 'in_learning')
             self._db_config['storage_dir'] = self._db_config['paths']['root']
 
             for path in self._db_config['paths']:

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -98,6 +98,7 @@ class Config():
             self._db_config['paths']['tmp'] = os.path.join(self._db_config['paths']['root'], 'tmp')
             self._db_config['paths']['log'] = os.path.join(self._db_config['paths']['root'], 'log')
             self._db_config['paths']['storage_dir'] = self._db_config['paths']['root']
+            self._db_config['paths']['in_learning'] = os.path.join(self._db_config['paths']['root'], 'in_learning')
             self._db_config['storage_dir'] = self._db_config['paths']['root']
 
             for path in self._db_config['paths']:

--- a/mindsdb/utilities/ps.py
+++ b/mindsdb/utilities/ps.py
@@ -4,6 +4,11 @@ from collections import namedtuple
 import psutil
 
 
+def get_child_pids(pid):
+    p = psutil.Process(pid=pid)
+    return p.children(recursive=True)
+
+
 def net_connections():
     """Cross-platform psutil.net_connections like interface"""
     if sys.platform.lower().startswith('linux'):


### PR DESCRIPTION
Fixes #1058 

  ## What:
 - ```close_api_gracefully only closes the API, but not any ongoing learn processes, which are left orphaned and consuming loads of memory.```
  ## How:
 - Each learning process when start working stories its own pid as empty file in `storage_dir/in_learning` directory and will delete it at the end if no interruption happens
 - `close_api_gracefully` read list of files in `storage_dir/in_learning` and sends SIGTERM to each of this process.

mindsdb