### PR TITLE
'check connection' not worked for existing connection

### DIFF
--- a/mindsdb/api/http/namespaces/config.py
+++ b/mindsdb/api/http/namespaces/config.py
@@ -12,6 +12,7 @@ from mindsdb.utilities.log import log
 from mindsdb.api.http.namespaces.configs.config import ns_conf
 from mindsdb.utilities.functions import get_all_models_meta_data
 from mindsdb.utilities.log import get_logs
+from mindsdb.integrations import CHECKERS
 
 def get_integration(name):
     integrations = ca.config_obj.get('integrations', {})
@@ -77,38 +78,32 @@ class Integration(Resource):
         is_test = params.get('test', False)
         if is_test:
             del params['test']
+            db_type = params.get('type')
+            checker_class = CHECKERS.get(db_type, None)
+            if checker_class is None:
+                abort(400, f"Unknown integration type: {db_type}")
+            checker = checker_class(**params)
+            return {'success': checker.check_connection()}, 200
 
         integration = get_integration(name)
-        if integration is not None and is_test:
-            add_name = name + '__TEST_INTEGRATION'
-            for k in integration:
-                if k not in params and k != 'test':
-                    params[k] = integration[k]
-        elif integration is not None:
+        if integration is not None:
             abort(400, f"Integration with name '{name}' already exists")
-        else:
-            add_name = name
 
         try:
             if 'enabled' in params:
                 params['publish'] = params['enabled']
                 del params['enabled']
-            ca.config_obj.add_db_integration(add_name, params)
+            ca.config_obj.add_db_integration(name, params)
 
             mdb = ca.mindsdb_native
             cst = ca.custom_models
             model_data_arr = get_all_models_meta_data(mdb, cst)
-            ca.dbw.setup_integration(add_name)
+            ca.dbw.setup_integration(name)
             if is_test is False:
                 ca.dbw.register_predictors(model_data_arr)
         except Exception as e:
             log.error(str(e))
             abort(500, f'Error during config update: {str(e)}')
-
-        if is_test:
-            cons = ca.dbw.check_connections()
-            ca.config_obj.remove_db_integration(add_name)
-            return {'success': cons[add_name]}, 200
 
         return '', 200
 

--- a/mindsdb/integrations/__init__.py
+++ b/mindsdb/integrations/__init__.py
@@ -1,1 +1,15 @@
+from .clickhouse.clickhouse import ClickhouseConnectionChecker
+from .mariadb.mariadb import MariadbConnectionChecker
+from .mongodb.mongodb import MongoConnectionChecker
+from .mssql.mssql import MSSQLConnectionChecker
+from .mysql.mysql import MySQLConnectionChecker
+from .postgres.postgres import PostgreSQLConnectionChecker
 
+CHECKERS = {
+        "clickhouse": ClickhouseConnectionChecker,
+        "mariadb": MariadbConnectionChecker,
+        "mongodb": MongoConnectionChecker,
+        "mssql": MSSQLConnectionChecker,
+        "mysql": MySQLConnectionChecker,
+        "postgres": PostgreSQLConnectionChecker
+        }

--- a/mindsdb/integrations/base/integration.py
+++ b/mindsdb/integrations/base/integration.py
@@ -22,7 +22,3 @@ class Integration(ABC):
     @abstractmethod
     def unregister_predictor(self, name):
         pass
-
-    @abstractmethod
-    def check_connection(self):
-        pass

--- a/mindsdb/integrations/clickhouse/clickhouse.py
+++ b/mindsdb/integrations/clickhouse/clickhouse.py
@@ -132,3 +132,21 @@ class Clickhouse(Integration):
         except Exception:
             connected = False
         return connected
+
+
+class ClickhouseConnectionChecker:
+    def __init__(self, **kwargs):
+        self.host = kwargs.get("host")
+        self.port= kwargs.get("port")
+        self.user = kwargs.get("user")
+        self.password = kwargs.get("password")
+
+    def check_connection(self):
+        try:
+            res = requests.post(f"http://{self.host}:{self.port}",
+                                data="select 1;",
+                                params={'user': self.user, 'password': self.password})
+            connected = res.status_code == 200
+        except Exception:
+            connected = False
+        return connected

--- a/mindsdb/integrations/mariadb/mariadb.py
+++ b/mindsdb/integrations/mariadb/mariadb.py
@@ -143,3 +143,25 @@ class Mariadb(Integration):
         except Exception:
             connected = False
         return connected
+
+
+class MariadbConnectionChecker:
+    def __init__(self, **kwargs):
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+        self.user = kwargs.get('user')
+        self.password = kwargs.get('password')
+
+    def check_connection(self):
+        try:
+            con = mysql.connector.connect(
+                host=self.host,
+                port=self.port,
+                user=self.user,
+                password=self.password
+            )
+            connected = con.is_connected()
+            con.close()
+        except Exception:
+            connected = False
+        return connected

--- a/mindsdb/integrations/mariadb/mariadb.py
+++ b/mindsdb/integrations/mariadb/mariadb.py
@@ -4,7 +4,37 @@ from mindsdb_native.libs.constants.mindsdb import DATA_SUBTYPES
 from mindsdb.integrations.base import Integration
 
 
-class Mariadb(Integration):
+class MariadbConnectionChecker:
+    def __init__(self, **kwargs):
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+        self.user = kwargs.get('user')
+        self.password = kwargs.get('password')
+
+    def check_connection(self):
+        try:
+            con = mysql.connector.connect(
+                host=self.host,
+                port=self.port,
+                user=self.user,
+                password=self.password
+            )
+            connected = con.is_connected()
+            con.close()
+        except Exception:
+            connected = False
+        return connected
+
+
+class Mariadb(Integration, MariadbConnectionChecker):
+    def __init__(self, config, name):
+        super().__init__(config, name)
+        db_info = self.config['integrations'][self.name]
+        self.user = db_info.get('user', 'default')
+        self.password = db_info.get('password', None)
+        self.host = db_info.get('host')
+        self.port = db_info.get('port')
+
     def _to_mariadb_table(self, stats, predicted_cols, columns):
         subtype_map = {
             DATA_SUBTYPES.INT: 'int',
@@ -129,39 +159,3 @@ class Mariadb(Integration):
             drop table if exists {self.mindsdb_database}.{self._escape_table_name(name)};
         """
         self._query(q)
-
-    def check_connection(self):
-        try:
-            con = mysql.connector.connect(
-                host=self.config['integrations'][self.name]['host'],
-                port=self.config['integrations'][self.name]['port'],
-                user=self.config['integrations'][self.name]['user'],
-                password=self.config['integrations'][self.name]['password']
-            )
-            connected = con.is_connected()
-            con.close()
-        except Exception:
-            connected = False
-        return connected
-
-
-class MariadbConnectionChecker:
-    def __init__(self, **kwargs):
-        self.host = kwargs.get('host')
-        self.port = kwargs.get('port')
-        self.user = kwargs.get('user')
-        self.password = kwargs.get('password')
-
-    def check_connection(self):
-        try:
-            con = mysql.connector.connect(
-                host=self.host,
-                port=self.port,
-                user=self.user,
-                password=self.password
-            )
-            connected = con.is_connected()
-            con.close()
-        except Exception:
-            connected = False
-        return connected

--- a/mindsdb/integrations/mongodb/mongodb.py
+++ b/mindsdb/integrations/mongodb/mongodb.py
@@ -6,58 +6,6 @@ from pymongo import MongoClient
 from mindsdb.integrations.base import Integration
 
 
-class MongoDB(Integration):
-    def _query(self, query):
-        return None
-
-    def setup(self):
-        pass
-
-    def register_predictors(self, model_data_arr):
-        pass
-
-    def unregister_predictor(self, name):
-        pass
-
-    def check_connection(self):
-        try:
-            integration = self.config['integrations'][self.name]
-            host = integration['host']
-            user = integration['user']
-            password = integration['password']
-
-            kwargs = {}
-
-            if isinstance(user, str) and len(user) > 0:
-                kwargs['username'] = user
-
-            if isinstance(password, str) and len(password) > 0:
-                kwargs['password'] = password
-
-            if re.match(r'\/\?.*tls=true', host.lower()):
-                kwargs['tls'] = True
-
-            if re.match(r'\/\?.*tls=false', host.lower()):
-                kwargs['tls'] = False
-
-            if re.match(r'.*\.mongodb.net', host.lower()) and kwargs.get('tls', None) is None:
-                kwargs['tlsCAFile'] = certifi.where()
-                if kwargs.get('tls', None) is None:
-                    kwargs['tls'] = True
-
-            server = MongoClient(
-                host,
-                port=integration.get('port', 27017),
-                serverSelectionTimeoutMS=5000,
-                **kwargs
-            )
-            server.server_info()
-            connected = True
-        except Exception:
-            connected = False
-        return connected
-
-
 class MongoConnectionChecker:
     def __init__(self, **kwargs):
         self.host = kwargs.get("host")
@@ -99,3 +47,25 @@ class MongoConnectionChecker:
         except Exception:
             connected = False
         return connected
+
+
+class MongoDB(Integration, MongoConnectionChecker):
+    def __init__(self, config, name):
+        super().__init__(config, name)
+        db_info = self.config['integrations'][self.name]
+        self.user = db_info.get('user', 'default')
+        self.password = db_info.get('password', None)
+        self.host = db_info.get('host')
+        self.port = db_info.get('port', 27017)
+
+    def _query(self, query):
+        return None
+
+    def setup(self):
+        pass
+
+    def register_predictors(self, model_data_arr):
+        pass
+
+    def unregister_predictor(self, name):
+        pass

--- a/mindsdb/integrations/mongodb/mongodb.py
+++ b/mindsdb/integrations/mongodb/mongodb.py
@@ -56,3 +56,46 @@ class MongoDB(Integration):
         except Exception:
             connected = False
         return connected
+
+
+class MongoConnectionChecker:
+    def __init__(self, **kwargs):
+        self.host = kwargs.get("host")
+        self.port = kwargs.get("port", 27017)
+        self.user = kwargs.get("username")
+        self.password = kwargs.get("password")
+
+    def _handle_params(self):
+        kwargs = {}
+        if isinstance(self.user, str) and len(self.user) > 0:
+            kwargs['username'] = self.user
+
+        if isinstance(self.password, str) and len(self.password) > 0:
+            kwargs['password'] = self.password
+
+        if re.match(r'\/\?.*tls=true', self.host.lower()):
+            kwargs['tls'] = True
+
+        if re.match(r'\/\?.*tls=false', self.host.lower()):
+            kwargs['tls'] = False
+
+        if re.match(r'.*\.mongodb.net', self.host.lower()) and kwargs.get('tls', None) is None:
+            kwargs['tlsCAFile'] = certifi.where()
+            if kwargs.get('tls', None) is None:
+                kwargs['tls'] = True
+
+        return kwargs
+
+    def check_connection(self):
+        try:
+            advanced_conn_params = self._handle_params()
+            server = MongoClient(self.host,
+                                 port=self.port,
+                                 serverSelectionTimeoutMS=5000,
+                                 **advanced_conn_params
+                                 )
+            server.server_info()
+            connected = True
+        except Exception:
+            connected = False
+        return connected

--- a/mindsdb/integrations/mssql/mssql.py
+++ b/mindsdb/integrations/mssql/mssql.py
@@ -73,3 +73,6 @@ class MSSQL(Integration, MSSQLConnectionChecker):
 
     def register_predictors(self, model_data_arr):
         pass
+
+    def unregister_predictor(self, name):
+        pass

--- a/mindsdb/integrations/mssql/mssql.py
+++ b/mindsdb/integrations/mssql/mssql.py
@@ -61,3 +61,24 @@ class MSSQL(Integration):
         except Exception:
             connected = False
         return connected
+
+
+class MSSQLConnectionChecker:
+    def __init__(self, **kwargs):
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+        self.user = kwargs.get('user')
+        self.password = kwargs.get('password')
+    
+    def check_connection(self):
+        try:
+            conn = pytds.connect(user=self.user, password=self.password,
+                                 dsn=self.host, port=self.port,
+                                 as_dict=True, autocommit=True)
+            conn.close()
+            connected = True
+        except Exception:
+            connected = False
+
+        return connected
+

--- a/mindsdb/integrations/mysql/mysql.py
+++ b/mindsdb/integrations/mysql/mysql.py
@@ -147,3 +147,25 @@ class MySQL(Integration):
         except Exception:
             connected = False
         return connected
+
+
+class MySQLConnectionChecker:
+    def __init__(self, **kwargs):
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+        self.user = kwargs.get('user')
+        self.password = kwargs.get('password')
+
+    def check_connection(self):
+        try:
+            con = mysql.connector.connect(
+                host=self.host,
+                port=self.port,
+                user=self.user,
+                password=self.password
+            )
+            connected = con.is_connected()
+            con.close()
+        except Exception:
+            connected = False
+        return connected

--- a/mindsdb/integrations/mysql/mysql.py
+++ b/mindsdb/integrations/mysql/mysql.py
@@ -1,10 +1,43 @@
+from contextlib import closing
 import mysql.connector
 
 from mindsdb_native.libs.constants.mindsdb import DATA_SUBTYPES
 from mindsdb.integrations.base import Integration
 
 
-class MySQL(Integration):
+class MySQLConnectionChecker:
+    def __init__(self, **kwargs):
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+        self.user = kwargs.get('user')
+        self.password = kwargs.get('password')
+
+    def _get_connnection(self):
+        return mysql.connector.connect(
+                host=self.host,
+                port=self.port,
+                user=self.user,
+                password=self.password)
+
+    def check_connection(self):
+        try:
+            con = self._get_connnection()
+            with closing(con) as con:
+                connected = con.is_connected()
+        except Exception:
+            connected = False
+        return connected
+
+
+class MySQL(Integration, MySQLConnectionChecker):
+    def __init__(self, config, name):
+        super().__init__(config, name)
+        db_info = self.config['integrations'][self.name]
+        self.user = db_info.get('user')
+        self.password = db_info.get('password')
+        self.host = db_info.get('host')
+        self.port = db_info.get('port')
+
     def _to_mysql_table(self, stats, predicted_cols, columns):
         subtype_map = {
             DATA_SUBTYPES.INT: 'int',
@@ -40,22 +73,16 @@ class MySQL(Integration):
         return '`' + name.replace('`', '``') + '`'
 
     def _query(self, query):
-        con = mysql.connector.connect(
-            host=self.config['integrations'][self.name]['host'],
-            port=self.config['integrations'][self.name]['port'],
-            user=self.config['integrations'][self.name]['user'],
-            password=self.config['integrations'][self.name]['password']
-        )
-
-        cur = con.cursor(dictionary=True, buffered=True)
-        cur.execute(query)
-        res = True
-        try:
-            res = cur.fetchall()
-        except Exception:
-            pass
-        con.commit()
-        con.close()
+        con = self._get_connnection()
+        with closing(con) as con:
+            cur = con.cursor(dictionary=True, buffered=True)
+            cur.execute(query)
+            res = True
+            try:
+                res = cur.fetchall()
+            except Exception:
+                pass
+            con.commit()
 
         return res
 
@@ -133,39 +160,3 @@ class MySQL(Integration):
             drop table if exists {self.mindsdb_database}.{self._escape_table_name(name)};
         """
         self._query(q)
-
-    def check_connection(self):
-        try:
-            con = mysql.connector.connect(
-                host=self.config['integrations'][self.name]['host'],
-                port=self.config['integrations'][self.name]['port'],
-                user=self.config['integrations'][self.name]['user'],
-                password=self.config['integrations'][self.name]['password']
-            )
-            connected = con.is_connected()
-            con.close()
-        except Exception:
-            connected = False
-        return connected
-
-
-class MySQLConnectionChecker:
-    def __init__(self, **kwargs):
-        self.host = kwargs.get('host')
-        self.port = kwargs.get('port')
-        self.user = kwargs.get('user')
-        self.password = kwargs.get('password')
-
-    def check_connection(self):
-        try:
-            con = mysql.connector.connect(
-                host=self.host,
-                port=self.port,
-                user=self.user,
-                password=self.password
-            )
-            connected = con.is_connected()
-            con.close()
-        except Exception:
-            connected = False
-        return connected

--- a/mindsdb/integrations/postgres/postgres.py
+++ b/mindsdb/integrations/postgres/postgres.py
@@ -169,3 +169,28 @@ class PostgreSQL(Integration):
         except Exception:
             connected = False
         return connected
+
+
+class PostgreSQLConnectionChecker:
+    def __init__(self, **kwargs):
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+        self.user = kwargs.get('user')
+        self.password = kwargs.get('password')
+        self.database = kwargs.get('database', 'postgres')
+
+    def check_connection(self):
+        try:
+            con = pg8000.connect(
+                database=self.database,
+                user=self.user,
+                password=self.password,
+                host=self.host,
+                port=self.port
+            )
+            con.run('select 1;')
+            con.close()
+            connected = True
+        except Exception:
+            connected = False
+        return connected


### PR DESCRIPTION
Fixes #1082

**What:**
 - right now it is possible to check connection for `real` integrations that is why check connection (put /integration request with {test: true}) fails

**How**:
 - Provide connection checker for each integration type as a mixin to decouple strong conjunction between Integration abstraction and particular call to different database types