### PR TITLE
Pymongo requriements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cryptography >= 2.9.2, < 3.4
 pg8000 >= 1.15.3
 python-tds >= 1.10.0
 waitress >= 1.4.4
-pymongo[tsl, srv] >= 3.10.1
+pymongo[tls, srv] >= 3.10.1
 setuptools
 psutil
 sqlalchemy >= 1.3.0


### PR DESCRIPTION
Fixes #1120 

Fix typo for installing TLS optional requirement with Pymongo
