### PR TITLE
Fix for non latin characters in mysql/mariadb

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/data_types/mysql_datum.py
+++ b/mindsdb/api/mysql/mysql_proxy/data_types/mysql_datum.py
@@ -138,7 +138,10 @@ class Datum():
                 return self.lenencInt(self.value)
 
             if self.var_type in ['byte', 'string']:
-                val_len = len(self.value)
+                if isinstance(self.value, str):
+                    val_len = len(self.value.encode('utf8'))
+                else:
+                    val_len = len(self.value)
                 byte_count = int(math.ceil(math.log((val_len + 1), 2) / 8))
                 if val_len < NULL_VALUE[0]:
                     return self.lenencInt(val_len) + bytes(self.value, 'utf-8')

--- a/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
+++ b/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
@@ -13,6 +13,7 @@ from mindsdb.utilities.functions import cast_row_types
 from mindsdb_native.libs.helpers.general_helpers import NumpyJSONEncoder
 from mindsdb.utilities.config import Config
 
+
 class MindsDBDataNode(DataNode):
     type = 'mindsdb'
 
@@ -233,7 +234,7 @@ class MindsDBDataNode(DataNode):
                 explanation = explains[i]
                 for key in predicted_columns:
                     row[key + '_confidence'] = explanation[key]['confidence']
-                    row[key + '_explain'] = json.dumps(explanation[key], cls=NumpyJSONEncoder)
+                    row[key + '_explain'] = json.dumps(explanation[key], cls=NumpyJSONEncoder, ensure_ascii=False)
                 for key in min_max_keys:
                     row[key + '_min'] = min(explanation[key]['confidence_interval'])
                     row[key + '_max'] = max(explanation[key]['confidence_interval'])

--- a/mindsdb/integrations/mariadb/mariadb.py
+++ b/mindsdb/integrations/mariadb/mariadb.py
@@ -118,7 +118,7 @@ class Mariadb(Integration, MariadbConnectionChecker):
                 select_data_query VARCHAR(500),
                 external_datasource VARCHAR(500),
                 training_options VARCHAR(500)
-            ) ENGINE=CONNECT TABLE_TYPE=MYSQL CONNECTION='{connect}';
+            ) ENGINE=CONNECT CHARSET=utf8 TABLE_TYPE=MYSQL CONNECTION='{connect}';
         """
         self._query(q)
 
@@ -127,7 +127,7 @@ class Mariadb(Integration, MariadbConnectionChecker):
         q = f"""
             CREATE TABLE IF NOT EXISTS {self.mindsdb_database}.commands (
                 command VARCHAR(500)
-            ) ENGINE=CONNECT TABLE_TYPE=MYSQL CONNECTION='{connect}';
+            ) ENGINE=CONNECT CHARSET=utf8 TABLE_TYPE=MYSQL CONNECTION='{connect}';
         """
         self._query(q)
 
@@ -150,7 +150,7 @@ class Mariadb(Integration, MariadbConnectionChecker):
             q = f"""
                     CREATE TABLE {self.mindsdb_database}.{self._escape_table_name(name)}
                     ({columns_sql}
-                    ) ENGINE=CONNECT TABLE_TYPE=MYSQL CONNECTION='{connect}';
+                    ) ENGINE=CONNECT CHARSET=utf8 TABLE_TYPE=MYSQL CONNECTION='{connect}';
             """
             self._query(q)
 

--- a/mindsdb/integrations/mysql/mysql.py
+++ b/mindsdb/integrations/mysql/mysql.py
@@ -115,7 +115,7 @@ class MySQL(Integration, MySQLConnectionChecker):
                 external_datasource VARCHAR(500),
                 training_options VARCHAR(500),
                 key name_key (name)
-            ) ENGINE=FEDERATED CONNECTION='{connect}';
+            ) ENGINE=FEDERATED CHARSET=utf8 CONNECTION='{connect}';
         """
         self._query(q)
 
@@ -125,7 +125,7 @@ class MySQL(Integration, MySQLConnectionChecker):
             CREATE TABLE IF NOT EXISTS {self.mindsdb_database}.commands (
                 command VARCHAR(500),
                 key command_key (command)
-            ) ENGINE=FEDERATED CONNECTION='{connect}';
+            ) ENGINE=FEDERATED CHARSET=utf8 CONNECTION='{connect}';
         """
         self._query(q)
 
@@ -151,7 +151,7 @@ class MySQL(Integration, MySQLConnectionChecker):
                     index when_data_index (when_data),
                     index select_data_query_index (select_data_query),
                     index external_datasource_index (external_datasource)
-                ) ENGINE=FEDERATED CONNECTION='{connect}';
+                ) ENGINE=FEDERATED CHARSET=utf8 CONNECTION='{connect}';
             """
             self._query(q)
 


### PR DESCRIPTION
**why**

fix for #1127

**how**

1. issue could have been caused if datasource table had not same charset as default in database.
2. in our implementation of mysql protocol we calc length of text fields as count of characters, which was wrong, it should be length of bytes represented of string.