### PR TITLE
error in creating mongo datasource

### DIFF
--- a/mindsdb/interfaces/datastore/datastore.py
+++ b/mindsdb/interfaces/datastore/datastore.py
@@ -219,6 +219,9 @@ class DataStore():
                             'port': integration['port']
                         }
                     }
+
+                    ds = dsClass(**creation_info['kwargs'])
+
                 elif integration['type'] == 'athena':
                     creation_info = {
                         'class': dsClass.__name__,


### PR DESCRIPTION
Fixes 
`pymongo.errors.WriteError: local variable 'ds' referenced before assignment, full error: {'index': 0, 'code': 0, 'errmsg': "local variable 'ds' referenced before assignment"}` during creating predictor in mindsdb cloud via mongo api
