### PR TITLE
provide correct datasource id while train model via mongo API

### DIFF
--- a/mindsdb/interfaces/native/native.py
+++ b/mindsdb/interfaces/native/native.py
@@ -107,8 +107,9 @@ class NativeInterface():
                 self.fs_store.get(name, f'predictor_{self.company_id}_{predictor_record.id}', self.config['paths']['predictors'])
                 new_model_data = mindsdb_native.F.get_model_data(name)
             except Exception:
-                pass
-            if predictor_record.data is None or len(new_model_data) > len(predictor_record.data):
+                new_model_data = None
+
+            if predictor_record.data is None or (new_model_data is not None and len(new_model_data) > len(predictor_record.data)):
                 predictor_record.data = new_model_data
                 model = new_model_data
                 session.commit()


### PR DESCRIPTION
Fixes:
```
    raise exception
  File "/usr/local/lib/python3.8/dist-packages/sqlalchemy/engine/base.py", line 1276, in _execute_context
    self.dialect.do_execute(
  File "/usr/local/lib/python3.8/dist-packages/sqlalchemy/engine/default.py", line 608, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.ProgrammingError: (psycopg2.ProgrammingError) can't adapt type 'dict'
[SQL: UPDATE predictor SET updated_at=%(updated_at)s, data=%(data)s, to_predict=%(to_predict)s, version=%(version)s, datasource_id=%(datasource_id)s WHERE predictor.id = %(predictor_id)s]
[parameters: {'updated_at': datetime.datetime(2021, 3, 3, 13, 1, 9, 991338), 'data': '{"name": "mongo_pred1", "status": "training"}', 'to_predict': 'passenger_count', 'version': '2.34.0', 'datasource_id': {}, 'predictor_id': 1}]
(Background on this error at: http://sqlalche.me/e/13/f405)
```
Reason mongo::insert.py::_result provides wrong datasource_id (dict instead of int)
  -

mindsdb