### PR TITLE
Delete broken datasources + loggin errors

### DIFF
--- a/mindsdb/api/http/namespaces/datasource.py
+++ b/mindsdb/api/http/namespaces/datasource.py
@@ -138,9 +138,9 @@ class Datasource(Resource):
             if ca.default_store.config['integrations'][source_type]['type'] == 'mongodb':
                 data['find'] = data['query']
 
-            ca.default_store.save_datasource(name, source_type, data)
+            ds_obj, ds_name = ca.default_store.save_datasource(name, source_type, data)
             os.rmdir(temp_dir_path)
-            return ca.default_store.get_datasource(name)
+            return ca.default_store.get_datasource(ds_name)
 
         ds_name = data['name'] if 'name' in data else name
         source = data['source'] if 'source' in data else name
@@ -151,7 +151,7 @@ class Datasource(Resource):
         else:
             file_path = None
 
-        ca.default_store.save_datasource(ds_name, source_type, source, file_path)
+        ds_obj, ds_name = ca.default_store.save_datasource(ds_name, source_type, source, file_path)
         os.rmdir(temp_dir_path)
 
         return ca.default_store.get_datasource(ds_name)

--- a/mindsdb/api/http/start.py
+++ b/mindsdb/api/http/start.py
@@ -14,7 +14,7 @@ from mindsdb.api.http.namespaces.util import ns_conf as utils_ns
 from mindsdb.api.http.namespaces.config import ns_conf as conf_ns
 from mindsdb.api.http.initialize import initialize_flask, initialize_interfaces, initialize_static
 from mindsdb.utilities.config import Config
-from mindsdb.utilities.log import initialize_log
+from mindsdb.utilities.log import initialize_log, get_log
 from mindsdb.interfaces.storage.db import session
 
 
@@ -26,7 +26,7 @@ def start(verbose, no_studio):
     initialize_log(config, 'http', wrap_print=True)
 
     # start static initialization in a separate thread
-    init_static_thread=None
+    init_static_thread = None
     if not no_studio:
         init_static_thread = threading.Thread(target=initialize_static, args=(config,))
         init_static_thread.start()
@@ -53,6 +53,7 @@ def start(verbose, no_studio):
 
     @api.errorhandler(Exception)
     def handle_exception(e):
+        get_log('http').error(f'http exception: {e}')
         # pass through HTTP errors
         if isinstance(e, HTTPException):
             return {'message': str(e)}, e.code, e.get_response().headers

--- a/mindsdb/interfaces/datastore/datastore.py
+++ b/mindsdb/interfaces/datastore/datastore.py
@@ -107,12 +107,8 @@ class DataStore():
             raise Exception('`file_path` argument required when source_type == "file"')
 
         datasource_record = session.query(Datasource).filter_by(company_id=self.company_id, name=name).first()
-        original_name = name
-        i = 1
         while datasource_record is not None:
-            name = f'{original_name}_{i}'
-            datasource_record = session.query(Datasource).filter_by(company_id=self.company_id, name=name).first()
-            i += 1
+            raise Exception(f'Datasource with name {name} already exists')
 
         try:
             datasource_record = Datasource(


### PR DESCRIPTION
**why**

1. to add more errors logging on ds creation fails
2. i think it will be good to remove DS if it is broken, instead ignore it
3. there was possible get 'broken' ds if something happen in `def save_datasource` (even with `sesson.delete(ds_record)` in exception handler, because by default autocommit is false).

**how**