### PR TITLE
call 'register_predictor' only for creating integration

### DIFF
--- a/mindsdb/api/http/namespaces/config.py
+++ b/mindsdb/api/http/namespaces/config.py
@@ -96,12 +96,13 @@ class Integration(Resource):
                 del params['enabled']
             ca.config_obj.add_db_integration(name, params)
 
-            mdb = ca.mindsdb_native
-            cst = ca.custom_models
-            model_data_arr = get_all_models_meta_data(mdb, cst)
+            model_data_arr = get_all_models_meta_data(
+                ca.mindsdb_native,
+                ca.custom_models
+            )
             ca.dbw.setup_integration(name)
             if is_test is False:
-                ca.dbw.register_predictors(model_data_arr)
+                ca.dbw.register_predictors(model_data_arr, name)
         except Exception as e:
             log.error(str(e))
             abort(500, f'Error during config update: {str(e)}')

--- a/mindsdb/api/mongo/classes/responder.py
+++ b/mindsdb/api/mongo/classes/responder.py
@@ -1,8 +1,8 @@
 class Responder():
     def __init__(self, when=None, result=None):
-        if when:
+        if when is not None:
             self.when = when
-        if result:
+        if result is not None:
             self.result = result
         if not hasattr(self, 'when') or (not isinstance(self.when, dict) and not callable(self.when)):
             raise ValueError("Responder attr 'when' must be dict or function.")

--- a/mindsdb/interfaces/database/database.py
+++ b/mindsdb/interfaces/database/database.py
@@ -53,7 +53,8 @@ class DatabaseWrapper():
         if integration_name is None:
             integrations = self._get_integrations()
         else:
-            integrations = [self._get_integration(integration_name)]
+            integration = self._get_integration(integration_name)
+            integrations = [] if isinstance(integration, bool) else [integration]
 
         for integration in integrations:
             if integration.check_connection():

--- a/mindsdb/interfaces/database/database.py
+++ b/mindsdb/interfaces/database/database.py
@@ -8,6 +8,7 @@ from mindsdb.integrations.mongodb.mongodb import MongoDB
 from mindsdb.utilities.log import log as logger
 from mindsdb.utilities.config import Config
 
+
 class DatabaseWrapper():
     def __init__(self):
         self.config = Config()
@@ -48,8 +49,13 @@ class DatabaseWrapper():
         integrations = [x for x in integrations if x != True and x != False]
         return integrations
 
-    def register_predictors(self, model_data_arr):
-        for integration in self._get_integrations():
+    def register_predictors(self, model_data_arr, integration_name=None):
+        if integration_name is None:
+            integrations = self._get_integrations()
+        else:
+            integrations = [self._get_integration(integration_name)]
+
+        for integration in integrations:
             if integration.check_connection():
                 try:
                     integration.register_predictors(model_data_arr)


### PR DESCRIPTION
**why**

When creating an integration, function 'register predictors' is calling for each integration, which is not necessary.

**how**