### PR TITLE
local variable 'cloud' referenced before assignment

### DIFF
--- a/mindsdb/api/http/namespaces/config.py
+++ b/mindsdb/api/http/namespaces/config.py
@@ -169,12 +169,15 @@ class Vars(Resource):
         if os.getenv('CHECK_FOR_UPDATES', '1').lower() in ['0', 'false', 'False']:
             telemtry = False
 
-        mongo = True
         if ca.config_obj.get('disable_mongo', False):
             mongo = False
+        else:
+            mongo = True
 
         if ca.config_obj.get('cloud', False):
             cloud = False
+        else:
+            cloud = True
 
         return {'mongo': mongo, 'telemtry': telemtry, 'cloud': cloud}
 


### PR DESCRIPTION
Fixes #
```
http API: started on 47334
http exception: local variable 'cloud' referenced before assignment
[2021-03-15 15:47:32,235] ERROR in app: Exception on /api/config/vars [GET]
Traceback (most recent call last):
  File "/home/itsyplen/repos/work/MindsDB/mindsdb_env/lib/python3.8/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/itsyplen/repos/work/MindsDB/mindsdb_env/lib/python3.8/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/itsyplen/repos/work/MindsDB/mindsdb_env/lib/python3.8/site-packages/flask_restx/api.py", line 375, in wrapper
    resp = resource(*args, **kwargs)
  File "/home/itsyplen/repos/work/MindsDB/mindsdb_env/lib/python3.8/site-packages/flask/views.py", line 89, in view
    return self.dispatch_request(*args, **kwargs)
  File "/home/itsyplen/repos/work/MindsDB/mindsdb_env/lib/python3.8/site-packages/flask_restx/resource.py", line 44, in dispatch_request
    resp = meth(*args, **kwargs)
  File "/home/itsyplen/repos/work/MindsDB/mindsdb/mindsdb/api/http/namespaces/config.py", line 179, in get
    return {'mongo': mongo, 'telemtry': telemtry, 'cloud': cloud}
UnboundLocalError: local variable 'cloud' referenced before assignment
```