### PR TITLE
Fix for issues if predictor learn fail

### DIFF
--- a/mindsdb/interfaces/model/model_controller.py
+++ b/mindsdb/interfaces/model/model_controller.py
@@ -243,6 +243,8 @@ class ModelController():
         model['created_at'] = str(parse_datetime(str(predictor_record.created_at).split('.')[0]))
         model['updated_at'] = str(parse_datetime(str(predictor_record.updated_at).split('.')[0]))
         model['update'] = predictor_record.update_status
+        if model.get('predict') is None:
+            model['predict'] = predictor_record.to_predict
         return self._pack(model)
 
     def get_models(self):


### PR DESCRIPTION
**why**

two small fixes:
1. http call to list predictors can return predictor with `'predict': None` right after learn start, which is the cause of error on frontend
2. add error processing on predictor learn fail

**how**