### PR TITLE
Add GitHub Action for publishing AMIs

### DIFF
--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -159,6 +159,27 @@ jobs:
         sleep 20
         pip install mindsdb
 
+  build_amis_packer:
+   #NOTE: in the future migrate to https://github.com/hashicorp/packer-github-actions, when we can send config as an url
+      runs-on: ubuntu-latest
+      if: github.ref == 'refs/heads/stable' && github.actor != 'mindsdbadmin'
+      steps:
+      - uses: actions/checkout@v2
+      - name: Deploy AMI's
+        env:
+          ACCESS_KEY:  ${{ secrets.ACCESS_KEY }}
+          AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          MINDSDB_VERSION: 2.25.0
+        # Add bellow code to sh script, setup MINDSDB_VERSION var from distributions/ver/dist/stable_version.txt file
+        run: |
+          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+          sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+          sudo apt-get install packer
+          git clone https://${ACCESS_KEY}@github.com/mindsdb/mindsdb_gateway
+          cd mindsdb_gateway/deployments
+          sudo packer build config.json
+
   deploy_version_file:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/stable' && github.actor != 'mindsdbadmin'

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -46,7 +46,7 @@ jobs:
       shell: bash
       env:
         INSTALL_RAY: ${{ matrix.token }}
-        ACCESS_KEY:  ${{ secrets.ACCESS_KEY }}
+        ACCESS_KEY:  ${{ secrets.GH_ACCESS_KEY }}
         mindsdb_github_masterkey: ${{secrets.mindsdb_github_masterkey}}
     - name: Install dependencies Windows
       run: |

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -182,7 +182,7 @@ jobs:
           export MINDSDB_VERSION="$mdb_version"
           git clone https://${ACCESS_KEY}@github.com/mindsdb/mindsdb_gateway
           cd mindsdb_gateway/deployments
-          echo "$MINDSDB_VERSION"
+          echo "Building AMIs for $MINDSDB_VERSION"
           sudo packer build -var "mindsdb_version=$MINDSDB_VERSION" -var "aws_acces_key=$AWS_ACCESS_KEY" -var "aws_secret_key=$AWS_SECRET_KEY" config.json
 
   deploy_version_file:

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -167,9 +167,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Deploy AMI's
         env:
-          ACCESS_KEY:  ${{ secrets.ACCESS_KEY }}
-          AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          ACCESS_KEY:  ${{ secrets.GH_ACCESS_KEY }}
+          AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         # Add bellow code to sh script, setup MINDSDB_VERSION var from distributions/ver/dist/stable_version.txt file
         # Send variables to packer build command, because if using env in conf they are not vissible to build
         run: |

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -159,7 +159,7 @@ jobs:
         pip install mindsdb
 
   build_amis_packer:
-   #NOTE: in the future migrate to https://github.com/hashicorp/packer-github-actions, when we can send config as an url
+   #TODO: in the future migrate to https://github.com/hashicorp/packer-github-actions, when we can send config as an url
       runs-on: ubuntu-latest
       needs: deploy_to_pypi
       if: github.ref == 'refs/heads/stable' && github.actor != 'mindsdbadmin'
@@ -170,8 +170,8 @@ jobs:
           ACCESS_KEY:  ${{ secrets.GH_ACCESS_KEY }}
           AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        # Add bellow code to sh script, setup MINDSDB_VERSION var from distributions/ver/dist/stable_version.txt file
-        # Send variables to packer build command, because if using env in conf they are not vissible to build
+        #TODO: Add bellow code to sh script, setup MINDSDB_VERSION var from distributions/ver/dist/stable_version.txt file
+        #NOTE: Send variables to packer build command or var file, because if using env in conf they are not vissible to build
         run: |
           curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
           sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
@@ -182,7 +182,7 @@ jobs:
           git clone https://${ACCESS_KEY}@github.com/mindsdb/mindsdb_gateway
           cd mindsdb_gateway/deployments
           echo "Building AMIs for $MINDSDB_VERSION"
-          sudo packer build -var "mindsdb_version=$MINDSDB_VERSION" -var "aws_acces_key=$AWS_ACCESS_KEY" -var "aws_secret_key=$AWS_SECRET_KEY" config.json
+          sudo packer build -var "mindsdb_version=$MINDSDB_VERSION" -var "acces_key=$ACCESS_KEY" -var "aws_acces_key=$AWS_ACCESS_KEY" -var "aws_secret_key=$AWS_SECRET_KEY" config.json
 
   deploy_version_file:
     runs-on: ubuntu-latest

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -38,9 +38,7 @@ jobs:
         pip install boto3
         pip install --no-cache-dir .
         if [ "$INSTALL_RAY" == "install_ray" ]; then
-          echo "$mindsdb_github_masterkey" > ~/github_masterkey;
-          chmod -R 600 ~/github_masterkey;
-          ssh-agent bash -c 'ssh-add ~/github_masterkey; git clone git@github.com:mindsdb/worker.git';
+          git clone git@github.com:mindsdb/worker.git';
           cd worker;
           pip install --no-cache-dir .;
           cd ..;
@@ -48,6 +46,7 @@ jobs:
       shell: bash
       env:
         INSTALL_RAY: ${{ matrix.token }}
+        ACCESS_KEY:  ${{ secrets.ACCESS_KEY }}
         mindsdb_github_masterkey: ${{secrets.mindsdb_github_masterkey}}
     - name: Install dependencies Windows
       run: |

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -38,7 +38,7 @@ jobs:
         pip install boto3
         pip install --no-cache-dir .
         if [ "$INSTALL_RAY" == "install_ray" ]; then
-          git clone https://${ACCESS_KEY}@github.com/mindsdb/worker.git';
+          git clone https://${ACCESS_KEY}@github.com/mindsdb/worker.git;
           cd worker;
           pip install --no-cache-dir .;
           cd ..;

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -171,15 +171,19 @@ jobs:
           ACCESS_KEY:  ${{ secrets.ACCESS_KEY }}
           AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
-          MINDSDB_VERSION: 2.25.0
         # Add bellow code to sh script, setup MINDSDB_VERSION var from distributions/ver/dist/stable_version.txt file
+        # Send variables to packer build command, because if using env in conf they are not vissible to build
         run: |
           curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
           sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
           sudo apt-get install packer
+          python deploy_version.py release
+          mdb_version=`cat distributions/ver/dist/stable_version.txt`
+          export MINDSDB_VERSION="$mdb_version"
           git clone https://${ACCESS_KEY}@github.com/mindsdb/mindsdb_gateway
           cd mindsdb_gateway/deployments
-          sudo packer build config.json
+          echo "$MINDSDB_VERSION"
+          sudo packer build -var "mindsdb_version=$MINDSDB_VERSION" -var "aws_acces_key=$AWS_ACCESS_KEY" -var "aws_secret_key=$AWS_SECRET_KEY" config.json
 
   deploy_version_file:
     runs-on: ubuntu-latest

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -162,6 +162,7 @@ jobs:
   build_amis_packer:
    #NOTE: in the future migrate to https://github.com/hashicorp/packer-github-actions, when we can send config as an url
       runs-on: ubuntu-latest
+      needs: deploy_to_pypi
       if: github.ref == 'refs/heads/stable' && github.actor != 'mindsdbadmin'
       steps:
       - uses: actions/checkout@v2
@@ -182,6 +183,7 @@ jobs:
 
   deploy_version_file:
     runs-on: ubuntu-latest
+    needs: deploy_to_pypi
     if: github.ref == 'refs/heads/stable' && github.actor != 'mindsdbadmin'
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -38,7 +38,7 @@ jobs:
         pip install boto3
         pip install --no-cache-dir .
         if [ "$INSTALL_RAY" == "install_ray" ]; then
-          git clone git@github.com:mindsdb/worker.git';
+          git clone https://${ACCESS_KEY}@github.com/mindsdb/worker.git';
           cd worker;
           pip install --no-cache-dir .;
           cd ..;


### PR DESCRIPTION
This PR adds workflow for deploying amis to aws. To preview the whole flow visit https://github.com/mindsdb/mindsdb_gateway/tree/staging/deployments. 
>Note Before merging add    `ACCESS_KEY`,  `AWS_ACCESS_KEY` and   `AWS_SECRET_KEY` to repo secrets.