### PR TITLE
processing for 2 new mongo packages

### DIFF
--- a/mindsdb/api/mongo/responders/__init__.py
+++ b/mindsdb/api/mongo/responders/__init__.py
@@ -14,6 +14,8 @@ from .db_stats import responder as responder_db_stats
 from .coll_stats import responder as responder_coll_stats
 from .count import responder as responder_count
 from .aggregate import responder as responder_aggregate
+from .get_free_monitoring_status import responder as responder_get_free_monitoring_status
+from .end_sessions import responder as responder_end_sessions
 
 from .list_indexes import responder as responder_list_indexes
 from .list_collections import responder as responder_list_collections
@@ -44,6 +46,8 @@ responders = [
     responder_coll_stats,
     responder_count,
     responder_aggregate,
+    responder_get_free_monitoring_status,
+    responder_end_sessions,
     # user queries
     responder_list_indexes,
     responder_list_collections,

--- a/mindsdb/api/mongo/responders/buildinfo.py
+++ b/mindsdb/api/mongo/responders/buildinfo.py
@@ -5,9 +5,7 @@ from mindsdb.api.mongo.classes import Responder
 class Responce(Responder):
     def when(self, query):
         return (
-            ('buildinfo' in query or 'buildInfo' in query)
-            and '$db' in query
-            and (query['$db'] == 'test' or query['$db'] == 'admin')
+            'buildinfo' in query or 'buildInfo' in query
         )
 
     result = {

--- a/mindsdb/api/mongo/responders/end_sessions.py
+++ b/mindsdb/api/mongo/responders/end_sessions.py
@@ -1,0 +1,13 @@
+from mindsdb.api.mongo.classes import Responder
+import mindsdb.api.mongo.functions as helpers
+
+
+class Responce(Responder):
+    when = {'endSessions': helpers.is_true}
+
+    result = {
+        'ok': 1
+    }
+
+
+responder = Responce()

--- a/mindsdb/api/mongo/responders/get_free_monitoring_status.py
+++ b/mindsdb/api/mongo/responders/get_free_monitoring_status.py
@@ -1,0 +1,14 @@
+from mindsdb.api.mongo.classes import Responder
+import mindsdb.api.mongo.functions as helpers
+
+
+class Responce(Responder):
+    when = {'getFreeMonitoringStatus': helpers.is_true}
+
+    result = {
+        'state': 'undecided',
+        'ok': 1
+    }
+
+
+responder = Responce()


### PR DESCRIPTION
**why**

Latest mongo shell sends `getFreeMonitoringStatus` at start of connection and `endSessions` at the end. All works, but user see error message in console, and client reconnect, which make debugging much harder.

**how**