### PR TITLE
Add records to avoid, undefined error[Fix mongo api start]

### DIFF
--- a/mindsdb/utilities/log.py
+++ b/mindsdb/utilities/log.py
@@ -47,6 +47,7 @@ class DbHandler(logging.Handler):
         self.company_id = os.environ.get('MINDSDB_COMPANY_ID', None)
 
     def emit(self, record):
+        self.format(record)
         if len(record.message.strip(' \n')) == 0 \
             or (record.threadName == 'ray_print_logs' and 'mindsdb-logger' not in record.message):
             return


### PR DESCRIPTION
This PR fixes the issue for `AttributeError: 'LogRecord' object has no attribute 'message'`. This was happening when starting the Mongo API. Firstly I thought some other error happens and we are not able to catch it because of this issue but, after fixing this mongo was successfully started.