### PR TITLE
Remove constrain on ds table

### DIFF
--- a/mindsdb/integrations/clickhouse/clickhouse.py
+++ b/mindsdb/integrations/clickhouse/clickhouse.py
@@ -2,11 +2,13 @@ import requests
 
 from mindsdb.utilities.subtypes import DATA_SUBTYPES
 from mindsdb.integrations.base import Integration
+from mindsdb.utilities.log import log
+
 
 class ClickhouseConnectionChecker:
     def __init__(self, **kwargs):
         self.host = kwargs.get("host")
-        self.port= kwargs.get("port")
+        self.port = kwargs.get("port")
         self.user = kwargs.get("user")
         self.password = kwargs.get("password")
 
@@ -19,6 +21,7 @@ class ClickhouseConnectionChecker:
         except Exception:
             connected = False
         return connected
+
 
 class Clickhouse(Integration, ClickhouseConnectionChecker):
     def __init__(self, config, name):
@@ -56,8 +59,7 @@ class Clickhouse(Integration, ClickhouseConnectionChecker):
                 if name in predicted_cols:
                     column_declaration.append(f' `{name}_original` {new_type} ')
             except Exception as e:
-                print(e)
-                print(f'Error: cant convert type {col_subtype} of column {name} to clickhouse type')
+                log.error(f'Error: can not determine clickhouse data type for column {name}: {e}')
 
         return column_declaration
 

--- a/mindsdb/integrations/mariadb/mariadb.py
+++ b/mindsdb/integrations/mariadb/mariadb.py
@@ -2,6 +2,7 @@ import mysql.connector
 
 from mindsdb.utilities.subtypes import DATA_SUBTYPES
 from mindsdb.integrations.base import Integration
+from mindsdb.utilities.log import log
 
 
 class MariadbConnectionChecker:
@@ -61,8 +62,8 @@ class Mariadb(Integration, MariadbConnectionChecker):
                 column_declaration.append(f' `{name}` {new_type} ')
                 if name in predicted_cols:
                     column_declaration.append(f' `{name}_original` {new_type} ')
-            except Exception:
-                print(f'Error: cant convert type {col_subtype} of column {name} to mariadb type')
+            except Exception as e:
+                log.error(f'Error: can not determine mariadb data type for column {name}: {e}')
 
         return column_declaration
 

--- a/mindsdb/integrations/mssql/mssql.py
+++ b/mindsdb/integrations/mssql/mssql.py
@@ -18,6 +18,7 @@ class MSSQLConnectionChecker:
             as_dict=True,
             autocommit=True  # .commit() doesn't work
         )
+
     def check_connection(self):
         try:
             conn = self._get_connnection()

--- a/mindsdb/integrations/mysql/mysql.py
+++ b/mindsdb/integrations/mysql/mysql.py
@@ -3,6 +3,7 @@ import mysql.connector
 
 from mindsdb.utilities.subtypes import DATA_SUBTYPES
 from mindsdb.integrations.base import Integration
+from mindsdb.utilities.log import log
 
 
 class MySQLConnectionChecker:
@@ -14,10 +15,11 @@ class MySQLConnectionChecker:
 
     def _get_connnection(self):
         return mysql.connector.connect(
-                host=self.host,
-                port=self.port,
-                user=self.user,
-                password=self.password)
+            host=self.host,
+            port=self.port,
+            user=self.user,
+            password=self.password
+        )
 
     def check_connection(self):
         try:
@@ -64,8 +66,8 @@ class MySQL(Integration, MySQLConnectionChecker):
                 column_declaration.append(f' `{name}` {new_type} ')
                 if name in predicted_cols:
                     column_declaration.append(f' `{name}_original` {new_type} ')
-            except Exception:
-                print(f'Error: cant convert type {col_subtype} of column {name} to mysql type')
+            except Exception as e:
+                log.error(f'Error: can not determine mysql data type for column {name}: {e}')
 
         return column_declaration
 

--- a/mindsdb/interfaces/storage/db.py
+++ b/mindsdb/interfaces/storage/db.py
@@ -1,13 +1,12 @@
 import os
 import json
+import datetime
 
 import numpy as np
 from sqlalchemy import create_engine, orm, types, UniqueConstraint
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, DateTime, Boolean, Index
-from sqlalchemy.schema import ForeignKey
-import datetime
 
 if os.environ['MINDSDB_DB_CON'].startswith('sqlite:'):
     engine = create_engine(os.environ['MINDSDB_DB_CON'], echo=False)
@@ -109,10 +108,11 @@ class Predictor(Base):
     company_id = Column(Integer)
     mindsdb_version = Column(String)
     native_version = Column(String)
-    datasource_id = Column(Integer, ForeignKey('datasource.id'))
+    datasource_id = Column(Integer)
     is_custom = Column(Boolean)
     learn_args = Column(Json)
     update_status = Column(String, default='up_to_date')
+
 
 class AITable(Base):
     __tablename__ = 'ai_table'
@@ -155,6 +155,7 @@ class Stream(Base):
     integration = Column(String)
     company_id = Column(Integer)
     name = Column(String)
+
 
 Base.metadata.create_all(engine)
 orm.configure_mappers()


### PR DESCRIPTION
**why**

1. At this moment is not possible to remove DS which was used for predictor training, if as storage database use not sqlite.
2. one of users get error on creation predictors table in db, there is no way to determine why. Add `log.error()` for that cases.

**how**

remove db constrain