### PR TITLE
Provide TS settings

### DIFF
--- a/mindsdb/api/http/namespaces/stream.py
+++ b/mindsdb/api/http/namespaces/stream.py
@@ -7,6 +7,7 @@ from mindsdb.api.http.namespaces.configs.streams import ns_conf
 
 from mindsdb.interfaces.storage.db import session
 from mindsdb.interfaces.storage.db import Stream as StreamDB
+from mindsdb.streams.base.base_stream import StreamTypes
 
 COMPANY_ID = os.environ.get('MINDSDB_COMPANY_ID', None)
 
@@ -74,11 +75,15 @@ class Stream(Resource):
         stream_in = params['stream_in']
         stream_out  = params['stream_out']
         _type = params.get('type', 'forecast')
+        if _type.lower() == StreamTypes.timeseries:
+            ts_params = params.get('ts_params')
+        else:
+            ts_params = {}
         if predictor not in get_predictors():
             abort(400, f"requested predictor '{predictor}' is not ready or doens't exist")
         stream = StreamDB(_type=_type, name=name, connection_params=connection_params, advanced_params=advanced_params,
                           predictor=predictor, stream_in=stream_in, stream_out=stream_out,
-                          integration=integration_name, company_id=COMPANY_ID)
+                          integration=integration_name, company_id=COMPANY_ID, ts_params=ts_params)
 
         session.add(stream)
         session.commit()

--- a/mindsdb/integrations/redis/redisdb.py
+++ b/mindsdb/integrations/redis/redisdb.py
@@ -2,6 +2,8 @@ from threading import Thread
 import walrus
 from mindsdb.integrations.base import StreamIntegration
 from mindsdb.streams.redis.redis_stream import RedisStream
+from mindsdb.streams.base.base_stream import StreamTypes
+
 from mindsdb.interfaces.storage.db import session, Stream
 
 
@@ -112,7 +114,7 @@ class Redis(StreamIntegration, RedisConnectionChecker):
         stream_rec = Stream(name=stream.stream_name, connection_params=self.connection_info, advanced_params=self.advanced_info,
                             _type=stream._type, predictor=stream.predictor,
                             integration=self.name, company_id=self.company_id,
-                            stream_in=stream.stream_in_name, stream_out=stream.stream_out_name)
+                            stream_in=stream.stream_in_name, stream_out=stream.stream_out_name, ts_params=stream.ts_params)
         session.add(stream_rec)
         session.commit()
         self.streams[stream.stream_name] = stream.stop_event
@@ -122,7 +124,8 @@ class Redis(StreamIntegration, RedisConnectionChecker):
                   "name": db_record.name,
                   "predictor": db_record.predictor,
                   "input_stream": db_record.stream_in,
-                  "output_stream": db_record.stream_out}
+                  "output_stream": db_record.stream_out,
+                  "ts_params": db_record.ts_params}
         return self.get_stream_from_kwargs(**kwargs)
 
     def get_stream_from_kwargs(self, **kwargs):
@@ -131,9 +134,10 @@ class Redis(StreamIntegration, RedisConnectionChecker):
         stream_out = kwargs.get('output_stream')
         predictor_name = kwargs.get('predictor')
         stream_type = kwargs.get('type', 'forecast')
+        ts_params = kwargs.get('ts_params')
         return RedisStream(name, self.connection_info, self.advanced_info,
                            stream_in, stream_out, predictor_name,
-                           stream_type)
+                           stream_type, **ts_params)
 
     def _decode(self, b_dict):
         """convert binary key/value into strings"""

--- a/mindsdb/interfaces/storage/db.py
+++ b/mindsdb/interfaces/storage/db.py
@@ -146,9 +146,6 @@ class Stream(Base):
     # integration_id = Column(Integer, ForeignKey('integration.id'))
     created_at = Column(DateTime, default=datetime.datetime.now)
     _type = Column(String)
-    # host = Column(String)
-    # port = Column(Integer)
-    # db = Column(Integer, default=0)
     predictor = Column(String)
     stream_in = Column(String)
     stream_out = Column(String)
@@ -157,6 +154,7 @@ class Stream(Base):
     name = Column(String)
     connection_params = Column(Json)
     advanced_params = Column(Json)
+    ts_params = Column(Json, default={})
 
 
 Base.metadata.create_all(engine)

--- a/mindsdb/streams/base/base_stream.py
+++ b/mindsdb/streams/base/base_stream.py
@@ -1,0 +1,4 @@
+
+
+class StreamTypes:
+    timeseries = "timeseries"

--- a/mindsdb/streams/kafka/kafka_stream.py
+++ b/mindsdb/streams/kafka/kafka_stream.py
@@ -6,12 +6,13 @@ import kafka
 from kafka.admin import NewTopic
 
 from mindsdb.utilities.log import log
+from mindsdb.streams.base.base_stream import StreamTypes
 from mindsdb.interfaces.storage.db import session
 from mindsdb.interfaces.storage.db import Predictor as DBPredictor
 from mindsdb.interfaces.model.model_interface import ModelInterface as NativeInterface
 
 class KafkaStream(Thread):
-    def __init__(self, connection_info, advanced_info, topic_in, topic_out, predictor, _type):
+    def __init__(self, connection_info, advanced_info, topic_in, topic_out, predictor, _type, **ts_params):
         self.connection_info = connection_info
         self.advanced_info = advanced_info
         self.predictor = predictor
@@ -33,26 +34,15 @@ class KafkaStream(Thread):
         self.stop_event = Event()
         self.company_id = os.environ.get('MINDSDB_COMPANY_ID', None)
         self.caches = {}
-        if self._type == 'timeseries':
+        self.ts_params = ts_params
+        if self._type.lower() == StreamTypes.timeseries:
+            self.target = self.ts_params.get('target')
+            self.window = self.ts_params.get('window_size')
+            self.gb = self.ts_params.get('group_by')
+            self.dt = self.ts_params.get('order_by')
             super().__init__(target=KafkaStream.make_timeseries_predictions, args=(self,))
         else:
             super().__init__(target=KafkaStream.make_prediction, args=(self,))
-
-    def _get_target(self):
-        return "pnew_case"
-        # pass
-
-    def _get_window_size(self):
-        return 10
-        # pass
-
-    def _get_gb(self):
-        return "state"
-        # pass
-
-    def _get_dt(self):
-        return "time"
-        # pass
 
     def predict_ts(self, cache_name):
         when_list = [x for x  in self.caches[cache_name]]
@@ -107,10 +97,6 @@ class KafkaStream(Thread):
         if predict_record is None:
             log.error(f"Error creating stream: requested predictor {self.predictor} is not exist")
             return
-        self.target = self._get_target()
-        self.window = self._get_window_size()
-        self.gb = self._get_gb()
-        self.dt = self._get_dt()
 
         while not self.stop_event.wait(0.5):
             try:


### PR DESCRIPTION
Fixed #1171

How (this is the last part of implementation):
by providing ts_setting like (`order_by`, `group_by`, `window_size` and prediction `target`) in creating Stream API request (for Kafka and Redis):

```
import requests

stream_info = {"predictor": "covid_ts",
               "stream_in": "covid_in",
               "stream_out": "covid_out",
               "integration_name": "kafka_test",
               "type": "timeseries",
               "ts_params": {"target": "adult_icu_bed_utilization",
                   "order_by": "time",
                   "group_by": "state",
                   "window_size": 10},
               }


url = "http://127.0.0.1:47334/api/streams/kafka_stream_http_api"
res = requests.put(url, json={'params': stream_info})

print(res.status_code, res.text)
```