### PR TITLE
Timeseries fix + various

### DIFF
--- a/.github/workflows/matrix_includes.json
+++ b/.github/workflows/matrix_includes.json
@@ -11,7 +11,6 @@
       "token": "not_install_ray",
       "runOn": "always"
     },
-    
     {
       "runs_on": "windows-latest",
       "python-version": 3.7,
@@ -24,7 +23,7 @@
       "token": "not_install_ray",
       "runOn": "refs/heads/stable"
     },
-    
+
     {
       "runs_on": "windows-latest",
       "python-version": 3.8,
@@ -50,18 +49,6 @@
       "runOn": "always"
     },
 
-    {
-      "runs_on": "windows-latest",
-      "python-version": 3.6,
-      "token": "not_install_ray",
-      "runOn": "refs/heads/stable"
-    },
-    {
-      "runs_on": "macos-latest",
-      "python-version": 3.6,
-      "token": "not_install_ray",
-      "runOn": "refs/heads/stable"
-    },
     {
       "runs_on": "ubuntu-latest",
       "python-version": 3.6,

--- a/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
+++ b/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
@@ -266,6 +266,7 @@ class MindsDBDataNode(DataNode):
             return data
         else:
             pred_dicts, explanations = self.model_interface.predict(table, 'dict&explain', when_data=where_data)
+            # Fix since for some databases we *MUST* return the same value for the columns originally specified in the `WHERE`
             if isinstance(where_data, list):
                 for i in range(len(pred_dicts)):
                     for col in where_data[i]:

--- a/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
+++ b/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
@@ -273,6 +273,10 @@ class MindsDBDataNode(DataNode):
                         if col not in predicted_columns:
                             pred_dicts[i][col] = where_data[i][col]
 
+            if isinstance(where_data, dict):
+                    for col in where_data:
+                        if col not in predicted_columns:
+                            pred_dicts[0][col] = where_data[col]
 
             keys = [x for x in pred_dicts[0] if x in columns]
             min_max_keys = []

--- a/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
+++ b/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
@@ -119,9 +119,12 @@ class MindsDBDataNode(DataNode):
         query = aitable_record.integration_query
         predictor_name = aitable_record.predictor_name
 
+        print(f'\n\n\n ERROR - Predicting fom query: {query}\n\n\n')
         ds, ds_name = self.data_store.save_datasource('temp_ds', integration, {'query': query})
         dso = self.data_store.get_datasource_obj(ds_name, raw=True)
+        print(f'\n\n\n ERROR - Predicting with temp datasource: {dso}\n\n\n')
         res = self.model_interface.predict(predictor_name, 'dict', when_data=dso)
+        print(f'\n\n\n ERROR - Got predictions {res}\n\n\n')
         self.data_store.delete_datasource(ds_name)
 
         keys_map = {}

--- a/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
+++ b/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
@@ -309,5 +309,4 @@ class MindsDBDataNode(DataNode):
                     row[key + '_min'] = min(explanation[key]['confidence_interval'])
                     row[key + '_max'] = max(explanation[key]['confidence_interval'])
 
-            log.error(f'Returning data: {data}')
             return data

--- a/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
+++ b/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
@@ -872,8 +872,8 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
         self.sendPackageGroup(packages)
 
     def queryAnswer(self, sql):
+        from mindsdb.utilities.log import log
         statement = SqlStatementParser(sql)
-
         sql = statement.sql
         sql_lower = sql.lower()
         sql_lower = sql_lower.replace('`', '')

--- a/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
+++ b/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
@@ -872,7 +872,6 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
         self.sendPackageGroup(packages)
 
     def queryAnswer(self, sql):
-        from mindsdb.utilities.log import log
         statement = SqlStatementParser(sql)
         sql = statement.sql
         sql_lower = sql.lower()

--- a/mindsdb/interfaces/model/model_controller.py
+++ b/mindsdb/interfaces/model/model_controller.py
@@ -273,7 +273,7 @@ class ModelController():
         model['updated_at'] = str(parse_datetime(str(predictor_record.updated_at).split('.')[0]))
         model['predict'] = predictor_record.to_predict
         model['update'] = predictor_record.update_status
-        model['name'] = model['name'].split('@@@@@')[1]
+        model['name'] = predictor_record.name
         return self._pack(model)
 
     def get_models(self, company_id=None):

--- a/mindsdb/interfaces/model/model_controller.py
+++ b/mindsdb/interfaces/model/model_controller.py
@@ -195,7 +195,6 @@ class ModelController():
                 data_source = when_data
 
         predictor = self.predictor_cache[name]['predictor']
-
         predictions = predictor.predict(
             when_data=data_source,
             **kwargs

--- a/mindsdb/utilities/log.py
+++ b/mindsdb/utilities/log.py
@@ -5,6 +5,7 @@ import traceback
 
 from mindsdb.interfaces.storage.db import session, Log
 from mindsdb.utilities.config import Config
+from functools import partial
 
 global_config = Config().get_all()
 telemtry_enabled = os.getenv('CHECK_FOR_UPDATES', '1').lower() not in ['0', 'false', 'False']
@@ -153,6 +154,7 @@ def initialize_log(config=global_config, logger_name='main', wrap_print=False):
         sys.stdout = LoggerWrapper([log.debug, log.info, log.warning, log.error], 1)
         sys.stderr = LoggerWrapper([log.debug, log.info, log.warning, log.error], 3)
 
+    log.error = partial(log.error, exc_info=True)
     return log
 
 


### PR DESCRIPTION
Mindsdb won't return any rows if the `data` resulting from the `select` function in the datanode has the values for the received columns changed. (when using from within clickhouse)

E.g. if we get ` WHERE A=1 AND B='2'` but then try to return the data dict:
`{'A': None, 'B': '2', 'to_pred': 13242}`, then we will see `0` rows being returned to clickhouse.

The original values that the prediction is generated from being made "null" was happening inside the native `predict` call and is an unknown bug, but in case this happens in the future it might make sense to implement a "fix" for it mindsdb side, which this PR does. I assume this might have to do with clickhouse doing the `WHERE` filtering on their side too, but am unsure.

Also:

* Fixed `get_model` to work before `name` gets set as a property in the local metadata.
* Fixed `error` logging to also print the traceback.