### PR TITLE
Optional ray usage

### DIFF
--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -72,6 +72,10 @@ jobs:
 
           export USE_EXTERNAL_DB_SERVER="1"
 
+          if [ "$INSTALL_RAY" == "install_ray" ]; then
+            export USE_RAY="1"
+          fi
+
           # Company independent
           echo -e "\n===============\ntest company independent\n===============\n"
           python tests/integration_tests/flows/test_company_independent.py
@@ -133,6 +137,7 @@ jobs:
         DATABASE_CREDENTIALS: ${{secrets.DATABASE_CREDENTIALS}}
         AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
         AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+        INSTALL_RAY: ${{ matrix.token }}
 
   deploy_to_pypi:
     runs-on: ubuntu-latest

--- a/mindsdb/__init__.py
+++ b/mindsdb/__init__.py
@@ -63,7 +63,7 @@ if not is_ray_worker:
     elif 'ray' in user_config:
         os.environ['USE_RAY'] = str(user_config['ray']).lower()
 
-    if os.environ.get('USE_RAY').lower() in ['1', 'true']:
+    if os.environ.get('USE_RAY', '0').lower() in ['1', 'true']:
         try:
             import ray
         except Exception as e:

--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -4,13 +4,11 @@ import sys
 import os
 import time
 import asyncio
-import datetime
 import signal
 
 import torch.multiprocessing as mp
 
 from mindsdb.utilities.config import Config, STOP_THREADS_EVENT
-from mindsdb.utilities.os_specific import get_mp_context
 from mindsdb.interfaces.model.model_interface import ray_based, ModelInterface
 from mindsdb.api.http.start import start as start_http
 from mindsdb.api.mysql.start import start as start_mysql
@@ -23,7 +21,6 @@ from mindsdb.utilities.log import log
 from mindsdb.interfaces.database.integrations import get_db_integrations
 
 COMPANY_ID = os.environ.get('MINDSDB_COMPANY_ID', None)
- 
 
 
 def close_api_gracefully(apis):
@@ -40,7 +37,8 @@ def close_api_gracefully(apis):
             process.terminate()
             process.join()
             sys.stdout.flush()
-        os.system('ray stop --force')
+        if ray_based:
+            os.system('ray stop --force')
     except KeyboardInterrupt:
         sys.exit(0)
 
@@ -58,7 +56,6 @@ if __name__ == '__main__':
     os.environ['LIGHTWOOD_LOG_LEVEL'] = config['log']['level']['console']
 
     # Switch to this once the native interface has it's own thread :/
-    # ctx = mp.get_context(get_mp_context())
     ctx = mp.get_context('spawn')
     if not ray_based:
         from mindsdb.interfaces.model.model_controller import start as start_model_controller

--- a/mindsdb/api/mongo/responders/insert.py
+++ b/mindsdb/api/mongo/responders/insert.py
@@ -1,4 +1,3 @@
-import os
 from mindsdb.api.mongo.classes import Responder
 from mindsdb.interfaces.storage.db import session, Datasource
 import mindsdb.api.mongo.functions as helpers

--- a/mindsdb/interfaces/model/model_controller.py
+++ b/mindsdb/interfaces/model/model_controller.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import psutil
 import datetime
 import time
+import os
 from contextlib import contextmanager
 
 import pandas as pd
@@ -359,19 +360,21 @@ class ModelController():
             return str(e)
 
 
-try:
-    from mindsdb_worker.cluster.ray_controller import ray_ify
-    import ray
+if os.environ.get('USE_RAY') in ['1', 'true']:
     try:
-        ray.init(ignore_reinit_error=True, address='auto')
-    except Exception:
-        ray.init(ignore_reinit_error=True)
-    ModelController = ray_ify(ModelController)
-except Exception as e:
-    log.error(e)
+        from mindsdb_worker.cluster.ray_controller import ray_ify
+        import ray
+        try:
+            ray.init(ignore_reinit_error=True, address='auto')
+        except Exception:
+            ray.init(ignore_reinit_error=True)
+        ModelController = ray_ify(ModelController)
+    except Exception as e:
+        log.error(f'Failed to import ray: {e}')
 
 
-def ping(): return True
+def ping():
+    return True
 
 
 def start():

--- a/mindsdb/interfaces/model/model_controller.py
+++ b/mindsdb/interfaces/model/model_controller.py
@@ -360,7 +360,7 @@ class ModelController():
             return str(e)
 
 
-if os.environ.get('USE_RAY') in ['1', 'true']:
+if os.environ.get('USE_RAY', '0').lower() in ['1', 'true']:
     try:
         from mindsdb_worker.cluster.ray_controller import ray_ify
         import ray

--- a/mindsdb/interfaces/model/model_interface.py
+++ b/mindsdb/interfaces/model/model_interface.py
@@ -3,6 +3,7 @@ import xmlrpc
 import xmlrpc.client
 import time
 import pickle
+import os
 
 from mindsdb.utilities.log import log
 
@@ -73,15 +74,20 @@ class ModelInterfaceRPC():
         return 'Model updating is no available in this version of mindsdb'
 
 
-try:
-    from mindsdb_worker.cluster.ray_interface import ModelInterfaceRay
-    import ray
+if os.environ.get('USE_RAY') in ['1', 'true']:
     try:
-        ray.init(ignore_reinit_error=True, address='auto')
-    except Exception:
-        ray.init(ignore_reinit_error=True)
-    ModelInterface = ModelInterfaceRay
-    ray_based = True
-except Exception:
+        from mindsdb_worker.cluster.ray_interface import ModelInterfaceRay
+        import ray
+        try:
+            ray.init(ignore_reinit_error=True, address='auto')
+        except Exception:
+            ray.init(ignore_reinit_error=True)
+        ModelInterface = ModelInterfaceRay
+        ray_based = True
+    except Exception as e:
+        log.error(f'Failed to import ray: {e}')
+        ModelInterface = ModelInterfaceRPC
+        ray_based = False
+else:
     ModelInterface = ModelInterfaceRPC
     ray_based = False

--- a/mindsdb/interfaces/model/model_interface.py
+++ b/mindsdb/interfaces/model/model_interface.py
@@ -74,7 +74,7 @@ class ModelInterfaceRPC():
         return 'Model updating is no available in this version of mindsdb'
 
 
-if os.environ.get('USE_RAY') in ['1', 'true']:
+if os.environ.get('USE_RAY', '0').lower() in ['1', 'true']:
     try:
         from mindsdb_worker.cluster.ray_interface import ModelInterfaceRay
         import ray

--- a/mindsdb/utilities/functions.py
+++ b/mindsdb/utilities/functions.py
@@ -9,7 +9,9 @@ def args_parse():
     parser.add_argument('--verbose', action='store_true')
     parser.add_argument('--no_studio', action='store_true')
     parser.add_argument('-v', '--version', action='store_true')
+    parser.add_argument('--ray', action='store_true', default=False)
     return parser.parse_args()
+
 
 def cast_row_types(row, field_types):
     '''
@@ -29,6 +31,7 @@ def cast_row_types(row, field_types):
                 row[key] = int(row[key])
             except Exception:
                 pass
+
 
 def is_notebook():
     try:

--- a/mindsdb/utilities/functions.py
+++ b/mindsdb/utilities/functions.py
@@ -9,7 +9,7 @@ def args_parse():
     parser.add_argument('--verbose', action='store_true')
     parser.add_argument('--no_studio', action='store_true')
     parser.add_argument('-v', '--version', action='store_true')
-    parser.add_argument('--ray', action='store_true', default=False)
+    parser.add_argument('--ray', action='store_true', default=None)
     return parser.parse_args()
 
 

--- a/mindsdb/utilities/os_specific.py
+++ b/mindsdb/utilities/os_specific.py
@@ -1,8 +1,0 @@
-import platform
-
-
-def get_mp_context():
-    if platform.system() in ['Linux', 'Darwin']:
-        return 'fork'
-    else:
-        return spawn


### PR DESCRIPTION
Currently we use ray always if it installed. This PR make that optional. So we avoid possible errors if user already use ray, and make local testing much easier.
Use or not ray checked by:
1. env variable USE_RAY
2. arg --ray (which is more priority)
By default ray is not used