### PR TITLE
Better manage ds names on creation

### DIFF
--- a/mindsdb/api/http/namespaces/datasource.py
+++ b/mindsdb/api/http/namespaces/datasource.py
@@ -4,7 +4,6 @@ import tempfile
 import re
 import multipart
 
-import mindsdb
 from dateutil.parser import parse
 from flask import request, send_file
 from flask_restx import Resource, abort     # 'abort' using to return errors as json: {'message': 'error text'}
@@ -137,9 +136,9 @@ class Datasource(Resource):
             if integration['type'] == 'mongodb':
                 data['find'] = data['query']
 
-            ds_obj, ds_name = request.default_store.save_datasource(name, integration_id, data)
+            request.default_store.save_datasource(name, integration_id, data)
             os.rmdir(temp_dir_path)
-            return request.default_store.get_datasource(ds_name)
+            return request.default_store.get_datasource(name)
 
         ds_name = data['name'] if 'name' in data else name
         source = data['source'] if 'source' in data else name
@@ -150,7 +149,7 @@ class Datasource(Resource):
         else:
             file_path = None
 
-        ds_obj, ds_name = request.default_store.save_datasource(ds_name, source_type, source, file_path)
+        request.default_store.save_datasource(ds_name, source_type, source, file_path)
         os.rmdir(temp_dir_path)
 
         return request.default_store.get_datasource(ds_name)

--- a/mindsdb/api/mongo/responders/find.py
+++ b/mindsdb/api/mongo/responders/find.py
@@ -62,15 +62,14 @@ class Responce(Responder):
                 if connection is None:
                     raise Exception("Can't find connection from which fetch data")
 
-                ds_name = 'temp'
+                ds_name = mindsdb_env['data_store'].get_vacant_name('temp')
 
-                ds, ds_name = mindsdb_env['data_store'].save_datasource(
+                mindsdb_env['data_store'].save_datasource(
                     name=ds_name,
                     source_type=connection,
                     source=where_data['select_data_query']
                 )
                 datasource = mindsdb_env['data_store'].get_datasource_obj(ds_name, raw=True)
-
 
             if 'external_datasource' in where_data:
                 ds_name = where_data['external_datasource']

--- a/mindsdb/api/mongo/responders/insert.py
+++ b/mindsdb/api/mongo/responders/insert.py
@@ -86,8 +86,9 @@ class Responce(Responder):
                 if connection is None:
                     raise Exception("Can't find connection for data source")
 
-                _, ds_name = mindsdb_env['data_store'].save_datasource(
-                    name=doc['name'],
+                ds_name = mindsdb_env['data_store'].get_vacant_name(doc['name'])
+                mindsdb_env['data_store'].save_datasource(
+                    name=ds_name,
                     source_type=connection,
                     source=dict(doc['select_data_query'])
                 )

--- a/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/integration_datanode.py
+++ b/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/integration_datanode.py
@@ -1,5 +1,3 @@
-import time
-
 import pandas as pd
 from moz_sql_parser import format
 
@@ -48,7 +46,8 @@ class IntegrationDataNode(DataNode):
 
         query = format(format_data)
 
-        ds, ds_name = self.data_store.save_datasource(f'temp_ds_{int(time.time()*100)}', self.integration_name, {'query': query})
+        ds_name = self.data_store.get_vacant_name('temp')
+        self.data_store.save_datasource(ds_name, self.integration_name, {'query': query})
         dso = self.data_store.get_datasource_obj(ds_name)
 
         data = dso.df.to_dict(orient='records')

--- a/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
+++ b/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
@@ -119,8 +119,8 @@ class MindsDBDataNode(DataNode):
         query = aitable_record.integration_query
         predictor_name = aitable_record.predictor_name
 
-
-        ds, ds_name = self.data_store.save_datasource('temp_ds', integration, {'query': query})
+        ds_name = self.data_store.get_vacant_name('temp')
+        self.data_store.save_datasource(ds_name, integration, {'query': query})
         dso = self.data_store.get_datasource_obj(ds_name, raw=True)
         res = self.model_interface.predict(predictor_name, 'dict', when_data=dso)
         self.data_store.delete_datasource(ds_name)
@@ -274,9 +274,9 @@ class MindsDBDataNode(DataNode):
                             pred_dicts[i][col] = where_data[i][col]
 
             if isinstance(where_data, dict):
-                    for col in where_data:
-                        if col not in predicted_columns:
-                            pred_dicts[0][col] = where_data[col]
+                for col in where_data:
+                    if col not in predicted_columns:
+                        pred_dicts[0][col] = where_data[col]
 
             keys = [x for x in pred_dicts[0] if x in columns]
             min_max_keys = []

--- a/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
+++ b/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
@@ -26,7 +26,6 @@ from collections import OrderedDict
 from functools import partial
 import select
 import base64
-import time
 
 import moz_sql_parser as sql_parser
 
@@ -406,7 +405,8 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
                 ).send()
                 return
             insert['select_data_query'] = insert['select_data_query'].replace(r"\'", "'")
-            ds, ds_name = data_store.save_datasource(insert['name'], integration, {'query': insert['select_data_query']})
+            ds_name = data_store.get_vacant_name(insert['name'])
+            ds = data_store.save_datasource(ds_name, integration, {'query': insert['select_data_query']})
         elif is_external_datasource:
             ds = data_store.get_datasource_obj(insert['external_datasource'], raw=True)
             ds_name = insert['external_datasource']
@@ -469,10 +469,10 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
         is_temp_ds = False
         ds_name = struct.get('datasource_name')
         if ds_name is None:
-            ds_name = f'temp_ds_{int(time.time()*100)}'
+            ds_name = data_store.get_vacant_name('temp')
             is_temp_ds = True
 
-        ds, ds_name = data_store.save_datasource(ds_name, struct['integration_name'], {'query': struct['select']})
+        ds = data_store.save_datasource(ds_name, struct['integration_name'], {'query': struct['select']})
         ds_data = data_store.get_datasource(ds_name)
 
         # TODO add alias here

--- a/mindsdb/interfaces/datastore/datastore.py
+++ b/mindsdb/interfaces/datastore/datastore.py
@@ -314,7 +314,7 @@ class DataStore():
                 pass
             raise e
 
-        return self.get_datasource_obj(name, raw=True, company_id=company_id), name
+        return self.get_datasource_obj(name, raw=True, company_id=company_id)
 
     def get_datasource_obj(self, name, raw=False, id=None, company_id=None):
         try:

--- a/mindsdb/interfaces/datastore/datastore.py
+++ b/mindsdb/interfaces/datastore/datastore.py
@@ -123,6 +123,21 @@ class DataStore():
         except Exception:
             pass
 
+    def get_vacant_name(self, base=None, company_id=None):
+        ''' returns name of datasource, which starts from 'base' and ds with that name is not exists yet
+        '''
+        if base is None:
+            base = 'datasource'
+        datasources = session.query(Datasource).filter_by(company_id=company_id).all()
+        datasources_names = [x.name for x in datasources]
+        if base not in datasources_names:
+            return base
+        for i in range(1, 1000):
+            candidate = f'{base}_{i}'
+            if candidate not in datasources_names:
+                return candidate
+        raise Exception(f"Can not find appropriate name for datasource '{base}'")
+
     def save_datasource(self, name, source_type, source, file_path=None, company_id=None):
         if source_type == 'file' and (file_path is None):
             raise Exception('`file_path` argument required when source_type == "file"')


### PR DESCRIPTION
**why**

to fix https://github.com/mindsdb/mindsdb/issues/1204
In some cases we need raise error if name of creating datasource is exists (e.g. creating datasource through http api), in some other cases we need create ds name on fly (e.g. creating temp ds for 'range' query).

**how**