### PR TITLE
Fix amis

### DIFF
--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -175,7 +175,6 @@ jobs:
 
   deploy_version_file:
     runs-on: ubuntu-latest
-    needs: build_amis_packer
     if: github.ref == 'refs/heads/stable' && github.actor != 'mindsdbadmin'
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,31 +6,6 @@ on:
 
 jobs:
 
-  deploy_version_file:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.7'
-    - name: Deploy version files
-      run: |
-        python deploy_version.py release
-
-    - name: Sync linux sh installer to s3
-      uses: jakejarvis/s3-sync-action@master
-      with:
-        args: --acl public-read --follow-symlinks
-      env:
-        AWS_S3_BUCKET: 'mindsdb-installer'
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_REGION: 'us-west-2'
-        SOURCE_DIR: 'distributions/ver/dist'
-        DEST_DIR: 'mindsdb-installer/ver'
-
-
   build_amis_packer:
    #TODO: in the future migrate to https://github.com/hashicorp/packer-github-actions, when we can send config as an url
       runs-on: ubuntu-latest
@@ -55,3 +30,27 @@ jobs:
           cd mindsdb_gateway/deployments
           echo "Building AMIs for $MINDSDB_VERSION"
           sudo packer build -var "mindsdb_version=$MINDSDB_VERSION" -var "acces_key=$ACCESS_KEY" -var "aws_acces_key=$AWS_ACCESS_KEY" -var "aws_secret_key=$AWS_SECRET_KEY" config.json
+
+  deploy_version_file:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.7'
+    - name: Deploy version files
+      run: |
+        python deploy_version.py release
+
+    - name: Sync linux sh installer to s3
+      uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read --follow-symlinks
+      env:
+        AWS_S3_BUCKET: 'mindsdb-installer'
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-west-2'
+        SOURCE_DIR: 'distributions/ver/dist'
+        DEST_DIR: 'mindsdb-installer/ver'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ jobs:
   build_amis_packer:
    #TODO: in the future migrate to https://github.com/hashicorp/packer-github-actions, when we can send config as an url
       runs-on: ubuntu-latest
-      needs: deploy_version_file
       if: github.ref == 'refs/heads/stable' && github.actor != 'mindsdbadmin'
       steps:
       - uses: actions/checkout@v2
@@ -33,6 +32,7 @@ jobs:
 
   deploy_version_file:
     runs-on: ubuntu-latest
+    needs: build_amis_packer
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python


### PR DESCRIPTION
Fixes #1283 

This PR changes the deploy_version_file job to depenends on build_amis job. If the second fails (usually on building GPUs) the version file shouldn't be deployed.