### PR TITLE
Refactor streams

### DIFF
--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -68,32 +68,33 @@ if __name__ == '__main__':
 
     # @TODO Backwards compatibiltiy for tests, remove later
     from mindsdb.interfaces.database.integrations import add_db_integration, get_db_integration
+
     dbw = DatabaseWrapper(COMPANY_ID)
     model_interface = ModelInterface()
-    raw_model_data_arr = model_interface.get_models()
+
     model_data_arr = []
-    for model in raw_model_data_arr:
+    for model in model_interface.get_models():
         if model['status'] == 'complete':
-            x = model_interface.get_model_data(model['name'])
             try:
                 model_data_arr.append(model_interface.get_model_data(model['name']))
             except Exception:
-                pass
-    for integration_name in get_db_integrations(COMPANY_ID, sensitive_info=True):
-        print(f"Setting up integration: {integration_name}")
-        dbw.setup_integration(integration_name)
+                log.error('get_model_data() failed for model "{}"'.format(model['name']))
 
     for integration_name in config.get('integrations', {}):
-        print(f'Adding: {integration_name}')
         try:
-            it = get_db_integration(integration_name, None)
-            if it is None:
+            if get_db_integration(integration_name, COMPANY_ID) is None:
+                print(f'Adding: "{integration_name}" from config["integrations"]')
                 add_db_integration(integration_name, config['integrations'][integration_name], None)            # Setup for user `None`, since we don't need this for cloud
-            if config['integrations'][integration_name].get('publish', False):
-                dbw.setup_integration(integration_name)
-                dbw.register_predictors(model_data_arr, integration_name=integration_name)
+            else:
+                print(f'Ignoring "{integration_name}" from config["integrations"] (already exists in DB)')
+
         except Exception as e:
             log.error(f'\n\nError: {e} adding database integration {integration_name}\n\n')
+
+    for integration_name in get_db_integrations(COMPANY_ID, sensitive_info=True):
+        print(integration_name)
+        print(f"Setting up integration: {integration_name}")
+        dbw.setup_integration(integration_name)
 
     del model_interface
     del dbw

--- a/mindsdb/api/http/namespaces/stream.py
+++ b/mindsdb/api/http/namespaces/stream.py
@@ -1,44 +1,31 @@
+COMPANY_ID = None
+import re
+from mindsdb.integrations.base import integration
+from mindsdb.api.mongo.responders import company_id
 import os
 from flask import request
 from flask_restx import Resource, abort
-from flask import current_app as ca
 from mindsdb.utilities.log import log
 from mindsdb.api.http.namespaces.configs.streams import ns_conf
 
+import mindsdb.interfaces.storage.db as db
 from mindsdb.interfaces.storage.db import session
-from mindsdb.interfaces.storage.db import Stream as StreamDB
-from mindsdb.streams.base.base_stream import StreamTypes
-
-from mindsdb.interfaces.database.integrations import (
-    get_db_integration,
-)
-
-# def get_integration(name):
-#     integrations = ca.config_obj.get('integrations', {})
-#     return integrations.get(name, {})
-
-def get_predictors():
-    # full_predictors_list = [*request.native_interface.get_models(),*request.custom_models.get_models()]
-    full_predictors_list = [*request.native_interface.get_models()]
-    return [x["name"] for x in full_predictors_list
-            if x["status"] == "complete" and x["current_phase"] == 'Trained']
 
 
 def get_streams():
-    streams = session.query(StreamDB).all()
-    return [to_dict(stream) for stream in streams]
-
-
-def to_dict(stream):
-    return {"connect_info": stream.connection_params,
-            "advanced_info": stream.advanced_params,
-            "type": stream._type,
-            "predictor": stream.predictor,
-            "stream_in": stream.stream_in,
-            "stream_out": stream.stream_out,
-            "stream_anomaly": stream.stream_anomaly,
-            "integration": stream.integration,
-            "name": stream.name}
+    streams = db.session.query(db.Stream).filter_by(company_id=COMPANY_ID).all()
+    streams_as_dicts = []
+    for s in streams:
+        streams_as_dicts.append({
+            'name': s.name,
+            'predictor': s.predictor,
+            'integration': s.integration,
+            'connection_info': s.connection_info,
+            'stream_in': s.stream_in,
+            'stream_out': s.stream_out,
+            'stream_anomaly': s.stream_anomaly,
+        })
+    return streams_as_dicts
 
 
 @ns_conf.route('/')
@@ -53,49 +40,51 @@ class StreamList(Resource):
 class Stream(Resource):
     @ns_conf.doc("get_stream")
     def get(self, name):
-        streams = get_streams()
-        for stream in streams:
-            if stream["name"] == name:
+        for stream in get_streams():
+            if stream['name'] == name:
                 return stream
-        abort(404, f"Can\'t find steam: {name}")
+        return abort(404, f'Stream "{name}" doesn\'t exist')
 
     @ns_conf.doc("put_stream")
     def put(self, name):
-        params = request.json.get('params')
-        if not isinstance(params, dict):
-            abort(400, "type of 'params' must be dict")
-        for param in ["predictor", "stream_in", "stream_out", "integration_name"]:
-            if param not in params:
-                abort(400, f"'{param}' is missed.")
-        integration_name = params['integration_name']
-        integration_info = get_db_integration(integration_name, request.company_id, False)
-        if not integration_info:
-            abort(400, f"integration '{integration_name}' doesn't exist.")
-        if integration_info["type"] not in ['redis', 'kafka']:
-            abort(400, f"only integration of redis or kafka might be used to crate redis streams. got: '{integration_info.type}' type")
-        connection_params = params.get('connect', {})
-        advanced_params = params.get('advanced', {})
-        predictor = params['predictor']
-        stream_in = params['stream_in']
-        stream_out = params['stream_out']
-        stream_anomaly = params.get('stream_anomaly', stream_out)
-        _type = params.get('type', 'forecast')
-        if predictor not in get_predictors():
-            abort(400, f"requested predictor '{predictor}' is not ready or doens't exist")
-        stream = StreamDB(_type=_type, name=name, connection_params=connection_params, advanced_params=advanced_params,
-                          predictor=predictor, stream_in=stream_in, stream_out=stream_out,
-                          integration=integration_name, company_id=request.company_id, stream_anomaly=stream_anomaly)
+        for param in ['name', 'integration', 'predictor', 'connection_info', 'stream_in', 'stream_out', 'stream_anomaly']:
+            if param not in request.json.keys():
+                return abort(400, 'Please provide "{}"'.format(param))
 
+        if db.session.query(db.Stream).filter_by(company_id=COMPANY_ID, name=request.json['name']).first() is not None:
+            return abort(404, 'Stream "{}" already exists'.format(request.json['name']))
+
+        if db.session.query(db.Integration).filter_by(company_id=COMPANY_ID, name=request.json['integration']).first() is None:
+            return abort(404, 'Integration "{}" doesn\'t exist'.format(request.json['integration']))
+
+        if db.session.query(db.Predictor).filter_by(company_id=COMPANY_ID, name=request.json['predictor']).first() is None:
+            return abort(404, 'Predictor "{}" doesn\'t exist'.format(request.json['predictor']))
+
+        stream = db.Stream(
+            company_id=COMPANY_ID,
+            name=request.json['name'],
+            integration=request.json['integration'],
+            predictor=request.json['predictor'],
+            connection_info=request.json['connection_info'],
+            stream_in=request.json['stream_in'],
+            stream_out=request.json['stream_out'],
+            stream_anomaly=request.json['stream_anomaly']
+        )
         session.add(stream)
         session.commit()
-        return {"status": "success", "stream_name": name}, 200
+
+        return {'success': True}, 200
 
     @ns_conf.doc("delete_stream")
     def delete(self, name):
-        try:
-            session.query(StreamDB).filter_by(company_id=request.company_id, name=name).delete()
-            session.commit()
-        except Exception as e:
-            log.error(e)
-            abort(400, str(e))
-        return '', 200
+        if 'name' not in request.json:
+            return abort(400, 'Please provide stream name')
+
+        stream = db.session.query(db.Stream).filter_by(company_id=COMPANY_ID, name=request.json['name']).first()
+        if stream is None:
+            return abort(404, 'Stream "{}" doesn\'t exist'.format(request.json['name']))
+
+        stream.delete()
+        db.session.commit()
+
+        return {"success": True}, 200

--- a/mindsdb/api/http/namespaces/stream.py
+++ b/mindsdb/api/http/namespaces/stream.py
@@ -44,7 +44,7 @@ class Stream(Resource):
 
     @ns_conf.doc("put_stream")
     def put(self, name):
-        for param in ['name', 'integration', 'predictor', 'stream_in', 'stream_out']:
+        for param in ['integration', 'predictor', 'stream_in', 'stream_out']:
             if param not in request.json.keys():
                 return abort(400, 'Please provide "{}"'.format(param))
 
@@ -52,8 +52,8 @@ class Stream(Resource):
         if integration is None:
             return abort(404, 'Integration "{}" doesn\'t exist'.format(request.json['integration']))
 
-        if db.session.query(db.Stream).filter_by(company_id=request.company_id, name=request.json['name']).first() is not None:
-            return abort(404, 'Stream "{}" already exists'.format(request.json['name']))
+        if db.session.query(db.Stream).filter_by(company_id=request.company_id, name=name).first() is not None:
+            return abort(404, 'Stream "{}" already exists'.format(name))
 
         if db.session.query(db.Predictor).filter_by(company_id=request.company_id, name=request.json['predictor']).first() is None:
             return abort(404, 'Predictor "{}" doesn\'t exist'.format(request.json['predictor']))
@@ -66,7 +66,7 @@ class Stream(Resource):
 
         stream = db.Stream(
             company_id=request.company_id,
-            name=request.json['name'],
+            name=name,
             integration=request.json['integration'],
             predictor=request.json['predictor'],
             stream_in=request.json['stream_in'],
@@ -79,12 +79,9 @@ class Stream(Resource):
 
     @ns_conf.doc("delete_stream")
     def delete(self, name):
-        if 'name' not in request.json:
-            return abort(400, 'Please provide stream name')
-
-        stream = db.session.query(db.Stream).filter_by(company_id=request.company_id, name=request.json['name']).first()
+        stream = db.session.query(db.Stream).filter_by(company_id=request.company_id, name=name).first()
         if stream is None:
-            return abort(404, 'Stream "{}" doesn\'t exist'.format(request.json['name']))
+            return abort(404, 'Stream "{}" doesn\'t exist'.format(name))
 
         stream.delete()
         db.session.commit()

--- a/mindsdb/api/http/namespaces/stream.py
+++ b/mindsdb/api/http/namespaces/stream.py
@@ -1,8 +1,4 @@
-COMPANY_ID = None
-import re
-from mindsdb.integrations.base import integration
-from mindsdb.api.mongo.responders import company_id
-import os
+from mindsdb.interfaces.database.integrations import get_db_integration
 from flask import request
 from flask_restx import Resource, abort
 from mindsdb.utilities.log import log
@@ -12,15 +8,17 @@ import mindsdb.interfaces.storage.db as db
 from mindsdb.interfaces.storage.db import session
 
 
+STREAM_INTEGRATION_TYPES = ('kafka', 'redis')
+
+
 def get_streams():
-    streams = db.session.query(db.Stream).filter_by(company_id=COMPANY_ID).all()
+    streams = db.session.query(db.Stream).filter_by(company_id=request.company_id).all()
     streams_as_dicts = []
     for s in streams:
         streams_as_dicts.append({
             'name': s.name,
             'predictor': s.predictor,
             'integration': s.integration,
-            'connection_info': s.connection_info,
             'stream_in': s.stream_in,
             'stream_out': s.stream_out,
             'stream_anomaly': s.stream_anomaly,
@@ -47,25 +45,31 @@ class Stream(Resource):
 
     @ns_conf.doc("put_stream")
     def put(self, name):
-        for param in ['name', 'integration', 'predictor', 'connection_info', 'stream_in', 'stream_out', 'stream_anomaly']:
+        for param in ['name', 'integration', 'predictor', 'stream_in', 'stream_out', 'stream_anomaly']:
             if param not in request.json.keys():
                 return abort(400, 'Please provide "{}"'.format(param))
 
-        if db.session.query(db.Stream).filter_by(company_id=COMPANY_ID, name=request.json['name']).first() is not None:
-            return abort(404, 'Stream "{}" already exists'.format(request.json['name']))
-
-        if db.session.query(db.Integration).filter_by(company_id=COMPANY_ID, name=request.json['integration']).first() is None:
+        integration = get_db_integration(request.json['integration'], request.company_id)
+        if integration is None:
             return abort(404, 'Integration "{}" doesn\'t exist'.format(request.json['integration']))
 
-        if db.session.query(db.Predictor).filter_by(company_id=COMPANY_ID, name=request.json['predictor']).first() is None:
+        if db.session.query(db.Stream).filter_by(company_id=request.company_id, name=request.json['name']).first() is not None:
+            return abort(404, 'Stream "{}" already exists'.format(request.json['name']))
+
+        if db.session.query(db.Predictor).filter_by(company_id=request.company_id, name=request.json['predictor']).first() is None:
             return abort(404, 'Predictor "{}" doesn\'t exist'.format(request.json['predictor']))
 
+        if integration['type'] not in STREAM_INTEGRATION_TYPES:
+            return abort(400, 'Integration "{}" is not of type [{}]'.format(
+                request.json['integration'],
+                '/'.join(STREAM_INTEGRATION_TYPES)
+            ))
+
         stream = db.Stream(
-            company_id=COMPANY_ID,
+            company_id=request.company_id,
             name=request.json['name'],
             integration=request.json['integration'],
             predictor=request.json['predictor'],
-            connection_info=request.json['connection_info'],
             stream_in=request.json['stream_in'],
             stream_out=request.json['stream_out'],
             stream_anomaly=request.json['stream_anomaly']
@@ -80,7 +84,7 @@ class Stream(Resource):
         if 'name' not in request.json:
             return abort(400, 'Please provide stream name')
 
-        stream = db.session.query(db.Stream).filter_by(company_id=COMPANY_ID, name=request.json['name']).first()
+        stream = db.session.query(db.Stream).filter_by(company_id=request.company_id, name=request.json['name']).first()
         if stream is None:
             return abort(404, 'Stream "{}" doesn\'t exist'.format(request.json['name']))
 

--- a/mindsdb/api/http/namespaces/stream.py
+++ b/mindsdb/api/http/namespaces/stream.py
@@ -21,7 +21,6 @@ def get_streams():
             'integration': s.integration,
             'stream_in': s.stream_in,
             'stream_out': s.stream_out,
-            'stream_anomaly': s.stream_anomaly,
         })
     return streams_as_dicts
 
@@ -45,7 +44,7 @@ class Stream(Resource):
 
     @ns_conf.doc("put_stream")
     def put(self, name):
-        for param in ['name', 'integration', 'predictor', 'stream_in', 'stream_out', 'stream_anomaly']:
+        for param in ['name', 'integration', 'predictor', 'stream_in', 'stream_out']:
             if param not in request.json.keys():
                 return abort(400, 'Please provide "{}"'.format(param))
 
@@ -72,7 +71,6 @@ class Stream(Resource):
             predictor=request.json['predictor'],
             stream_in=request.json['stream_in'],
             stream_out=request.json['stream_out'],
-            stream_anomaly=request.json['stream_anomaly']
         )
         session.add(stream)
         session.commit()

--- a/mindsdb/integrations/base/integration.py
+++ b/mindsdb/integrations/base/integration.py
@@ -1,6 +1,4 @@
-COMPANY_ID = None
 import os
-from re import S
 from threading import Thread
 
 from mindsdb.utilities.config import STOP_THREADS_EVENT
@@ -35,8 +33,9 @@ class StreamIntegration(Integration):
         Thread(target=StreamIntegration._loop, args=(self, )).start()
 
     def _loop(self):
+        company_id = os.environ.get('MINDSDB_COMPANY_ID', None)
         while not STOP_THREADS_EVENT.wait(1.0):
-            stream_db_recs = db.session.query(db.Stream).filter_by(company_id=COMPANY_ID, integration=self.name).all()
+            stream_db_recs = db.session.query(db.Stream).filter_by(company_id=company_id, integration=self.name).all()
 
             # Stop streams that weren't found in DB
             indices_to_delete = []
@@ -59,14 +58,17 @@ class StreamIntegration(Integration):
             s.thread.join()
             print('3s', s)
 
+    def check_connection(self):
+        raise NotImplementedError
+
     def _make_stream(self, s):
         raise NotImplementedError
 
     def _query(self, query, fetch=False):
-        raise NotImplementedError
+        pass
 
     def register_predictors(self, model_data_arr):
-        raise NotImplementedError
+        pass
 
     def unregister_predictor(self, name):
-        raise NotImplementedError
+        pass

--- a/mindsdb/integrations/base/integration.py
+++ b/mindsdb/integrations/base/integration.py
@@ -46,7 +46,6 @@ class StreamIntegration(Integration):
                 if s.name not in map(lambda x: x.name, stream_db_recs):
                     indices_to_delete.append(i)
                     self._streams[i].stop_event.set()
-                    self._streams[i].thread.join()
             self._streams = [s for i, s in enumerate(self._streams) if i not in indices_to_delete]
 
             # Start new streams found in DB
@@ -56,10 +55,6 @@ class StreamIntegration(Integration):
 
         for s in self._streams:
             s.stop_event.set()
-            s.thread.join()
-
-    def check_connection(self):
-        raise NotImplementedError
 
     def _make_stream(self, s: db.Stream):
         raise NotImplementedError

--- a/mindsdb/integrations/clickhouse/clickhouse.py
+++ b/mindsdb/integrations/clickhouse/clickhouse.py
@@ -143,13 +143,3 @@ class Clickhouse(Integration, ClickhouseConnectionChecker):
             drop table if exists {self.mindsdb_database}.{self._escape_table_name(name)};
         """
         self._query(q)
-
-    # def check_connection(self):
-    #     try:
-    #         res = requests.post(f"http://{self.host}:{self.port}",
-    #                             data="select 1;",
-    #                             params={'user': self.user, 'password': self.password})
-    #         connected = res.status_code == 200
-    #     except Exception:
-    #         connected = False
-    #     return connected

--- a/mindsdb/integrations/kafka/kafkadb.py
+++ b/mindsdb/integrations/kafka/kafkadb.py
@@ -1,123 +1,43 @@
-import json
 import kafka
 
-from threading import Thread
 from mindsdb.integrations.base import StreamIntegration
-from mindsdb.streams.kafka.kafka_stream import KafkaStream
-from mindsdb.interfaces.storage.db import session, Stream
-from mindsdb.interfaces.database.integrations import get_db_integration
+from mindsdb.streams import KafkaStream
 
 
 class KafkaConnectionChecker:
-    def __init__(self, **kwargs):
-        self.connection_info = kwargs.get('connection')
-        self.advanced_info = kwargs.get('advanced', {}).get('common', {})
-        self.connection_params = {}
-        self.connection_params.update(self.connection_info)
-        self.connection_params.update(self.advanced_info)
-
-    def _get_connection(self):
-        return kafka.KafkaClient(**self.connection_params)
+    def __init__(self, **params):
+        self.connection_info = {
+            'host': params['host'],
+            'port': params['port'],
+            'password': params['password'],
+        }
 
     def check_connection(self):
         try:
-            client = self._get_connection()
-            client.close()
-            return True
+            client = kafka.KafkaClient(**self.connection_info)
         except Exception:
             return False
+        else:
+            client.close()
+            return True
 
 
-class Kafka(StreamIntegration, KafkaConnectionChecker):
+class Kafka(StreamIntegration):
     def __init__(self, config, name, db_info):
         StreamIntegration.__init__(self, config, name)
-        integration_info = get_db_integration(self.name, self.company_id)
-        self.connection_info = integration_info.get('connection')
-        self.advanced_info = integration_info.get('advanced', {})
-        self.advanced_common = self.advanced_info.get('common', {})
-        self.connection_params = {}
-        self.connection_params.update(self.connection_info)
-        self.connection_params.update(self.advanced_common)
+        self.connection_info = {
+            'host': db_info['host'],
+            'port': db_info['port'],
+            'password': db_info['password'],
+        }
 
-        self.control_topic_name = integration_info.get('topic', None)
-        self.client = self._get_connection()
-
-    def start(self):
-        Thread(target=Kafka.work, args=(self, )).start()
-
-    def start_stored_streams(self):
-        existed_streams = session.query(Stream).filter_by(company_id=self.company_id, integration=self.name)
-
-        for stream in existed_streams:
-            if stream.name not in self.streams:
-                to_launch = self.get_stream_from_db(stream)
-                params = {"integration": stream.integration,
-                          "predictor": stream.predictor,
-                          "stream_in": stream.stream_in,
-                          "stream_out": stream.stream_out,
-                          "type": stream._type}
-
-                self.log.error(f"Integration {self.name} - launching from db : {params}")
-                to_launch.start()
-                self.streams[stream.name] = to_launch.stop_event
-
-    def work(self):
-        if self.control_topic_name is not None:
-            self.consumer = kafka.KafkaConsumer(**self.connection_params, **self.advanced_info.get('consumer', {}))
-
-            self.consumer.subscribe([self.control_topic_name])
-            self.log.error(f"Integration {self.name}: subscribed  to {self.control_topic_name} kafka topic")
-        else:
-            self.consumer = None
-            self.log.error(f"Integration {self.name}: worked mode - DB only.")
-
-        while not self.stop_event.wait(0.5):
-            try:
-                # break if no record about this integration has found in db
-                if not self.exist_in_db():
-                    self.delete_all_streams()
-                    break
-                self.start_stored_streams()
-                self.stop_deleted_streams()
-                if self.consumer is not None:
-                    try:
-                        msg_str = next(self.consumer)
-
-                        stream_params = json.loads(msg_str.value)
-                        stream = self.get_stream_from_kwargs(**stream_params)
-                        stream.start()
-                        # store created stream in database
-                        self.store_stream(stream)
-                    except StopIteration:
-                        pass
-            except Exception as e:
-                self.log.error(f"Integration {self.name} main loop error: {e}")
-
-        # received exit event
-        if self.consumer:
-            self.consumer.close()
-        self.stop_streams()
-        session.close()
-        self.log.error(f"Integration {self.name}: exiting...")
-
-    def store_stream(self, stream):
-        """Stories a created stream."""
-        stream_rec = Stream(name=stream.stream_name, connection_params=self.connection_params, advanced_params=self.advanced_info,
-                            _type=stream._type, predictor=stream.predictor,
-                            integration=self.name, company_id=self.company_id,
-                            stream_in=stream.stream_in_name, stream_out=stream.stream_out_name,
-                            stream_anomaly=stream.stream_anomaly_name)
-        session.add(stream_rec)
-        session.commit()
-        self.streams[stream.stream_name] = stream.stop_event
-
-    def get_stream_from_kwargs(self, **kwargs):
-        name = kwargs.get('name')
-        topic_in = kwargs.get('input_stream')
-        topic_out = kwargs.get('output_stream')
-        topic_anomaly = kwargs.get('anomaly_stream', topic_out)
-        predictor_name = kwargs.get('predictor')
-        stream_type = kwargs.get('type', 'forecast')
-        return KafkaStream(name, self.connection_params, self.advanced_info,
-                           topic_in, topic_out, topic_anomaly,
-                           predictor_name, stream_type)
+    def _make_stream(self, s):
+        return KafkaStream(
+            s.name,
+            s.predictor,
+            self.connection_info,
+            s.topic_in,
+            s.topic_out,
+            s.topic_anomaly
+        )
+    

--- a/mindsdb/integrations/kafka/kafkadb.py
+++ b/mindsdb/integrations/kafka/kafkadb.py
@@ -23,7 +23,7 @@ class KafkaConnectionChecker:
             return True
 
 
-class Kafka(StreamIntegration):
+class Kafka(StreamIntegration, KafkaConnectionChecker):
     def __init__(self, config, name, db_info):
         StreamIntegration.__init__(self, config, name)
         self.connection_info = {

--- a/mindsdb/integrations/kafka/kafkadb.py
+++ b/mindsdb/integrations/kafka/kafkadb.py
@@ -27,9 +27,7 @@ class Kafka(StreamIntegration):
     def __init__(self, config, name, db_info):
         StreamIntegration.__init__(self, config, name)
         self.connection_info = {
-            'host': db_info['connection']['host'],
-            'port': db_info['connection']['port'],
-            'password': db_info['connection']['password'],
+            'bootstrap_servers': [str(x) for x in db_info['connection']['bootstrap_servers']]
         }
 
     def _make_stream(self, s: db.Stream):

--- a/mindsdb/integrations/kafka/kafkadb.py
+++ b/mindsdb/integrations/kafka/kafkadb.py
@@ -35,8 +35,8 @@ class Kafka(StreamIntegration, KafkaConnectionChecker):
             s.name,
             s.predictor,
             self.connection_info,
-            s.topic_in,
-            s.topic_out,
-            s.topic_anomaly
+            s.stream_in,
+            s.stream_out,
+            s.stream_anomaly
         )
     

--- a/mindsdb/integrations/kafka/kafkadb.py
+++ b/mindsdb/integrations/kafka/kafkadb.py
@@ -1,15 +1,16 @@
 import kafka
 
 from mindsdb.integrations.base import StreamIntegration
-from mindsdb.streams import KafkaStream
+import mindsdb.interfaces.storage.db as db
+import mindsdb.streams
 
 
 class KafkaConnectionChecker:
     def __init__(self, **params):
         self.connection_info = {
-            'host': params['host'],
-            'port': params['port'],
-            'password': params['password'],
+            'host': params['connection']['host'],
+            'port': params['connection']['port'],
+            'password': params['connection']['password'],
         }
 
     def check_connection(self):
@@ -26,13 +27,13 @@ class Kafka(StreamIntegration):
     def __init__(self, config, name, db_info):
         StreamIntegration.__init__(self, config, name)
         self.connection_info = {
-            'host': db_info['host'],
-            'port': db_info['port'],
-            'password': db_info['password'],
+            'host': db_info['connection']['host'],
+            'port': db_info['connection']['port'],
+            'password': db_info['connection']['password'],
         }
 
-    def _make_stream(self, s):
-        return KafkaStream(
+    def _make_stream(self, s: db.Stream):
+        return mindsdb.streams.KafkaStream(
             s.name,
             s.predictor,
             self.connection_info,

--- a/mindsdb/integrations/kafka/kafkadb.py
+++ b/mindsdb/integrations/kafka/kafkadb.py
@@ -36,7 +36,6 @@ class Kafka(StreamIntegration, KafkaConnectionChecker):
             s.predictor,
             self.connection_info,
             s.stream_in,
-            s.stream_out,
-            s.stream_anomaly
+            s.stream_out
         )
     

--- a/mindsdb/integrations/redis/redisdb.py
+++ b/mindsdb/integrations/redis/redisdb.py
@@ -1,15 +1,16 @@
 import walrus
 
 from mindsdb.integrations.base import StreamIntegration
-from mindsdb.streams import RedisStream
+import mindsdb.interfaces.storage.db as db
+import mindsdb.streams
 
 
 class RedisConnectionChecker:
     def __init__(self, **params):
         self.connection_info = {
-            'host': params['host'],
-            'port': params['port'],
-            'password': params['password'],
+            'host': params['connection']['host'],
+            'port': params['connection']['port'],
+            'password': params['connection']['password'],
         }
 
     def check_connection(self):
@@ -26,13 +27,13 @@ class Redis(StreamIntegration):
     def __init__(self, config, name, db_info):
         StreamIntegration.__init__(self, config, name)
         self.connection_info = {
-            'host': db_info['host'],
-            'port': db_info['port'],
-            'password': db_info['password'],
+            'host': db_info['connection']['host'],
+            'port': db_info['connection']['port'],
+            'password': db_info['connection']['password'],
         }
     
-    def _make_stream(self, s):
-        return RedisStream(
+    def _make_stream(self, s: db.Stream):
+        return mindsdb.streams.RedisStream(
             s.name,
             s.predictor,
             self.connection_info,

--- a/mindsdb/integrations/redis/redisdb.py
+++ b/mindsdb/integrations/redis/redisdb.py
@@ -1,23 +1,15 @@
-from threading import Thread
 import walrus
+
 from mindsdb.integrations.base import StreamIntegration
 from mindsdb.streams.redis.redis_stream import RedisStream
-from mindsdb.streams.base.base_stream import StreamTypes
-
-from mindsdb.interfaces.storage.db import session, Stream
-from mindsdb.interfaces.database.integrations import get_db_integration
 
 
 class RedisConnectionChecker:
-    def __init__(self, **kwargs):
-        self.connection_info = kwargs.get("connection", {})
-        self.advanced_info = kwargs.get("advanced", {})
-        self.connection_params = {}
-        self.connection_params.update(self.connection_info)
-        self.connection_params.update(self.advanced_info)
+    def __init__(self, connection_info):
+        self.connection_info = connection_info
 
     def _get_connection(self):
-        return walrus.Database(**self.connection_params)
+        return walrus.Database(**self.connection_info)
 
     def check_connection(self):
         client = self._get_connection()
@@ -29,115 +21,8 @@ class RedisConnectionChecker:
 
 
 class Redis(StreamIntegration, RedisConnectionChecker):
-    """Redis Integration which is more a Streams factory
-    than classical Integration."""
     def __init__(self, config, name, db_info):
         StreamIntegration.__init__(self, config, name)
-        integration_info = get_db_integration(self.name, self.company_id)
-
-        self.connection_info = integration_info.get("connection", {})
-        self.advanced_info = integration_info.get("advanced", {})
-        self.connection_params = {}
-        self.connection_params.update(self.connection_info)
-        self.connection_params.update(self.advanced_info)
-        self.client = self._get_connection()
-
-
-        self.control_stream_name = integration_info.get('stream')
-        self.control_stream = self.client.Stream(self.control_stream_name)
-
-    def start(self):
-        Thread(target=Redis.work, args=(self, )).start()
-
-    def start_stored_streams(self):
-        existed_streams = session.query(Stream).filter_by(company_id=self.company_id, integration=self.name)
-
-        for stream in existed_streams:
-            to_launch = self.get_stream_from_db(stream)
-            if stream.name not in self.streams:
-                params = {"integration": stream.integration,
-                          "predictor": stream.predictor,
-                          "stream_in": stream.stream_in,
-                          "stream_out": stream.stream_out,
-                          "type": stream._type}
-
-                self.log.error(f"Integration {self.name} - launching from db : {params}")
-                to_launch.start()
-                self.streams[stream.name] = to_launch.stop_event
-
-    def work(self):
-        """Creates a Streams by receiving initial information from control stream."""
-        self.log.error(f"INTEGRATION HAS BEEN CREATED: {self.connection_params}")
-        self.log.error(f"Integration {self.name}: start listening {self.control_stream_name} redis stream")
-        while not self.stop_event.wait(0.5):
-            try:
-                # break if no record about this integration has found in db
-                if not self.exist_in_db():
-                    self.delete_all_streams()
-                    break
-                # First, lets check that there are no new records in db, created via HTTP API for e.g.
-                self.start_stored_streams()
-                # stop streams which have been deleted from db.
-                self.stop_deleted_streams()
-                # Checking new incoming records(requests) for new stream.
-                # Could't use blocking reading here, because this loop must
-                # also check new records in db (created via HTTP api for e.g)
-                recs = self.control_stream.read()
-                for r in recs:
-                    r_id = r[0]
-                    binary_r = r[1]
-                    stream_params = self._decode(binary_r)
-                    if "input_stream" not in stream_params or "output_stream" not in stream_params:
-                        self.delete_stream(stream_params['predictor'])
-                        self.control_stream.delete(r_id)
-                        continue
-
-                    stream_params['name'] = f"{self.name}_{stream_params['predictor']}"
-                    stream = self.get_stream_from_kwargs(**stream_params)
-                    self.log.error(f"Integration {self.name}: creating stream: {stream_params}")
-                    stream.start()
-                    # store created stream in database
-                    self.store_stream(stream)
-                    # need to delete record which steam is already created
-                    self.control_stream.delete(r_id)
-            except Exception as e:
-                self.log.error(f"Integration {self.name}: {e}")
-                raise e
-
-        # received exit event
-        self.log.error(f"Integration {self.name}: exiting...")
-        self.client.close()
-        self.stop_streams()
-        session.close()
-
-    def store_stream(self, stream):
-        """Stories a created stream."""
-        stream_rec = Stream(name=stream.stream_name, connection_params=self.connection_info, advanced_params=self.advanced_info,
-                            _type=stream._type, predictor=stream.predictor,
-                            integration=self.name, company_id=self.company_id,
-                            stream_in=stream.stream_in_name, stream_out=stream.stream_out_name, stream_anomaly=stream.stream_anomaly_name)
-        session.add(stream_rec)
-        session.commit()
-        self.streams[stream.stream_name] = stream.stop_event
-
-
-    def get_stream_from_kwargs(self, **kwargs):
-        name = kwargs.get('name')
-        stream_in = kwargs.get('input_stream')
-        stream_out = kwargs.get('output_stream')
-        stream_anomaly = kwargs.get('anomaly_stream', stream_out)
-        predictor_name = kwargs.get('predictor')
-        stream_type = kwargs.get('type', 'forecast')
-        return RedisStream(name, self.connection_info, self.advanced_info,
-                           stream_in, stream_out, stream_anomaly, predictor_name,
-                           stream_type)
-
-    def _decode(self, b_dict):
-        """convert binary key/value into strings"""
-        decoded = {}
-        if not isinstance(b_dict, dict):
-            self.log.error(f"Integration {self.name}: got unexpected data format from redis control stream {self.control_stream_name}: {b_dict}")
-            return {}
-        for k in b_dict:
-            decoded[k.decode('utf8')] = b_dict[k].decode('utf8')
-        return decoded
+    
+    def _make_stream(self, s):
+        return RedisStream(s.name, s.predictor, s.connection_info, s.stream_in, s.stream_out, s.stream_anomaly)

--- a/mindsdb/integrations/redis/redisdb.py
+++ b/mindsdb/integrations/redis/redisdb.py
@@ -39,5 +39,4 @@ class Redis(StreamIntegration, RedisConnectionChecker):
             self.connection_info,
             s.stream_in,
             s.stream_out,
-            s.stream_anomaly
         )

--- a/mindsdb/integrations/redis/redisdb.py
+++ b/mindsdb/integrations/redis/redisdb.py
@@ -1,28 +1,42 @@
 import walrus
 
 from mindsdb.integrations.base import StreamIntegration
-from mindsdb.streams.redis.redis_stream import RedisStream
+from mindsdb.streams import RedisStream
 
 
 class RedisConnectionChecker:
-    def __init__(self, connection_info):
-        self.connection_info = connection_info
-
-    def _get_connection(self):
-        return walrus.Database(**self.connection_info)
+    def __init__(self, **params):
+        self.connection_info = {
+            'host': params['host'],
+            'port': params['port'],
+            'password': params['password'],
+        }
 
     def check_connection(self):
-        client = self._get_connection()
         try:
+            client = walrus.Database(**self.connection_info)
             client.dbsize()
-            return True
         except Exception:
+            return False
+        else:
             return False
 
 
-class Redis(StreamIntegration, RedisConnectionChecker):
+class Redis(StreamIntegration):
     def __init__(self, config, name, db_info):
         StreamIntegration.__init__(self, config, name)
+        self.connection_info = {
+            'host': db_info['host'],
+            'port': db_info['port'],
+            'password': db_info['password'],
+        }
     
     def _make_stream(self, s):
-        return RedisStream(s.name, s.predictor, s.connection_info, s.stream_in, s.stream_out, s.stream_anomaly)
+        return RedisStream(
+            s.name,
+            s.predictor,
+            self.connection_info,
+            s.stream_in,
+            s.stream_out,
+            s.stream_anomaly
+        )

--- a/mindsdb/integrations/redis/redisdb.py
+++ b/mindsdb/integrations/redis/redisdb.py
@@ -23,7 +23,7 @@ class RedisConnectionChecker:
             return False
 
 
-class Redis(StreamIntegration):
+class Redis(StreamIntegration, RedisConnectionChecker):
     def __init__(self, config, name, db_info):
         StreamIntegration.__init__(self, config, name)
         self.connection_info = {

--- a/mindsdb/interfaces/database/database.py
+++ b/mindsdb/interfaces/database/database.py
@@ -7,7 +7,6 @@ from mindsdb.integrations.mssql.mssql import MSSQL
 from mindsdb.integrations.mongodb.mongodb import MongoDB
 from mindsdb.integrations.redis.redisdb import Redis
 from mindsdb.integrations.kafka.kafkadb import Kafka
-from mindsdb.integrations import CHECKERS
 
 from mindsdb.utilities.log import log as logger
 from mindsdb.utilities.config import Config
@@ -67,7 +66,7 @@ class DatabaseWrapper():
             integrations = [] if isinstance(integration, bool) else [integration]
 
         for integration in integrations:
-            if CHECKERS[integration['type']](**integration['connection']).check_connection():
+            if integration.check_connection():
                 try:
                     integration.register_predictors(model_data_arr)
                 except Exception as e:
@@ -81,7 +80,7 @@ class DatabaseWrapper():
             # !!! Integrations from config.json add to db on each start!!!!
             if '@@@@@' in name:
                 name = name.split('@@@@@')[1]
-            if CHECKERS[integration['type']](**integration['connection']).check_connection():
+            if integration.check_connection():
                 integration.unregister_predictor(name)
             else:
                 logger.warning(f"There is no connection to {integration.name}. predictor wouldn't be unregistred")
@@ -89,6 +88,6 @@ class DatabaseWrapper():
     def check_connections(self):
         connections = {}
         for integration in self._get_integrations():
-            connections[integration.name] = CHECKERS[integration['type']](**integration['connection']).check_connection()
+            connections[integration.name] = integration.check_connection()
 
         return connections

--- a/mindsdb/interfaces/database/database.py
+++ b/mindsdb/interfaces/database/database.py
@@ -1,3 +1,4 @@
+import traceback
 from mindsdb.integrations.clickhouse.clickhouse import Clickhouse
 from mindsdb.integrations.postgres.postgres import PostgreSQL
 from mindsdb.integrations.mariadb.mariadb import Mariadb
@@ -35,6 +36,7 @@ class DatabaseWrapper():
             if integration is not True:
                 integration.setup()
         except Exception as e:
+            traceback.print_exc()
             logger.warning('Failed to integrate with database ' + db_alias + f', error: {e}')
 
     def _get_integration(self, db_alias):

--- a/mindsdb/interfaces/database/database.py
+++ b/mindsdb/interfaces/database/database.py
@@ -7,6 +7,7 @@ from mindsdb.integrations.mssql.mssql import MSSQL
 from mindsdb.integrations.mongodb.mongodb import MongoDB
 from mindsdb.integrations.redis.redisdb import Redis
 from mindsdb.integrations.kafka.kafkadb import Kafka
+from mindsdb.integrations import CHECKERS
 
 from mindsdb.utilities.log import log as logger
 from mindsdb.utilities.config import Config
@@ -66,7 +67,7 @@ class DatabaseWrapper():
             integrations = [] if isinstance(integration, bool) else [integration]
 
         for integration in integrations:
-            if integration.check_connection():
+            if CHECKERS[integration['type']](**integration['connection']).check_connection():
                 try:
                     integration.register_predictors(model_data_arr)
                 except Exception as e:
@@ -80,7 +81,7 @@ class DatabaseWrapper():
             # !!! Integrations from config.json add to db on each start!!!!
             if '@@@@@' in name:
                 name = name.split('@@@@@')[1]
-            if integration.check_connection():
+            if CHECKERS[integration['type']](**integration['connection']).check_connection():
                 integration.unregister_predictor(name)
             else:
                 logger.warning(f"There is no connection to {integration.name}. predictor wouldn't be unregistred")
@@ -88,6 +89,6 @@ class DatabaseWrapper():
     def check_connections(self):
         connections = {}
         for integration in self._get_integrations():
-            connections[integration.name] = integration.check_connection()
+            connections[integration.name] = CHECKERS[integration['type']](**integration['connection']).check_connection()
 
         return connections

--- a/mindsdb/interfaces/database/database.py
+++ b/mindsdb/interfaces/database/database.py
@@ -36,7 +36,6 @@ class DatabaseWrapper():
             if integration is not True:
                 integration.setup()
         except Exception as e:
-            traceback.print_exc()
             logger.warning('Failed to integrate with database ' + db_alias + f', error: {e}')
 
     def _get_integration(self, db_alias):

--- a/mindsdb/interfaces/storage/db.py
+++ b/mindsdb/interfaces/storage/db.py
@@ -7,6 +7,7 @@ from sqlalchemy import create_engine, orm, types, UniqueConstraint
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, DateTime, Boolean, Index
+from sqlalchemy.sql.expression import null
 from sqlalchemy.sql.schema import ForeignKey
 
 if os.environ['MINDSDB_DB_CON'].startswith('sqlite:'):
@@ -93,7 +94,7 @@ class Predictor(Base):
     id = Column(Integer, primary_key=True)
     updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
     created_at = Column(DateTime, default=datetime.datetime.now)
-    name = Column(String)
+    name = Column(String, unique=True)
     data = Column(Json)  # A JSON -- should be everything returned by `get_model_data`, I think
     to_predict = Column(Array)
     company_id = Column(Integer)
@@ -136,7 +137,7 @@ class Integration(Base):
     id = Column(Integer, primary_key=True)
     updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
     created_at = Column(DateTime, default=datetime.datetime.now)
-    name = Column(String)
+    name = Column(String, nullable=False, unique=True)
     data = Column(Json)
     company_id = Column(Integer)
 
@@ -144,14 +145,13 @@ class Integration(Base):
 class Stream(Base):
     __tablename__ = 'stream'
     id = Column(Integer, primary_key=True)
-    name = Column(String)
-    connection_info = Column(Json)
-    stream_in = Column(String)
-    stream_out = Column(String)
-    stream_anomaly = Column(String)
-    integration = Column(String)
+    name = Column(String, nullable=False, unique=True)
+    stream_in = Column(String, nullable=False)
+    stream_out = Column(String, nullable=False)
+    stream_anomaly = Column(String, nullable=False)
+    integration = Column(String, ForeignKey('integration.name', ondelete='CASCADE'), nullable=False)
+    predictor = Column(String, ForeignKey('predictor.name', ondelete='CASCADE'), nullable=False)
     company_id = Column(Integer)
-    predictor = Column(String)
     updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
     created_at = Column(DateTime, default=datetime.datetime.now)
 

--- a/mindsdb/interfaces/storage/db.py
+++ b/mindsdb/interfaces/storage/db.py
@@ -148,7 +148,6 @@ class Stream(Base):
     name = Column(String, nullable=False, unique=True)
     stream_in = Column(String, nullable=False)
     stream_out = Column(String, nullable=False)
-    stream_anomaly = Column(String, nullable=False)
     integration = Column(String, ForeignKey('integration.name', ondelete='CASCADE'), nullable=False)
     predictor = Column(String, ForeignKey('predictor.name', ondelete='CASCADE'), nullable=False)
     company_id = Column(Integer)

--- a/mindsdb/interfaces/storage/db.py
+++ b/mindsdb/interfaces/storage/db.py
@@ -7,6 +7,7 @@ from sqlalchemy import create_engine, orm, types, UniqueConstraint
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, DateTime, Boolean, Index
+from sqlalchemy.sql.schema import ForeignKey
 
 if os.environ['MINDSDB_DB_CON'].startswith('sqlite:'):
     engine = create_engine(os.environ['MINDSDB_DB_CON'], echo=False)
@@ -130,31 +131,29 @@ class Log(Base):
     created_at_index = Index("some_index", "created_at_index")
 
 
-class Stream(Base):
-    __tablename__ = 'stream'
-    id = Column(Integer, primary_key=True)
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
-    created_at = Column(DateTime, default=datetime.datetime.now)
-    company_id = Column(Integer)
-    _type = Column(String)
-    predictor = Column(String)
-    stream_in = Column(String)
-    stream_out = Column(String)
-    stream_anomaly = Column(String)
-    integration = Column(String)
-    name = Column(String)
-    connection_params = Column(Json)
-    advanced_params = Column(Json)
-
-
 class Integration(Base):
-    __tablename__ = 'integration'
+    __tablename__ = 'integrationq'
     id = Column(Integer, primary_key=True)
     updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
     created_at = Column(DateTime, default=datetime.datetime.now)
     name = Column(String)
     data = Column(Json)
     company_id = Column(Integer)
+
+
+class Stream(Base):
+    __tablename__ = 'streamq'
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    connection_info = Column(Json)
+    stream_in = Column(String)
+    stream_out = Column(String)
+    stream_anomaly = Column(String)
+    integration = Column(String)
+    company_id = Column(Integer)
+    predictor = Column(String)
+    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    created_at = Column(DateTime, default=datetime.datetime.now)
 
 
 Base.metadata.create_all(engine)

--- a/mindsdb/interfaces/storage/db.py
+++ b/mindsdb/interfaces/storage/db.py
@@ -132,7 +132,7 @@ class Log(Base):
 
 
 class Integration(Base):
-    __tablename__ = 'integrationq'
+    __tablename__ = 'integration'
     id = Column(Integer, primary_key=True)
     updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
     created_at = Column(DateTime, default=datetime.datetime.now)
@@ -142,7 +142,7 @@ class Integration(Base):
 
 
 class Stream(Base):
-    __tablename__ = 'streamq'
+    __tablename__ = 'stream'
     id = Column(Integer, primary_key=True)
     name = Column(String)
     connection_info = Column(Json)

--- a/mindsdb/streams/__init__.py
+++ b/mindsdb/streams/__init__.py
@@ -1,0 +1,2 @@
+from .redis import RedisStream
+from .kafka import KafkaStream

--- a/mindsdb/streams/base/__init__.py
+++ b/mindsdb/streams/base/__init__.py
@@ -1,0 +1,1 @@
+from .base_stream import BaseStream

--- a/mindsdb/streams/base/base_stream.py
+++ b/mindsdb/streams/base/base_stream.py
@@ -69,12 +69,6 @@ class BaseStream:
                 )
 
                 if len(cache) >= window:
-                    for when_data in cache[-window:]:
-                        if self.target in when_data:
-                            when_data['make_predictions'] = True
-                        else:
-                            when_data['make_predictions'] = False
-                        
                     res_list = self.native_interface.predict(self.predictor, 'dict', when_data=cache[-window:])
                     self._write_to_out_stream(res_list[-1])
                     cache = cache[1 - window:]
@@ -102,11 +96,6 @@ class BaseStream:
                     )
 
                     if len(gb_cache[gb_value]) >= window:
-                        for when_data in gb_cache[gb_value][-window:]:
-                            if self.target in when_data:
-                                when_data['make_predictions'] = True
-                            else:
-                                when_data['make_predictions'] = False
                         res_list = self.native_interface.predict(self.predictor, 'dict', when_data=gb_cache[gb_value][-window:])
                         self._write_to_out_stream(res_list[-1])
                         gb_cache[gb_value] = gb_cache[gb_value][1 - window:]

--- a/mindsdb/streams/base/base_stream.py
+++ b/mindsdb/streams/base/base_stream.py
@@ -76,8 +76,6 @@ class BaseStream:
             gb_cache = defaultdict(list)
 
             while not self.stop_event.wait(0.5):
-                if len(gb_cache):
-                    print(gb_cache)
                 for when_data in self._read_from_in_stream():
                     for ob in order_by:
                         if ob not in when_data:

--- a/mindsdb/streams/base/base_stream.py
+++ b/mindsdb/streams/base/base_stream.py
@@ -1,34 +1,89 @@
 import os
-from threading import Event
-from mindsdb.interfaces.model.model_interface import ModelInterface as NativeInterface
+from threading import Event, Thread
 
+from mindsdb.interfaces.model.model_interface import ModelInterface
+from collections import defaultdict
+import mindsdb.interfaces.storage.db as db
 
-class StreamTypes:
-    timeseries = "timeseries"
 
 
 class BaseStream:
-    def __init__(self):
-        self.format_flag = 'dict'
-        self.stop_event = Event()
+    def __init__(self, name, predictor):
+        self.name = name
+        self.predictor = predictor
+
         self.company_id = os.environ.get('MINDSDB_COMPANY_ID', None)
-        self.target = None
-        self.window = None
-        self.gb = None
-        self.dt = None
-        self.native_interface = NativeInterface()
 
-    @staticmethod
-    def get_ts_settings(predict_record):
-        ts_settings = predict_record.learn_args['kwargs'].get('timeseries_settings', None)
+        self.stop_event = Event()
+
+        self.native_interface = ModelInterface()
+
+        p = db.session.query(db.Predictor).filter_by(company_id=self.company_id, name=self.predictor).first()
+
+        if p is None:
+            raise Exception(f'Predictor {predictor} doesn\'t exist')
+
+        self.target = p.learn_args['to_predict']
+
+        ts_settings = p.learn_args['kwargs'].get('timeseries_settings', None)
+
         if ts_settings is None:
-            raise Exception(f"Attempt to use {predict_record.name} predictor (not TS type) as timeseries predictor.")
-        ts_settings['to_predict'] = predict_record.learn_args['to_predict']
-        return ts_settings
+            self.thread = Thread(target=BaseStream._make_predictions, args=(self,))
+        else:
+            self.ts_settings = ts_settings
+            self.thread = Thread(target=BaseStream._make_ts_predictions, args=(self,))
 
-    @staticmethod
-    def is_anomaly(prediction):
-        for key in prediction:
-            if "anomaly" in key and prediction[key] is not None:
-                return True
-        return False
+        self.thread.start()
+
+    def _read_from_in_stream(self):
+        raise NotImplementedError
+
+    def _del_from_in_stream(self, k):
+        raise NotImplementedError
+
+    def _write_to_out_stream(self, dct):
+        raise NotImplementedError
+
+    def write_to_in_stream(self, dct):
+        raise NotImplementedError
+
+    def _make_predictions(self):
+        while not self.stop_event.wait(0.5):
+            for k, when_data in self._read_from_in_stream():
+                for res in self.native_interface.predict(self.predictor, 'dict', when_data=when_data):
+                    self._write_to_out_stream(res)
+                self._del_from_in_stream(k)
+
+    def _make_ts_predictions(self):
+        window = self.ts_settings['window']
+
+        order_by = self.ts_settings['order_by']
+        order_by = [order_by] if isinstance(order_by, str) else order_by
+
+        group_by = self.ts_settings['group_by']
+        group_by = [group_by] if isinstance(group_by, str) else group_by
+
+        gb_dict = defaultdict(list)
+
+        while not self.stop_event.wait(0.5):
+            for k, when_data in self._read_from_in_stream():
+                gb_value = tuple(when_data.get(gb, None) for gb in group_by)
+                gb_hash = str(hash(gb_value))
+                gb_dict[gb_hash].append(when_data)
+                self._del_from_in_stream(k)
+
+            for gb_hash, when_data_list in gb_dict.items():
+                gb_dict[gb_hash] = sorted(
+                    gb_dict[gb_hash],
+                    key=lambda wd: (float(wd[ob]) for ob in order_by)
+                )
+
+                if len(when_data_list) >= window:
+                    for res in self.native_interface.predict(self.predictor, 'dict', when_data=when_data_list[-window:]):
+                        self._write_to_out_stream(res)
+                    gb_dict[gb_hash] = when_data_list[1 - window:]
+
+            import time
+            time.sleep(2)
+
+            print(gb_dict)

--- a/mindsdb/streams/base/base_stream.py
+++ b/mindsdb/streams/base/base_stream.py
@@ -35,8 +35,8 @@ class BaseStream:
 
     def _write_to_out_stream(self, dct):
         raise NotImplementedError
-
-    def write_to_in_stream(self, dct):
+    
+    def _write_to_anomaly_stream(self, dct):
         raise NotImplementedError
 
     def _make_predictions(self):

--- a/mindsdb/streams/base/base_stream.py
+++ b/mindsdb/streams/base/base_stream.py
@@ -62,11 +62,11 @@ class BaseStream:
 
                     cache.append(when_data)
                 
-                cache = sorted(
+                cache = [*sorted(
                     cache,
                     # WARNING: assuming wd[ob] is numeric
                     key=lambda wd: tuple(wd[ob] for ob in order_by)
-                )
+                )]
 
                 if len(cache) >= window:
                     res_list = self.native_interface.predict(self.predictor, 'dict', when_data=cache[-window:])
@@ -76,6 +76,8 @@ class BaseStream:
             gb_cache = defaultdict(list)
 
             while not self.stop_event.wait(0.5):
+                if len(gb_cache):
+                    print(gb_cache)
                 for when_data in self._read_from_in_stream():
                     for ob in order_by:
                         if ob not in when_data:
@@ -89,11 +91,11 @@ class BaseStream:
                     gb_cache[gb_value].append(when_data)
 
                 for gb_value in gb_cache.keys():
-                    gb_cache[gb_value] = sorted(
+                    gb_cache[gb_value] = [*sorted(
                         gb_cache[gb_value],
                         # WARNING: assuming wd[ob] is numeric
                         key=lambda wd: tuple(wd[ob] for ob in order_by)
-                    )
+                    )]
 
                     if len(gb_cache[gb_value]) >= window:
                         res_list = self.native_interface.predict(self.predictor, 'dict', when_data=gb_cache[gb_value][-window:])

--- a/mindsdb/streams/kafka/__init__.py
+++ b/mindsdb/streams/kafka/__init__.py
@@ -1,0 +1,1 @@
+from .kafka_stream import KafkaStream

--- a/mindsdb/streams/kafka/kafka_stream.py
+++ b/mindsdb/streams/kafka/kafka_stream.py
@@ -14,6 +14,13 @@ class KafkaStream(BaseStream):
         self.producer = kafka.KafkaProducer(**connection_info, acks='all')
 
     def _read_from_in_stream(self):
+        # while True:
+        #     try:
+        #         msg = next(self.consumer)
+        #     except StopIteration:
+        #         return
+        #     else:
+        #         yield json.loads(msg.value)
         for msg in self.consumer:
             yield json.loads(msg.value)
 

--- a/mindsdb/streams/kafka/kafka_stream.py
+++ b/mindsdb/streams/kafka/kafka_stream.py
@@ -14,15 +14,15 @@ class KafkaStream(BaseStream):
         self.producer = kafka.KafkaProducer(**connection_info, acks='all')
 
     def _read_from_in_stream(self):
-        # while True:
-        #     try:
-        #         msg = next(self.consumer)
-        #     except StopIteration:
-        #         return
-        #     else:
-        #         yield json.loads(msg.value)
-        for msg in self.consumer:
-            yield json.loads(msg.value)
+        while True:
+            try:
+                msg = next(self.consumer)
+            except StopIteration:
+                return
+            else:
+                yield json.loads(msg.value)
+        # for msg in self.consumer:
+        #     yield json.loads(msg.value)
 
     def _write_to_out_stream(self, dct):
         self.producer.send(self.topic_out, json.dumps(dct).encode('utf-8'))

--- a/mindsdb/streams/kafka/kafka_stream.py
+++ b/mindsdb/streams/kafka/kafka_stream.py
@@ -5,102 +5,31 @@ import kafka
 
 from mindsdb.utilities.log import log
 from mindsdb.utilities.cache import Cache
-from mindsdb.streams.base.base_stream import StreamTypes, BaseStream
+from mindsdb.streams.base.base_stream import BaseStream
 from mindsdb.interfaces.storage.db import session
 from mindsdb.interfaces.storage.db import Predictor as DBPredictor
 
 
-class KafkaStream(Thread, BaseStream):
-    def __init__(self, name, connection_info, advanced_info, topic_in, topic_out, topic_anomaly, predictor, _type):
-        self.stream_name = name
-        self.connection_info = connection_info
-        self.advanced_info = advanced_info
-        self.predictor = predictor
-        self.stream_in_name = topic_in
-        self.stream_out_name = topic_out
-        self.stream_anomaly_name = topic_anomaly
-        self.consumer = kafka.KafkaConsumer(**self.connection_info, **self.advanced_info.get('consumer', {}))
-        self.consumer.subscribe(topics=[self.stream_in_name])
-        self.producer = kafka.KafkaProducer(**self.connection_info, **self.advanced_info.get('producer', {}), acks='all')
+class KafkaStream(BaseStream):
+    def __init__(self, name, predictor, connection_info, topic_in, topic_out, topic_anomaly):
+        BaseStream.__init__(self, name, predictor)
+        self.topic_in = topic_in
+        self.topic_out = topic_out
+        self.topic_anomaly = topic_anomaly
+        self.consumer = kafka.KafkaConsumer(**connection_info)
+        self.consumer.subscribe(topics=[self.topic_in])
+        self.producer = kafka.KafkaProducer(**connection_info, acks='all')
 
-        BaseStream.__init__(self)
-        self._type = _type
+    def _read_from_in_stream(self):
+        for msg in self.consumer:
+            yield json.loads(msg.value)
 
-        if self._type.lower() == StreamTypes.timeseries:
-            super().__init__(target=KafkaStream.make_timeseries_predictions, args=(self,))
-        else:
-            super().__init__(target=KafkaStream.make_prediction, args=(self,))
-            self.cache = None
+    def _write_to_out_stream(self, dct):
+        self.producer.send(self.topic_out, json.dumps(dct).encode('utf-8'))
+    
+    def _write_to_anomaly_stream(self, dct):
+        self.producer.send(self.topic_anomaly, json.dumps(dct).encode('utf-8'))
 
-    def predict_ts(self, group_by):
-        with self.cache:
-            when_list = self.cache[group_by]
-            for x in when_list:
-                if self.target not in x:
-                    x['make_predictions'] = False
-                else:
-                    x['make_predictions'] = True
-            result = self.native_interface.predict(self.predictor, self.format_flag, when_data=when_list)
-            log.debug(f"TIMESERIES STREAM {self.stream_name}: got {result}")
-            for res in result:
-                in_json = json.dumps(res)
-                to_send = in_json.encode('utf-8')
-                out_stream = self.stream_anomaly_name if self.is_anomaly(res) else self.stream_out_name
-                log.debug(f"STREAM {self.stream_name}: sending {to_send}")
-                self.producer.send(out_stream, to_send)
-
-            #delete the oldest record from cache
-            updated_list = self.cache[group_by][1:]
-            self.cache[group_by] = updated_list
-
-    def make_timeseries_predictions(self):
-        self.cache = Cache(self.stream_name)
-        log.debug("STREAM: running 'make_timeseries_predictions'")
-        predict_record = session.query(DBPredictor).filter_by(company_id=self.company_id, name=self.predictor).first()
-        if predict_record is None:
-            log.error(f"STREAM {self.stream_name} got error: requested predictor {self.predictor} is not exist")
-            return
-        ts_settings = self.get_ts_settings(predict_record)
-        log.debug(f"STREAM {self.stream_name} TS_SETTINGS: {ts_settings}")
-        self.target = ts_settings['to_predict'][0]
-        self.window = ts_settings['window']
-        self.gb = ts_settings['group_by'][0]
-        self.dt = ts_settings['order_by'][0]
-
-        while not self.stop_event.wait(0.5):
-            try:
-                msg_str = next(self.consumer)
-                when_data = json.loads(msg_str.value)
-                self.to_cache(when_data)
-            except StopIteration:
-                pass
-
-        log.debug(f"STREAM {self.stream_name}: stopping...")
-        self.producer.close()
+    def __del__(self):
         self.consumer.close()
-        self.cache.delete()
-        session.close()
-
-    def make_prediction(self):
-        predict_record = session.query(DBPredictor).filter_by(company_id=self.company_id, name=self.predictor).first()
-        if predict_record is None:
-            log.error(f"STREAM {self.stream_name} got error: requested predictor {self.predictor} is not exist")
-            return
-        while not self.stop_event.wait(0.5):
-            try:
-                msg_str = next(self.consumer)
-                when_data = json.loads(msg_str.value)
-                result = self.native_interface.predict(self.predictor, self.format_flag, when_data=when_data)
-                log.debug(f"STREAM {self.stream_name}: got {result}")
-                for res in result:
-                    in_json = json.dumps(res)
-                    to_send = in_json.encode('utf-8')
-                    log.debug(f"STREAM {self.stream_name}: sending {to_send}")
-                    out_stream = self.stream_anomaly_name if self.is_anomaly(res) else self.stream_out_name
-                    self.producer.send(out_stream, to_send)
-            except StopIteration:
-                pass
-        log.debug(f"STREAM {self.stream_name}: stopping...")
         self.producer.close()
-        self.consumer.close()
-        session.close()

--- a/mindsdb/streams/kafka/kafka_stream.py
+++ b/mindsdb/streams/kafka/kafka_stream.py
@@ -14,6 +14,7 @@ class KafkaStream(BaseStream):
         self.producer = kafka.KafkaProducer(**connection_info, acks='all')
 
     def _read_from_in_stream(self):
+        print('reading from stream_in')
         while True:
             try:
                 msg = next(self.consumer)
@@ -25,6 +26,7 @@ class KafkaStream(BaseStream):
         #     yield json.loads(msg.value)
 
     def _write_to_out_stream(self, dct):
+        print('writing to stream_out')
         self.producer.send(self.topic_out, json.dumps(dct).encode('utf-8'))
     
     def __del__(self):

--- a/mindsdb/streams/kafka/kafka_stream.py
+++ b/mindsdb/streams/kafka/kafka_stream.py
@@ -1,13 +1,7 @@
 import json
-from threading import Thread
-
 import kafka
 
-from mindsdb.utilities.log import log
-from mindsdb.utilities.cache import Cache
 from mindsdb.streams.base.base_stream import BaseStream
-from mindsdb.interfaces.storage.db import session
-from mindsdb.interfaces.storage.db import Predictor as DBPredictor
 
 
 class KafkaStream(BaseStream):

--- a/mindsdb/streams/kafka/kafka_stream.py
+++ b/mindsdb/streams/kafka/kafka_stream.py
@@ -5,11 +5,10 @@ from mindsdb.streams.base.base_stream import BaseStream
 
 
 class KafkaStream(BaseStream):
-    def __init__(self, name, predictor, connection_info, topic_in, topic_out, topic_anomaly):
+    def __init__(self, name, predictor, connection_info, topic_in, topic_out):
         BaseStream.__init__(self, name, predictor)
         self.topic_in = topic_in
         self.topic_out = topic_out
-        self.topic_anomaly = topic_anomaly
         self.consumer = kafka.KafkaConsumer(**connection_info)
         self.consumer.subscribe(topics=[self.topic_in])
         self.producer = kafka.KafkaProducer(**connection_info, acks='all')
@@ -21,9 +20,6 @@ class KafkaStream(BaseStream):
     def _write_to_out_stream(self, dct):
         self.producer.send(self.topic_out, json.dumps(dct).encode('utf-8'))
     
-    def _write_to_anomaly_stream(self, dct):
-        self.producer.send(self.topic_anomaly, json.dumps(dct).encode('utf-8'))
-
     def __del__(self):
         self.consumer.close()
         self.producer.close()

--- a/mindsdb/streams/redis/__init__.py
+++ b/mindsdb/streams/redis/__init__.py
@@ -1,0 +1,1 @@
+from .redis_stream import RedisStream

--- a/mindsdb/streams/redis/redis_stream.py
+++ b/mindsdb/streams/redis/redis_stream.py
@@ -5,12 +5,11 @@ from mindsdb.streams.base import BaseStream
 
 
 class RedisStream(BaseStream):
-    def __init__(self, name, predictor, connection_info, stream_in, stream_out, stream_anomaly):
+    def __init__(self, name, predictor, connection_info, stream_in, stream_out):
         BaseStream.__init__(self, name, predictor)
         self.client = walrus.Database(**connection_info)
         self.stream_in = self.client.Stream(stream_in)
         self.stream_out = self.client.Stream(stream_out)
-        self.stream_anomaly = self.client.Stream(stream_anomaly)
 
     def _read_from_in_stream(self):
         print('reading from stream_in')

--- a/mindsdb/streams/redis/redis_stream.py
+++ b/mindsdb/streams/redis/redis_stream.py
@@ -13,7 +13,7 @@ class RedisStream(BaseStream):
 
     def _read_from_in_stream(self):
         print('reading from stream_in')
-        for k, when_data in self.stream_in.read(block=0):
+        for k, when_data in self.stream_in.read():
             self.stream_in.delete(k)
             yield json.loads(when_data[b''])
 

--- a/mindsdb/streams/redis/redis_stream.py
+++ b/mindsdb/streams/redis/redis_stream.py
@@ -5,11 +5,12 @@ from mindsdb.streams.base import BaseStream
 
 
 class RedisStream(BaseStream):
-    def __init__(self, name, predictor, connection_info, stream_in, stream_out):
+    def __init__(self, name, predictor, connection_info, stream_in, stream_out, stream_anomaly):
         BaseStream.__init__(self, name, predictor)
         self.client = walrus.Database(**connection_info)
         self.stream_in = self.client.Stream(stream_in)
         self.stream_out = self.client.Stream(stream_out)
+        self.stream_anomaly = self.client.Stream(stream_anomaly)
 
     def _read_from_in_stream(self):
         print('reading from stream_in')
@@ -21,6 +22,6 @@ class RedisStream(BaseStream):
         print('writing to stream_out')
         self.stream_out.add({'': json.dumps(dct)})
 
-    def write_to_in_stream(self, dct):
-        print('writing to stream_in')
-        self.stream_in.add({'': json.dumps(dct)})
+    def _write_to_anomaly_stream(self, dct):
+        print('writing to stream_anomaly')
+        self.stream_anomaly.add({'': json.dumps(dct)})

--- a/mindsdb/streams/redis/redis_stream.py
+++ b/mindsdb/streams/redis/redis_stream.py
@@ -1,7 +1,7 @@
 import json
 import walrus
 
-from mindsdb.streams.base.base_stream import BaseStream
+from mindsdb.streams.base import BaseStream
 
 
 class RedisStream(BaseStream):

--- a/mindsdb/streams/redis/redis_stream.py
+++ b/mindsdb/streams/redis/redis_stream.py
@@ -1,150 +1,29 @@
 import json
-from threading import Thread, Event
 import walrus
 
-from mindsdb.utilities.log import log
-from mindsdb.streams.base.base_stream import StreamTypes, BaseStream
-from mindsdb.interfaces.storage.db import session
-from mindsdb.interfaces.storage.db import Predictor as DBPredictor
-from mindsdb.interfaces.model.model_interface import ModelInterface as NativeInterface
+from mindsdb.streams.base.base_stream import BaseStream
 
 
-class RedisStream(Thread, BaseStream):
-    def __init__(self, name, connection_info, advanced_info, stream_in, stream_out, stream_anomaly, predictor, _type):
-        self.stream_name = name
-        self.connection_info = connection_info
-        self.connection_info.update(advanced_info)
-        self.predictor = predictor
-        self.client = self._get_client()
-        self.stream_in_name = stream_in
-        self.stream_out_name = stream_out
+class RedisStream(BaseStream):
+    def __init__(self, name, predictor, connection_info, stream_in, stream_out):
+        BaseStream.__init__(self, name, predictor)
+        self.client = walrus.Database(**connection_info)
         self.stream_in = self.client.Stream(stream_in)
         self.stream_out = self.client.Stream(stream_out)
-        self.stream_anomaly = self.client.Stream(stream_anomaly)
-        self._type = _type
 
-        BaseStream.__init__(self)
-        if self._type.lower() == StreamTypes.timeseries:
-            super().__init__(target=RedisStream.make_timeseries_predictions, args=(self,))
-        else:
-            super().__init__(target=RedisStream.make_predictions, args=(self,))
+    def _read_from_in_stream(self):
+        print('reading from stream_in')
+        for k, when_data in self.stream_in.read():
+            yield (k, json.loads(when_data[b'']))
 
-    def _get_client(self):
-        return walrus.Database(**self.connection_info)
+    def _del_from_in_stream(self, k):
+        print('deleting from stream_in')
+        self.stream_in.delete(k)
 
-    def predict(self, stream_in, timeseries_mode=False):
-        predict_info = stream_in.read(block=0)
-        when_list = []
-        for record in predict_info:
-            record_id = record[0]
-            raw_when_data = record[1]
-            when_data = self.decode(raw_when_data)
-            if timeseries_mode:
-                if self.target not in when_data:
-                    when_data['make_predictions'] = False
-                else:
-                    when_data['make_predictions'] = True
-                when_list.append(when_data)
-            else:
-                result = self.native_interface.predict(self.predictor, self.format_flag, when_data=when_data)
-                log.error(f"STREAM: got {result}")
-                for res in result:
-                    in_json = json.dumps(res)
-                    stream_out = self.stream_anomaly if self.is_anomaly(res) else self.stream_out
-                    stream_out.add({'prediction': in_json})
-                stream_in.delete(record_id)
+    def _write_to_out_stream(self, dct):
+        print('writing to stream_out')
+        self.stream_out.add({'': json.dumps(dct)})
 
-        if timeseries_mode:
-            result = self.native_interface.predict(self.predictor, self.format_flag, when_data=when_list)
-            log.error(f"TIMESERIES STREAM: got {result}")
-            for res in result:
-                in_json = json.dumps(res)
-                stream_out = self.stream_anomaly if self.is_anomaly(res) else self.stream_out
-                stream_out.add({'prediction': in_json})
-            stream_in.trim(len(stream_in) - 1, approximate=False)
-
-
-    def make_prediction_from_cache(self, cache):
-        log.error("STREAM: in make_prediction_from_cache")
-        if len(cache) >= self.window:
-            log.error(f"STREAM: make_prediction_from_cache - len(cache) = {len(cache)}")
-            self.predict(cache, timeseries_mode=True)
-
-    def make_timeseries_predictions(self):
-        log.error("STREAM: running 'make_timeseries_predictions'")
-        predict_record = session.query(DBPredictor).filter_by(company_id=self.company_id, name=self.predictor).first()
-        if predict_record is None:
-            log.error(f"Error creating stream: requested predictor {self.predictor} is not exist")
-            return
-        ts_settings = self.get_ts_settings(predict_record)
-        log.error(f"STREAM TS_SETTINGS: {ts_settings}")
-        self.target = ts_settings['to_predict'][0]
-        self.window = ts_settings['window']
-        self.gb = ts_settings['group_by'][0]
-        self.dt = ts_settings['order_by'][0]
-
-
-        while not self.stop_event.wait(0.5):
-            predict_info = self.stream_in.read()
-            for record in predict_info:
-                record_id = record[0]
-                raw_when_data = record[1]
-                when_data = self.decode(raw_when_data)
-                log.error(f"STREAM: next record have read from {self.stream_in.key}: {when_data}")
-                self.to_cache(when_data)
-                self.stream_in.delete(record_id)
-        session.close()
-
-    def to_cache(self, record):
-        gb_val = record[self.gb]
-        cache = self.client.Stream(f"{self.stream_name}.cache.{gb_val}")
-        log.error(f"STREAM: cache {cache.key} has been created")
-        self.make_prediction_from_cache(cache)
-        self.handle_record(cache, record)
-        self.make_prediction_from_cache(cache)
-        log.error("STREAM in cache: current iteration has done.")
-
-    def handle_record(self, cache, record):
-        log.error(f"STREAM: handling cache {cache.key} and {record} record.")
-        records = cache.read()
-        records = [self.decode(x[1]) for x in records]
-        log.error(f"STREAM: read {records} from cache.")
-        records.append(record)
-        records = self.sort_cache(records)
-        log.error(f"STREAM: after updating and sorting - {records}.")
-        cache.trim(0, approximate=False)
-        for rec in records:
-            cache.add(rec)
-        log.error(f"STREAM: finish updating {cache.key}")
-
-    def sort_cache(self, cache):
-        return sorted(cache, key=lambda x: x[self.dt])
-
-    def make_predictions(self):
-        predict_record = session.query(DBPredictor).filter_by(company_id=self.company_id, name=self.predictor).first()
-        if predict_record is None:
-            log.error(f"Error creating stream: requested predictor {self.predictor} is not exist")
-            return
-
-        while not self.stop_event.wait(0.5):
-            predict_info = self.stream_in.read()
-            for record in predict_info:
-                record_id = record[0]
-                raw_when_data = record[1]
-                when_data = self.decode(raw_when_data)
-
-                result = self.native_interface.predict(self.predictor, self.format_flag, when_data=when_data)
-                log.error(f"STREAM: got {result}")
-                for res in result:
-                    in_json = json.dumps(res)
-                    self.stream_out.add({"prediction": in_json})
-                self.stream_in.delete(record_id)
-
-        session.close()
-        log.error("STREAM: stopping...")
-
-    def decode(self, redis_data):
-        decoded = {}
-        for k in redis_data:
-            decoded[k.decode('utf8')] = redis_data[k].decode('utf8')
-        return decoded
+    def write_to_in_stream(self, dct):
+        print('writing to stream_in')
+        self.stream_in.add({'': json.dumps(dct)})

--- a/mindsdb/streams/redis/redis_stream.py
+++ b/mindsdb/streams/redis/redis_stream.py
@@ -13,12 +13,9 @@ class RedisStream(BaseStream):
 
     def _read_from_in_stream(self):
         print('reading from stream_in')
-        for k, when_data in self.stream_in.read():
-            yield (k, json.loads(when_data[b'']))
-
-    def _del_from_in_stream(self, k):
-        print('deleting from stream_in')
-        self.stream_in.delete(k)
+        for k, when_data in self.stream_in.read(block=0):
+            self.stream_in.delete(k)
+            yield json.loads(when_data[b''])
 
     def _write_to_out_stream(self, dct):
         print('writing to stream_out')

--- a/mindsdb/streams/redis/redis_stream.py
+++ b/mindsdb/streams/redis/redis_stream.py
@@ -20,7 +20,3 @@ class RedisStream(BaseStream):
     def _write_to_out_stream(self, dct):
         print('writing to stream_out')
         self.stream_out.add({'': json.dumps(dct)})
-
-    def _write_to_anomaly_stream(self, dct):
-        print('writing to stream_anomaly')
-        self.stream_anomaly.add({'': json.dumps(dct)})

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -48,7 +48,7 @@ class Config():
 
             },
             "debug": False,
-            "integrations": {},
+            "integrations": {'redis': {'type': 'redis'}},
             "api": {
                 "http": {
                     "host": "127.0.0.1",

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -48,7 +48,7 @@ class Config():
 
             },
             "debug": False,
-            "integrations": {'redis': {'type': 'redis'}},
+            "integrations": {},
             "api": {
                 "http": {
                     "host": "127.0.0.1",

--- a/tests/integration_tests/flows/test_kafka.py
+++ b/tests/integration_tests/flows/test_kafka.py
@@ -30,7 +30,7 @@ DS_NAME = "kafka_test_ds"
 
 
 def read_stream(stream_name):
-    consumer = kafka.KafkaConsumer(**CONNECTION_PARAMS, consumer_timeout_ms=1000)
+    consumer = kafka.KafkaConsumer(**CONNECTION_PARAMS)
     consumer.subscribe([stream_name])
     while True:
         try:

--- a/tests/integration_tests/flows/test_kafka.py
+++ b/tests/integration_tests/flows/test_kafka.py
@@ -149,10 +149,8 @@ class KafkaTest(unittest.TestCase):
             when_data = {'x1': x, 'x2': 2*x}
             to_send = json.dumps(when_data)
             producer.send(STREAM_IN, to_send.encode("utf-8"))
-        producer.close()
-        threshold = time.time() + 120
-        while len(predictions) != 2 and time.time() < threshold:
-            time.sleep(1)
+            time.sleep(5)
+
         stop_event.set()
         self.assertTrue(len(predictions)==2, f"expected 2 predictions but got {len(predictions)}")
 
@@ -191,11 +189,9 @@ class KafkaTest(unittest.TestCase):
             when_data = {'x1': x, 'x2': 2*x, 'order': x, 'group': "A"}
             to_send = json.dumps(when_data)
             producer.send(STREAM_IN_TS, to_send.encode("utf-8"))
+            time.sleep(5)
         producer.close()
 
-        threshold = time.time() + 120
-        while len(predictions) != 2 and time.time() < threshold:
-            time.sleep(1)
         stop_event.set()
         self.assertTrue(len(predictions)==2, f"expected 2 predictions, but got {len(predictions)}")
 

--- a/tests/integration_tests/flows/test_kafka.py
+++ b/tests/integration_tests/flows/test_kafka.py
@@ -11,13 +11,11 @@ import pandas as pd
 
 from common import HTTP_API_ROOT, run_environment, EXTERNAL_DB_CREDENTIALS, USE_EXTERNAL_DB_SERVER
 
-
 INTEGRATION_NAME = 'test_kafka'
 kafka_creds = {}
 if USE_EXTERNAL_DB_SERVER:
     with open(EXTERNAL_DB_CREDENTIALS, 'rt') as f:
         kafka_creds = json.loads(f.read())['kafka']
-
 
 KAFKA_PORT = kafka_creds.get('port', 9092)
 KAFKA_HOST = kafka_creds.get('host', "127.0.0.1")
@@ -123,6 +121,7 @@ class KafkaTest(unittest.TestCase):
             self.fail(f"couldn't train predictor: {e}")
 
         params = {
+            "name": "test_kafka_stream",
             "predictor": self._testMethodName,
             "stream_in": STREAM_IN,
             "stream_out": STREAM_OUT,
@@ -165,6 +164,7 @@ class KafkaTest(unittest.TestCase):
             self.fail(f"couldn't train ts predictor: {e}")
 
         params = {
+            "name": "test_kafka_stream_ts",
             "predictor": self._testMethodName,
             "stream_in": STREAM_IN_TS,
             "stream_out": STREAM_OUT_TS,
@@ -200,6 +200,7 @@ class KafkaTest(unittest.TestCase):
             time.sleep(1)
         stop_event.set()
         self.assertTrue(len(predictions)==2, f"expected 2 predictions, but got {len(predictions)}")
+
 
 if __name__ == "__main__":
     try:

--- a/tests/integration_tests/flows/test_kafka.py
+++ b/tests/integration_tests/flows/test_kafka.py
@@ -120,16 +120,14 @@ class KafkaTest(unittest.TestCase):
         except Exception as e:
             self.fail(f"couldn't train predictor: {e}")
 
-        params = {
-            "predictor": self._testMethodName,
-            "stream_in": STREAM_IN,
-            "stream_out": STREAM_OUT,
-            "integration": INTEGRATION_NAME
-        }
-
         try:
             url = f'{HTTP_API_ROOT}/streams/{self._testMethodName}_{STREAM_SUFFIX}'
-            res = requests.put(url, json=params)
+            res = requests.put(url, json={
+                "predictor": self._testMethodName,
+                "stream_in": STREAM_IN,
+                "stream_out": STREAM_OUT,
+                "integration": INTEGRATION_NAME
+            })
             self.assertTrue(res.status_code == 200, res.text)
         except Exception as e:
             self.fail(f"error creating stream: {e}")
@@ -144,6 +142,7 @@ class KafkaTest(unittest.TestCase):
             time.sleep(5)
         
         predictions = list(read_stream(STREAM_OUT))
+        producer.close()
         self.assertTrue(len(predictions)==2, f"expected 2 predictions but got {len(predictions)}")
 
     def test_4_create_kafka_ts_stream(self):
@@ -152,16 +151,14 @@ class KafkaTest(unittest.TestCase):
         except Exception as e:
             self.fail(f"couldn't train ts predictor: {e}")
 
-        params = {
-            "predictor": self._testMethodName,
-            "stream_in": STREAM_IN_TS,
-            "stream_out": STREAM_OUT_TS,
-            "integration": INTEGRATION_NAME,
-        }
-
         try:
             url = f'{HTTP_API_ROOT}/streams/{self._testMethodName}_{STREAM_SUFFIX}'
-            res = requests.put(url, json=params)
+            res = requests.put(url, json={
+                "predictor": self._testMethodName,
+                "stream_in": STREAM_IN_TS,
+                "stream_out": STREAM_OUT_TS,
+                "integration": INTEGRATION_NAME,
+            })
             self.assertTrue(res.status_code == 200, res.text)
         except Exception as e:
             self.fail(f"error creating stream: {e}")
@@ -174,9 +171,9 @@ class KafkaTest(unittest.TestCase):
             to_send = json.dumps(when_data)
             producer.send(STREAM_IN_TS, to_send.encode("utf-8"))
             time.sleep(5)
-        producer.close()
 
         predictions = list(read_stream(STREAM_OUT_TS))
+        producer.close()
         self.assertTrue(len(predictions)==2, f"expected 2 predictions, but got {len(predictions)}")
 
 

--- a/tests/integration_tests/flows/test_kafka.py
+++ b/tests/integration_tests/flows/test_kafka.py
@@ -104,7 +104,7 @@ class KafkaTest(unittest.TestCase):
         url = f'{HTTP_API_ROOT}/config/integrations/{INTEGRATION_NAME}'
         params = {"type": "kafka", "connection": CONNECTION_PARAMS}
         try:
-            res = requests.put(url, json=params)
+            res = requests.put(url, json={'params': params})
             self.assertTrue(res.status_code == 200, res.text)
         except Exception as e:
             self.fail(e)
@@ -121,7 +121,6 @@ class KafkaTest(unittest.TestCase):
             self.fail(f"couldn't train predictor: {e}")
 
         params = {
-            "name": "test_kafka_stream",
             "predictor": self._testMethodName,
             "stream_in": STREAM_IN,
             "stream_out": STREAM_OUT,
@@ -164,7 +163,6 @@ class KafkaTest(unittest.TestCase):
             self.fail(f"couldn't train ts predictor: {e}")
 
         params = {
-            "name": "test_kafka_stream_ts",
             "predictor": self._testMethodName,
             "stream_in": STREAM_IN_TS,
             "stream_out": STREAM_OUT_TS,

--- a/tests/integration_tests/flows/test_kafka.py
+++ b/tests/integration_tests/flows/test_kafka.py
@@ -143,7 +143,7 @@ class KafkaTest(unittest.TestCase):
             producer.send(STREAM_IN, to_send.encode("utf-8"))
             time.sleep(5)
         
-        predictions = read_stream(STREAM_OUT)
+        predictions = list(read_stream(STREAM_OUT))
         self.assertTrue(len(predictions)==2, f"expected 2 predictions but got {len(predictions)}")
 
     def test_4_create_kafka_ts_stream(self):
@@ -176,7 +176,7 @@ class KafkaTest(unittest.TestCase):
             time.sleep(5)
         producer.close()
 
-        predictions = read_stream(STREAM_OUT_TS)
+        predictions = list(read_stream(STREAM_OUT_TS))
         self.assertTrue(len(predictions)==2, f"expected 2 predictions, but got {len(predictions)}")
 
 

--- a/tests/integration_tests/flows/test_redis.py
+++ b/tests/integration_tests/flows/test_redis.py
@@ -134,8 +134,7 @@ class RedisTest(unittest.TestCase):
         for x in range(1, 3):
             when_data = {'x1': x, 'x2': 2*x}
             stream_in.add({'': json.dumps(when_data)})
-
-        time.sleep(10)
+            time.sleep(5)
 
         predictions = stream_out.read()
         stream_out.trim(0, approximate=False)
@@ -168,10 +167,8 @@ class RedisTest(unittest.TestCase):
 
         for x in range(210, 221):
             when_data = {'x1': x, 'x2': 2*x, 'order': x, 'group': "A"}
-            time.sleep(5)
             stream_in.add({'': json.dumps(when_data)})
-
-        time.sleep(10)
+            time.sleep(5)
 
         predictions = stream_out.read()
         stream_out.trim(0, approximate=False)

--- a/tests/integration_tests/flows/test_redis.py
+++ b/tests/integration_tests/flows/test_redis.py
@@ -166,8 +166,9 @@ class RedisTest(unittest.TestCase):
         stream_in = client.Stream(STREAM_IN_TS)
         stream_out = client.Stream(STREAM_OUT_TS)
 
-        for x in range(210, 233):
+        for x in range(210, 221):
             when_data = {'x1': x, 'x2': 2*x, 'order': x, 'group': "A"}
+            time.sleep(5)
             stream_in.add({'': json.dumps(when_data)})
 
         time.sleep(10)

--- a/tests/integration_tests/flows/test_redis.py
+++ b/tests/integration_tests/flows/test_redis.py
@@ -116,7 +116,6 @@ class RedisTest(unittest.TestCase):
         try:
             url = f'{HTTP_API_ROOT}/streams/{self._testMethodName}_{STREAM_SUFFIX}'
             res = requests.put(url, json={
-                "name": "test_redis_stream",
                 "predictor": DEFAULT_PREDICTOR,
                 "stream_in": STREAM_IN,
                 "stream_out": STREAM_OUT,
@@ -150,7 +149,6 @@ class RedisTest(unittest.TestCase):
         try:
             url = f'{HTTP_API_ROOT}/streams/{self._testMethodName}_{STREAM_SUFFIX}'
             res = requests.put(url, json={
-                "name": "test_redis_stream_ts",
                 "predictor": TS_PREDICTOR,
                 "stream_in": STREAM_IN_TS,
                 "stream_out": STREAM_OUT_TS,

--- a/tests/integration_tests/flows/test_redis.py
+++ b/tests/integration_tests/flows/test_redis.py
@@ -116,6 +116,7 @@ class RedisTest(unittest.TestCase):
         try:
             url = f'{HTTP_API_ROOT}/streams/{self._testMethodName}_{STREAM_SUFFIX}'
             res = requests.put(url, json={
+                "name": "test_redis_stream",
                 "predictor": DEFAULT_PREDICTOR,
                 "stream_in": STREAM_IN,
                 "stream_out": STREAM_OUT,
@@ -149,6 +150,7 @@ class RedisTest(unittest.TestCase):
         try:
             url = f'{HTTP_API_ROOT}/streams/{self._testMethodName}_{STREAM_SUFFIX}'
             res = requests.put(url, json={
+                "name": "test_redis_stream_ts",
                 "predictor": TS_PREDICTOR,
                 "stream_in": STREAM_IN_TS,
                 "stream_out": STREAM_OUT_TS,

--- a/tests/integration_tests/flows/test_redis.py
+++ b/tests/integration_tests/flows/test_redis.py
@@ -166,7 +166,7 @@ class RedisTest(unittest.TestCase):
         stream_in = client.Stream(STREAM_IN_TS)
         stream_out = client.Stream(STREAM_OUT_TS)
 
-        for x in range(210, 223):
+        for x in range(210, 233):
             when_data = {'x1': x, 'x2': 2*x, 'order': x, 'group': "A"}
             stream_in.add({'': json.dumps(when_data)})
 

--- a/tests/integration_tests/flows/test_redis.py
+++ b/tests/integration_tests/flows/test_redis.py
@@ -136,6 +136,7 @@ class RedisTest(unittest.TestCase):
             stream_in.add({'': json.dumps(when_data)})
 
         time.sleep(10)
+
         predictions = stream_out.read()
         stream_out.trim(0, approximate=False)
         stream_in.trim(0, approximate=False)
@@ -165,14 +166,12 @@ class RedisTest(unittest.TestCase):
         stream_in = client.Stream(STREAM_IN_TS)
         stream_out = client.Stream(STREAM_OUT_TS)
 
-        for x in range(210, 221):
+        for x in range(210, 223):
             when_data = {'x1': x, 'x2': 2*x, 'order': x, 'group': "A"}
             stream_in.add({'': json.dumps(when_data)})
 
-        threshold = time.time() + 60
-        while len(stream_in) and time.time() < threshold:
-            time.sleep(1)
         time.sleep(10)
+
         predictions = stream_out.read()
         stream_out.trim(0, approximate=False)
         stream_in.trim(0, approximate=False)

--- a/tests/integration_tests/flows/test_redis.py
+++ b/tests/integration_tests/flows/test_redis.py
@@ -132,7 +132,7 @@ class RedisTest(unittest.TestCase):
 
         for x in range(1, 3):
             when_data = {'x1': x, 'x2': 2*x}
-            stream_in.add(when_data)
+            stream_in.add({'': json.dumps(when_data)})
 
         time.sleep(10)
         predictions = stream_out.read()
@@ -165,7 +165,7 @@ class RedisTest(unittest.TestCase):
 
         for x in range(210, 221):
             when_data = {'x1': x, 'x2': 2*x, 'order': x, 'group': "A"}
-            stream_in.add(when_data)
+            stream_in.add({'': json.dumps(when_data)})
 
         threshold = time.time() + 60
         while len(stream_in) and time.time() < threshold:

--- a/tests/integration_tests/flows/test_redis.py
+++ b/tests/integration_tests/flows/test_redis.py
@@ -97,7 +97,7 @@ class RedisTest(unittest.TestCase):
     def test_1_create_integration(self):
         url = f'{HTTP_API_ROOT}/config/integrations/{INTEGRATION_NAME}'
         try:
-            res = requests.put(url, json={"type": "redis", "connection": CONNECTION_PARAMS})
+            res = requests.put(url, json={"params": {"type": "redis", "connection": CONNECTION_PARAMS}})
             self.assertTrue(res.status_code == 200, res.text)
         except Exception as e:
             self.fail(e)


### PR DESCRIPTION
- all complex logic is moved to `BaseStream` class, its subclasses (`KafkaStream`, `RedisStream`) only implement a few small methods to read/write to/from in/out streams
- `group_by` and `order_by` can now be lists
- when the number of records read from the input stream exceeds `ts_settings['window']`, only last `ts_settings['window']` records are used to predict, others are discarded. This way timeseries cache has constant space complexity so it's stored in a python `dict`. 