### PR TITLE
Don't allow deleting datasources if they are linked to a predictor

### DIFF
--- a/mindsdb/api/http/namespaces/datasource.py
+++ b/mindsdb/api/http/namespaces/datasource.py
@@ -28,8 +28,6 @@ from mindsdb.api.http.namespaces.entitites.datasources.datasource_missed_files i
 )
 from mindsdb.interfaces.database.integrations import get_db_integration
 
-from mindsdb.utilities.config import Config
-
 
 def parse_filter(key, value):
     result = re.search(r'filter(_*.*)\[(.*)\]', key)
@@ -77,11 +75,6 @@ class Datasource(Resource):
     def delete(self, name):
         '''delete datasource'''
 
-        if not Config()["force_datasource_removing"]:
-            models = request.native_interface.get_models()
-            linked_models = [x["name"] for x in models if x['data_source_name'] == name]
-            if linked_models:
-                return "Can't delete {} datasource because there are next models linked to it: {}".format(name, linked_models), 403
         try:
             request.default_store.delete_datasource(name)
         except Exception as e:

--- a/mindsdb/api/http/namespaces/datasource.py
+++ b/mindsdb/api/http/namespaces/datasource.py
@@ -28,6 +28,8 @@ from mindsdb.api.http.namespaces.entitites.datasources.datasource_missed_files i
 )
 from mindsdb.interfaces.database.integrations import get_db_integration
 
+from mindsdb.utilities.config import Config
+
 
 def parse_filter(key, value):
     result = re.search(r'filter(_*.*)\[(.*)\]', key)
@@ -75,10 +77,11 @@ class Datasource(Resource):
     def delete(self, name):
         '''delete datasource'''
 
-        models = request.native_interface.get_models()
-        linked_models = [x["name"] for x in models if x['data_source_name'] == name]
-        if linked_models:
-            return "Can't delete {} datasource because there are next models linked to it: {}".format(name, linked_models), 403
+        if not Config()["force_datasource_removing"]:
+            models = request.native_interface.get_models()
+            linked_models = [x["name"] for x in models if x['data_source_name'] == name]
+            if linked_models:
+                return "Can't delete {} datasource because there are next models linked to it: {}".format(name, linked_models), 403
         try:
             request.default_store.delete_datasource(name)
         except Exception as e:

--- a/mindsdb/api/http/namespaces/datasource.py
+++ b/mindsdb/api/http/namespaces/datasource.py
@@ -74,6 +74,11 @@ class Datasource(Resource):
     @ns_conf.doc('delete_datasource')
     def delete(self, name):
         '''delete datasource'''
+
+        models = request.native_interface.get_models()
+        linked_models = [x["name"] for x in models if x['data_source_name'] == name]
+        if linked_models:
+            return "Can't delete {} datasource because there are next models linked to it: {}".format(name, linked_models), 403
         try:
             request.default_store.delete_datasource(name)
         except Exception as e:

--- a/mindsdb/api/http/namespaces/entitites/predictor_status.py
+++ b/mindsdb/api/http/namespaces/entitites/predictor_status.py
@@ -10,6 +10,7 @@ predictor_status = ns_conf.model('PredictorStatus', {
     # other attributes
     'is_active': fields.Boolean(required=False, description='Only one predictor by public_name can be active'),
     'data_source': fields.String(required=False, description='The data source it\'s learning from'),
+    'data_source_name': fields.String(required=False, description='The name of the datasource it\'s learning from'),
     'predict': fields.List(fields.String, required=False, description='The list of columns/fields to be predicted'),
     'accuracy': fields.Float(description='The current accuracy of the model'),
     'status': fields.String(required=False, description='The current model status', enum=['training', 'complete', 'error']),

--- a/mindsdb/interfaces/model/model_controller.py
+++ b/mindsdb/interfaces/model/model_controller.py
@@ -219,7 +219,7 @@ class ModelController():
     def get_model_data(self, name, db_fix=True, company_id=None):
         from mindsdb_native import F
         from mindsdb_native.libs.constants.mindsdb import DATA_SUBTYPES
-        from mindsdb.interfaces.storage.db import session, Predictor
+        from mindsdb.interfaces.storage.db import session, Predictor, Datasource
         import torch
         import gc
 
@@ -230,6 +230,7 @@ class ModelController():
         name = f'{company_id}@@@@@{name}'
 
         predictor_record = Predictor.query.filter_by(company_id=company_id, name=original_name, is_custom=False).first()
+        linked_data_source = Datasource.query.filter_by(company_id=company_id, id=predictor_record.datasource_id).first()
         predictor_record = self._try_outdate_db_status(predictor_record)
         model = predictor_record.data
         if model is None or model['status'] == 'training':
@@ -274,6 +275,7 @@ class ModelController():
         model['predict'] = predictor_record.to_predict
         model['update'] = predictor_record.update_status
         model['name'] = predictor_record.name
+        model['data_source_name'] = linked_data_source.name if linked_data_source else None
         return model
 
     def get_models(self, company_id=None):
@@ -290,7 +292,7 @@ class ModelController():
 
                 reduced_model_data = {}
 
-                for k in ['name', 'version', 'is_active', 'predict', 'status', 'current_phase', 'accuracy', 'data_source', 'update']:
+                for k in ['name', 'version', 'is_active', 'predict', 'status', 'current_phase', 'accuracy', 'data_source', 'update', 'data_source_name']:
                     reduced_model_data[k] = model_data.get(k, None)
 
                 for k in ['train_end_at', 'updated_at', 'created_at']:

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -71,7 +71,8 @@ class Config():
             },
             "cache": {
                 "type": "local"
-            }
+            },
+            "force_datasource_removing": False
         }
 
         self._default_config['paths']['root'] = os.environ['MINDSDB_STORAGE_DIR']


### PR DESCRIPTION
Fixes #1280

Perform simple checking before delete a datasource.
By setting `force_datasource_removing` to True in config any datasource would be deleted despite on any linked models.