### PR TITLE
Error register predictors for integrations with same DB

### DIFF
--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -88,10 +88,10 @@ if __name__ == '__main__':
                 dbw.register_predictors(model_data_arr, integration_name=integration_name)
 
     for integration_name in config.get('integrations', {}):
-        print(f'Adding: {integration_name}')
         try:
             it = get_db_integration(integration_name, None)
             if it is None:      # register and setup it only if it doesn't conflict with records in db
+                print(f'Adding: {integration_name}')
                 add_db_integration(integration_name, config['integrations'][integration_name], None)            # Setup for user `None`, since we don't need this for cloud
                 if config['integrations'][integration_name].get('publish', False) and not is_cloud:
                     dbw.setup_integration(integration_name)

--- a/mindsdb/integrations/clickhouse/clickhouse.py
+++ b/mindsdb/integrations/clickhouse/clickhouse.py
@@ -132,7 +132,7 @@ class Clickhouse(Integration, ClickhouseConnectionChecker):
             msqyl_user = self._get_mysql_user()
 
             q = f"""
-                CREATE IF NOT EXISTS TABLE {self.mindsdb_database}.{name}
+                CREATE TABLE IF NOT EXISTS {self.mindsdb_database}.{name}
                 ({columns_sql}
                 ) ENGINE=MySQL('{msqyl_conn}', 'mindsdb', {name}, '{msqyl_user}', '{msqyl_pass}')
             """

--- a/mindsdb/integrations/clickhouse/clickhouse.py
+++ b/mindsdb/integrations/clickhouse/clickhouse.py
@@ -131,8 +131,9 @@ class Clickhouse(Integration, ClickhouseConnectionChecker):
             msqyl_pass = self.config['api']['mysql']['password']
             msqyl_user = self._get_mysql_user()
 
+            self.unregister_predictor(model_meta['name'])
             q = f"""
-                CREATE TABLE IF NOT EXISTS {self.mindsdb_database}.{name}
+                CREATE TABLE {self.mindsdb_database}.{name}
                 ({columns_sql}
                 ) ENGINE=MySQL('{msqyl_conn}', 'mindsdb', {name}, '{msqyl_user}', '{msqyl_pass}')
             """

--- a/mindsdb/integrations/clickhouse/clickhouse.py
+++ b/mindsdb/integrations/clickhouse/clickhouse.py
@@ -132,7 +132,7 @@ class Clickhouse(Integration, ClickhouseConnectionChecker):
             msqyl_user = self._get_mysql_user()
 
             q = f"""
-                CREATE TABLE {self.mindsdb_database}.{name}
+                CREATE IF NOT EXISTS TABLE {self.mindsdb_database}.{name}
                 ({columns_sql}
                 ) ENGINE=MySQL('{msqyl_conn}', 'mindsdb', {name}, '{msqyl_user}', '{msqyl_pass}')
             """

--- a/mindsdb/integrations/mariadb/mariadb.py
+++ b/mindsdb/integrations/mariadb/mariadb.py
@@ -148,7 +148,7 @@ class Mariadb(Integration, MariadbConnectionChecker):
             connect = self._get_connect_string(name)
 
             q = f"""
-                    CREATE TABLE {self.mindsdb_database}.{self._escape_table_name(name)}
+                    CREATE TABLE IF NOT EXISTS {self.mindsdb_database}.{self._escape_table_name(name)}
                     ({columns_sql}
                     ) ENGINE=CONNECT CHARSET=utf8 TABLE_TYPE=MYSQL CONNECTION='{connect}';
             """

--- a/mindsdb/integrations/mariadb/mariadb.py
+++ b/mindsdb/integrations/mariadb/mariadb.py
@@ -147,8 +147,9 @@ class Mariadb(Integration, MariadbConnectionChecker):
 
             connect = self._get_connect_string(name)
 
+            self.unregister_predictor(name)
             q = f"""
-                    CREATE TABLE IF NOT EXISTS {self.mindsdb_database}.{self._escape_table_name(name)}
+                    CREATE TABLE {self.mindsdb_database}.{self._escape_table_name(name)}
                     ({columns_sql}
                     ) ENGINE=CONNECT CHARSET=utf8 TABLE_TYPE=MYSQL CONNECTION='{connect}';
             """

--- a/mindsdb/integrations/mysql/mysql.py
+++ b/mindsdb/integrations/mysql/mysql.py
@@ -146,8 +146,9 @@ class MySQL(Integration, MySQLConnectionChecker):
 
             connect = self._get_connect_string(name)
 
+            self.unregister_predictor(name)
             q = f"""
-                CREATE TABLE IF NOT EXISTS {self.mindsdb_database}.{self._escape_table_name(name)} (
+                CREATE TABLE {self.mindsdb_database}.{self._escape_table_name(name)} (
                     {columns_sql},
                     index when_data_index (when_data),
                     index select_data_query_index (select_data_query),

--- a/mindsdb/integrations/mysql/mysql.py
+++ b/mindsdb/integrations/mysql/mysql.py
@@ -147,7 +147,7 @@ class MySQL(Integration, MySQLConnectionChecker):
             connect = self._get_connect_string(name)
 
             q = f"""
-                CREATE TABLE {self.mindsdb_database}.{self._escape_table_name(name)} (
+                CREATE TABLE IF NOT EXISTS {self.mindsdb_database}.{self._escape_table_name(name)} (
                     {columns_sql},
                     index when_data_index (when_data),
                     index select_data_query_index (select_data_query),

--- a/mindsdb/integrations/postgres/postgres.py
+++ b/mindsdb/integrations/postgres/postgres.py
@@ -173,7 +173,7 @@ class PostgreSQL(Integration, PostgreSQLConnectionChecker):
                 columns_sql += f',"{col}_explain" text'
 
             q = f"""
-                CREATE FOREIGN TABLE {self.mindsdb_database}.{self._escape_table_name(name)} (
+                CREATE FOREIGN IF NOT EXISTS TABLE {self.mindsdb_database}.{self._escape_table_name(name)} (
                     {columns_sql}
                 ) SERVER server_{self.mindsdb_database}
                 OPTIONS (dbname 'mindsdb', table_name '{name}');

--- a/mindsdb/integrations/postgres/postgres.py
+++ b/mindsdb/integrations/postgres/postgres.py
@@ -172,8 +172,9 @@ class PostgreSQL(Integration, PostgreSQLConnectionChecker):
                     columns_sql += f',"{col}_max" float8'
                 columns_sql += f',"{col}_explain" text'
 
+            self.unregister_predictor(name)
             q = f"""
-                CREATE FOREIGN TABLE IF NOT EXISTS {self.mindsdb_database}.{self._escape_table_name(name)} (
+                CREATE FOREIGN TABLE {self.mindsdb_database}.{self._escape_table_name(name)} (
                     {columns_sql}
                 ) SERVER server_{self.mindsdb_database}
                 OPTIONS (dbname 'mindsdb', table_name '{name}');

--- a/mindsdb/integrations/postgres/postgres.py
+++ b/mindsdb/integrations/postgres/postgres.py
@@ -173,7 +173,7 @@ class PostgreSQL(Integration, PostgreSQLConnectionChecker):
                 columns_sql += f',"{col}_explain" text'
 
             q = f"""
-                CREATE FOREIGN IF NOT EXISTS TABLE {self.mindsdb_database}.{self._escape_table_name(name)} (
+                CREATE FOREIGN TABLE IF NOT EXISTS {self.mindsdb_database}.{self._escape_table_name(name)} (
                     {columns_sql}
                 ) SERVER server_{self.mindsdb_database}
                 OPTIONS (dbname 'mindsdb', table_name '{name}');


### PR DESCRIPTION
Fixes #1198

change `CREATE TABLE...` to `CREATE TABLE IF NOT EXISTS....` for all predictor tables in all integrations