### PR TITLE
Allow to send data in timeseries format to 'predict' endpoint

### DIFF
--- a/mindsdb/api/http/namespaces/predictor.py
+++ b/mindsdb/api/http/namespaces/predictor.py
@@ -212,7 +212,7 @@ class PredictorPredict2(Resource):
         format_flag = data.get('format_flag', 'explain')
         kwargs = data.get('kwargs', {})
 
-        if isinstance(when, dict) is False or len(when) == 0:
+        if len(when) == 0:
             return 'No data provided for the predictions', 400
 
         results = request.native_interface.predict(name, format_flag, when_data=when, **kwargs)


### PR DESCRIPTION
currently `/predict` request with when_data in `timeseries` (list) format ends with error:
`'No data provided for the predictions', 400`
Need to fix it. 
There is more sanity fix:
1. get model info
2. check is it timeseries or not
3. Allow/decline list format according to previous item

but it is too expensive for us, I think

@StpMax Please suggest