### PR TITLE
Back compatibility for creating stream through redis API

### DIFF
--- a/mindsdb/streams/redis/redis_stream.py
+++ b/mindsdb/streams/redis/redis_stream.py
@@ -9,9 +9,20 @@ class RedisStream(BaseStream):
         self.client = walrus.Database(**connection_info)
         self.stream = self.client.Stream(stream)
 
+    @staticmethod
+    def _decode(redis_data):
+        decoded = {}
+        for k in redis_data:
+            decoded[k.decode('utf8')] = redis_data[k].decode('utf8')
+        return decoded
+
     def read(self):
         for k, when_data in self.stream.read():
-            yield json.loads(when_data[b''])
+            try:
+                res = json.loads(when_data[b''])
+            except KeyError:
+                res = self._decode(when_data)
+            yield res
             self.stream.delete(k)
 
     def write(self, dct):


### PR DESCRIPTION
I'm getting an error while creating mindsdb stream via Redis:
```XADD control * action create name covid_stream predictor covid stream_in covid_in stream_out covid_out stream_anomaly covid_anomaly```

```
2021-08-05 08:26:27,787 - ERROR - for dct in self._control_stream.read():
2021-08-05 08:26:27,799 - ERROR -   File "/home/itsyplen/repos/work/MindsDB/mindsdb/mindsdb/streams/redis/redis_stream.py", line 14, in read

2021-08-05 08:26:27,812 - ERROR - yield json.loads(when_data[b''])
2021-08-05 08:26:27,826 - ERROR - KeyError
2021-08-05 08:26:27,838 - ERROR - : 
2021-08-05 08:26:27,853 - ERROR - b''
```

Redis stream must handle bytes and dicts properly