### PR TITLE
Streaming tests pathing issue

### DIFF
--- a/tests/integration_tests/flows/test_kafka.py
+++ b/tests/integration_tests/flows/test_kafka.py
@@ -12,8 +12,6 @@ import kafka
 
 from common import HTTP_API_ROOT, run_environment, EXTERNAL_DB_CREDENTIALS, USE_EXTERNAL_DB_SERVER
 
-from mindsdb.streams import KafkaStream
-
 
 INTEGRATION_NAME = 'test_kafka'
 kafka_creds = {}
@@ -52,6 +50,7 @@ class KafkaTest(unittest.TestCase):
 
     def test_length(self):
         print(f"\nExecuting {self._testMethodName}")
+        from mindsdb.streams import KafkaStream
         stream = KafkaStream(f'test_stream_length_{STREAM_SUFFIX}', CONNECTION_PARAMS)
 
         self.assertEqual(len(list(stream.read())), 0)
@@ -151,6 +150,7 @@ class KafkaTest(unittest.TestCase):
 
     def test_3_making_stream_prediction(self):
         print(f"\nExecuting {self._testMethodName}")
+        from mindsdb.streams import KafkaStream
         stream_in = KafkaStream(STREAM_IN, CONNECTION_PARAMS, mode='w')
         stream_out = KafkaStream(STREAM_OUT, CONNECTION_PARAMS, mode='r')
         # wait when the integration launches created stream
@@ -177,6 +177,7 @@ class KafkaTest(unittest.TestCase):
 
     def test_5_making_ts_stream_prediction(self):
         print(f"\nExecuting {self._testMethodName}")
+        from mindsdb.streams import KafkaStream
         stream_in = KafkaStream(STREAM_IN_TS, CONNECTION_PARAMS)
         stream_out = KafkaStream(STREAM_OUT_TS, CONNECTION_PARAMS)
 
@@ -188,9 +189,9 @@ class KafkaTest(unittest.TestCase):
         time.sleep(10)
         self.assertEqual(len(list(stream_out.read())), 2)
 
-    '''
     def test_6_create_stream_kafka_native_api(self):
         print(f"\nExecuting {self._testMethodName}")
+        from mindsdb.streams import KafkaStream
         control_stream = KafkaStream(CONTROL_STREAM, CONNECTION_PARAMS)
         control_stream.write({
             'action': 'create',
@@ -211,8 +212,10 @@ class KafkaTest(unittest.TestCase):
 
         self.assertEqual(len(list(stream_out.read())), 2)
 
+    '''
     def test_8_test_online_learning(self):
         print(f"\nExecuting {self._testMethodName}")
+        from mindsdb.streams import KafkaStream
         control_stream = KafkaStream(CONTROL_STREAM, CONNECTION_PARAMS)
         learning_stream = KafkaStream(LEARNING_STREAM, CONNECTION_PARAMS)
 
@@ -228,6 +231,7 @@ class KafkaTest(unittest.TestCase):
         for x in range(1, 101):
             learning_stream.write({'x1': x, 'x2': 2*x})
     '''
+
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
Fixes #1388

## Please describe what changes you made, in as much detail as possible
  - Use local import only after calling `run_environment`
  - uncomment subset of tests
  - added test for ts prediction with empty `group_by`

mindsdb