### PR TITLE
modify mysql api connect doc

### DIFF
--- a/docs/mindsdb-docs/docs/sql/connect/cloud.md
+++ b/docs/mindsdb-docs/docs/sql/connect/cloud.md
@@ -10,11 +10,11 @@ MindsDB Cloud provides a powerful MySQL API that allows cloud users to connect t
 Open mysql client and run:
 
 ```
-mysql -h cloud-mysql.mindsdb.com --port 3306 -u cloudusername@mail.com -p
+mysql --port 3306 -u cloudusername@mail.com -p
 ```
 The required parameters are:
 
-* -h: Host name of mindsdbs mysql api (cloud-mysql.mindsdb.com)	
+* -h: Host name of mindsdbs mysql api (by default takes cloud-mysql.mindsdb.com if not specified)	
 * --port: TCP/IP port number for connection(3306)	
 * -u: MindsDB Cloud username
 * -p:  MindsDB Cloud password


### PR DESCRIPTION
Fixes #1479

## Please describe what changes you made, in as much detail as possible
  - Modified the file https://github.com/mindsdb/mindsdb/blob/b09ac13588957e6b4c3718f261da676bc5657b3a/docs/mindsdb-docs/docs/sql/connect/cloud.md#mysql-client  based on issue #1479 .
- Removed the -h paramater as according to issue mysql client automatically points to mindsdb mysql api

mindsdb