### PR TITLE
Remove 3.6.x from docs

### DIFF
--- a/docs/mindsdb-docs/docs/deployment/linux.md
+++ b/docs/mindsdb-docs/docs/deployment/linux.md
@@ -3,7 +3,7 @@
 !!! warning "Python 3.9"
     Currently, some of our dependencies have issues with the latest versions of Python 3.9.x. For now, our suggestion is to use Python 3.7.x, or 3.8.x versions.
 
-We suggest you to install MindsDB in a virtual environment when using **pip** to avoid dependency issues. Make sure your Python version is **>=3.6**.
+We suggest you to install MindsDB in a virtual environment when using **pip** to avoid dependency issues. Make sure your Python version is **>=3.7**.
 
 1. Create and activate venv:
 

--- a/docs/mindsdb-docs/docs/deployment/source.md
+++ b/docs/mindsdb-docs/docs/deployment/source.md
@@ -7,7 +7,7 @@ This section describes how to deploy MindsDB from the source code. This is the p
 !!! warning "Python 3.9"
     Currently, some of our dependencies have issues with the latest versions of Python 3.9.x. For now, our suggestion is to use Python 3.7.x, or 3.8.x versions.
 
-* [Python version](https://www.python.org/downloads/) >=3.6 (64 bit) and pip version >= 19.3.
+* [Python version](https://www.python.org/downloads/) >=3.7 (64 bit) and pip version >= 19.3.
 * [Pip](https://pip.pypa.io/en/stable/installing/) (is usually pre-installed with the latest Python versions).
 * [Git](https://git-scm.com/).
 

--- a/docs/mindsdb-docs/docs/deployment/windows.md
+++ b/docs/mindsdb-docs/docs/deployment/windows.md
@@ -31,9 +31,9 @@ You should see a list with the names of installed packages.
 # Deploy using pip
 
 !!! warning "Python 3.9"
-    Currently, some of our dependencies have issues with the latest versions of Python 3.9.x. For now, our suggestion is to use Python 3.6.x, 3.7.x, or 3.8.x versions.
+    Currently, some of our dependencies have issues with the latest versions of Python 3.9.x. For now, our suggestion is to use Python 3.7.x, or 3.8.x versions.
 
-We suggest you to install MindsDB in a virtual environment when using `pip` to avoid dependency issues. Make sure your Python version is **>=3.6** and pip version **>= 19.3**.
+We suggest you to install MindsDB in a virtual environment when using `pip` to avoid dependency issues. Make sure your Python version is **>=3.7** and pip version **>= 19.3**.
 
 1. Create new virtual environment called mindsdb:
 


### PR DESCRIPTION
Fixes #1487 1487

## Please describe what changes you made, in as much detail as possible
  - Updated all references to 3.6.x to 3.7.x within the /docs/deployment folder. (Found references that hadn't been updated in source.md and linux.md in addition to the referenced windows.md in the issue.)

mindsdb