### PR TITLE
Fix tutorial URL in docs

### DIFF
--- a/docs/mindsdb-docs/docs/sql/tutorials/customer-churn.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/customer-churn.md
@@ -35,7 +35,7 @@ Then, click on CONNECT. The next step is to use the MySQL client to connect to M
 I will use a mysql command line client in the next part of the tutorial but you can follow up with the one that works the best for you, like Dbeaver. The first step is to use the MindsDB Cloud user to connect to the MySQL API:
 
 ```
-mysql -h cloud-mysql.mindsdb.com --port 3306 -u theusername@mail.com -p
+mysql -h cloud.mindsdb.com --port 3306 -u theusername@mail.com -p
 ```
 
 In the above command, we specify the hostname and user name explicitly, as well as a password for connecting.


### PR DESCRIPTION
Fixes #1518

## Please describe what changes you made, in as much detail as possible
  - I changed the hostname to the MindsDB MySQL API from `cloud-mysql.mindsdb.com` to `cloud.mindsdb.com`

mindsdb