### PR TITLE
Changed SELECT Example Query in select.md

### DIFF
--- a/docs/mindsdb-docs/docs/sql/api/select.md
+++ b/docs/mindsdb-docs/docs/sql/api/select.md
@@ -44,7 +44,7 @@ The following SQL statement selects only the target variable `rental_price` as `
 
 ```sql
 SELECT rental_price as price, 
-rental_price_confidence as accuracy 
+rental_price_confidence as confidence 
 FROM mindsdb.home_rentals_model WHERE when_data='{"sqft": 800, "number_of_rooms": 4, "number_of_bathrooms": 2, 
                                             "location": "good", "days_on_market" : 12,  
                                             "neighborhood": "downtown", "initial_price": "2222"}';


### PR DESCRIPTION
Changed SELECT Example Query with ```rental_price_confidence as confidence``` at line 47 in select.md.

Fixes #1521 

## Please describe what changes you made, in as much detail as possible
 - I have changed the SELECT example query in ```select.md``` with ```rental_price_confidence as confidence```. 

mindsdb