### PR TITLE
Add method to count number of rows returned by a query

### DIFF
--- a/mindsdb/integrations/base/integration.py
+++ b/mindsdb/integrations/base/integration.py
@@ -26,6 +26,9 @@ class Integration:
     def unregister_predictor(self, name):
         raise NotImplementedError
 
+    def get_row_count(self, query):
+        return len(self._query(query))
+
 
 class StreamIntegration(Integration):
     def __init__(self, config, name, control_stream=None):


### PR DESCRIPTION
Fixes #1532

## Please describe what changes you made, in as much detail as possible
  - adds a method to be base integration class to count the number of rows returned by a query