### PR TITLE
Added get_row_count()

### DIFF
--- a/mindsdb/integrations/postgres/postgres.py
+++ b/mindsdb/integrations/postgres/postgres.py
@@ -95,7 +95,11 @@ class PostgreSQL(Integration, PostgreSQLConnectionChecker):
             con.commit()
 
         return res
-
+    
+     def get_row_count(self, query):
+        res = self._query(query)
+        return len(res)
+    
     def setup(self):
         user = f"{self.config['api']['mysql']['user']}_{self.name}"
         password = self.config['api']['mysql']['password']


### PR DESCRIPTION
Fixes #1490 

## Added get_row_count() for PostgreSQL datasources

This method returns the number of rows fetched by the given query from PostgreSQL datasources. The method has been added in the class PostgreSQL.

Dwaipayan