### PR TITLE
Add URL redirection from old installation in docs

### DIFF
--- a/docs/mindsdb-docs/mkdocs.yml
+++ b/docs/mindsdb-docs/mkdocs.yml
@@ -44,6 +44,7 @@ plugins:
             'installation/Linux/': 'installation/linux.md'
             'installation/Windows/': 'installation/windows.md'
             'installation/MacOS/': 'installation/macos.md'
+            'installation/macos/': '/deployment/macos.md'
     - table-reader
 
 markdown_extensions:


### PR DESCRIPTION

Fixes #1564

## Please describe what changes you made, in as much detail as possible
  - Add new redirect from: `installation/macos/` to `/deployment/macos.md`