### PR TITLE
added get_tables_list in postgres integration

### DIFF
--- a/mindsdb/integrations/postgres/postgres.py
+++ b/mindsdb/integrations/postgres/postgres.py
@@ -199,3 +199,13 @@ class PostgreSQL(Integration, PostgreSQLConnectionChecker):
             FROM ({query}) as query;"""
         result = self._query(q)
         return result[0]['count']
+    
+    def get_tables_list(self):
+        q = f""" SELECT table_schema, table_name
+                      FROM information_schema.tables
+                      WHERE table_schema != 'pg_catalog'
+                      AND table_schema != 'information_schema'
+                      ORDER BY table_schema, table_name"""
+        tables_list = self._query(q)
+        tables= [f"{table['table_schema']}.{table['table_name']}" for table in tables_list]
+        return tables


### PR DESCRIPTION
Fixes #1588 

## Please describe what changes you made, in as much detail as possible
  - added function `get_table_list ` to postgres integration that returns a list of table names in the form of `schema_name.table_name ` that the user has access to on the database.

mindsdb