### PR TITLE
Add URL redirection from old Linux installation docs

### DIFF
--- a/docs/mindsdb-docs/mkdocs.yml
+++ b/docs/mindsdb-docs/mkdocs.yml
@@ -45,6 +45,7 @@ plugins:
             'installation/Windows/': 'installation/windows.md'
             'installation/MacOS/': 'installation/macos.md'
             'installation/macos/': '/deployment/macos.md'
+            'installation/linux/': '/deployment/linux.md'
     - table-reader
 
 markdown_extensions:


### PR DESCRIPTION
Fixes #1598

## Please describe what changes you made, in as much detail as possible
  -    Add new redirect from: 'installation/linux/': '/deployment/linux.md'


mindsdb