### PR TITLE
Update redirection URLs for OSes

### DIFF
--- a/docs/mindsdb-docs/mkdocs.yml
+++ b/docs/mindsdb-docs/mkdocs.yml
@@ -41,12 +41,11 @@ plugins:
             'databases/tutorials/AiTablesInPostgreSQL': 'tutorials/postgresql.md'
             'databases/tutorials/AiTablesInMySQL': 'tutorials/mysql.md'
             'databases/MariaDB': 'tutorials/mariadb.md'
-            'installation/Linux/': 'installation/linux.md'
-            'installation/Windows/': 'installation/windows.md'
-            'installation/MacOS/': 'installation/macos.md'
-            'installation/macos/': '/deployment/macos.md'
+            'installation/Linux/': 'deployment/linux.md'
+            'installation/Windows/': 'deployment/windows.md'
+            'installation/MacOS/': 'deployment/macos.md'
     - table-reader
-
+    
 markdown_extensions:
   - codehilite
   - admonition


### PR DESCRIPTION
Fixes #1598

## Please describe what changes you made, in as much detail as possible
  - Changed the redirect URL for Windows, Mac, & Linux from `installation/*/` to `deployment/*.md`

mindsdb