### PR TITLE
A dirty little change to keep release versions pinned

### DIFF
--- a/docker/build.py
+++ b/docker/build.py
@@ -1,21 +1,35 @@
 import os
 import sys
+import requests
 
+installer_version_url = 'https://public.api.mindsdb.com/installer/@@beta_or_release/docker___success___None'
+
+api_response = requests.get(
+    installer_version_url.replace('@@beta_or_release', sys.argv[1]))
+
+if api_response.status_code != 200:
+    exit(1)
+
+installer_version = api_response.text
 
 os.system('mkdir -p dist')
-installer_version = '1.6'
 
-with open('Dockerfile.template', 'r') as fp:
+if sys.argv[1] == 'release':
+    container_name = 'mindsdb'
+    dockerfile_template = 'dockerfile_release.template'
+
+elif sys.argv[1] == 'beta':
+    container_name = 'mindsdb_beta'
+    dockerfile_template = 'dockerfile_beta.template'
+
+with open(dockerfile_template, 'r') as fp:
     content = fp.read()
     content = content.replace('@@beta_or_release', sys.argv[1])
+    content = content.replace('@@installer_version', installer_version)
 
 with open('dist/Dockerfile', 'w') as fp:
     fp.write(content)
 
-if sys.argv[1] == 'release':
-    container_name = 'mindsdb'
-elif sys.argv[1] == 'beta':
-    container_name = 'mindsdb_beta'
 print(f"""
         Build, tag publish:
         cd dist &&

--- a/docker/dockerfile_beta.template
+++ b/docker/dockerfile_beta.template
@@ -8,10 +8,9 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y git && \
     apt-get install -y curl && \
-    pip install mindsdb;
+    pip install mindsdb==@@installer_version;
 
 ENV PYTHONUNBUFFERED=1
-
 
 RUN echo '{' \
     '"config_version":"1.4",' \
@@ -45,5 +44,4 @@ RUN echo '{' \
     '}' \
 '}' > /root/mindsdb_config.json
 
-CMD bash -c 'if [ -n "$MDB_CONFIG_CONTENT" ]; then echo "$MDB_CONFIG_CONTENT" > /root/mindsdb_config.json; fi; pip install mindsdb==$(curl https://public.api.mindsdb.com/installer/@@beta_or_release/docker___started___None) && curl https://public.api.mindsdb.com/installer/@@beta_or_release/docker___success___None && python -m mindsdb --config=/root/mindsdb_config.json --api=http,mysql,mongodb'
-
+CMD bash -c 'if [ -n "$MDB_CONFIG_CONTENT" ]; then echo "$MDB_CONFIG_CONTENT" > /root/mindsdb_config.json; fi; pip install mindsdb==$(curl https://public.api.mindsdb.com/installer/@@beta_or_release/docker___started___None) && python -m mindsdb --config=/root/mindsdb_config.json --api=http,mysql,mongodb'

--- a/docker/dockerfile_release.template
+++ b/docker/dockerfile_release.template
@@ -1,0 +1,47 @@
+FROM docker.io/pytorch/pytorch:1.10.0-cuda11.3-cudnn8-runtime
+
+EXPOSE 47334/tcp
+EXPOSE 47335/tcp
+EXPOSE 47336/tcp
+
+ENV PYTHONUNBUFFERED=1
+
+RUN python -m pip install --prefer-binary --no-cache-dir --upgrade pip==21.3.1 && \
+    pip install --prefer-binary --no-cache-dir wheel==0.37.0 && \
+    pip install --prefer-binary --no-cache-dir mindsdb==@@installer_version
+
+RUN echo \
+    '{' \
+        '"config_version":"1.4",' \
+        '"storage_dir": "/root/mdb_storage",' \
+        '"log": {' \
+            '"level": {' \
+                '"console": "ERROR",' \
+                '"file": "WARNING",' \
+                '"db": "WARNING"' \
+            '}' \
+        '},' \
+        '"debug": false,' \
+        '"integrations": {},' \
+        '"api": {' \
+            '"http": {' \
+                '"host": "0.0.0.0",' \
+                '"port": "47334"' \
+            '},' \
+            '"mysql": {' \
+                '"host": "0.0.0.0",' \
+                '"password": "",' \
+                '"port": "47335",' \
+                '"user": "mindsdb",' \
+                '"database": "mindsdb",' \
+                '"ssl": true' \
+            '}', \
+             '"mongodb": {' \
+                '"host": "0.0.0.0",' \
+                '"port": "47336",' \
+                '"database": "mindsdb"' \
+            '}' \
+        '}' \
+    '}' > /root/mindsdb_config.json
+
+CMD bash -c 'if [ -n "$MDB_CONFIG_CONTENT" ]; then echo "$MDB_CONFIG_CONTENT" > /root/mindsdb_config.json; fi; python -m mindsdb --config=/root/mindsdb_config.json --api=http,mysql,mongodb'


### PR DESCRIPTION
This is a small change for container creation in Docker. **build.py** will create the following types of containers:
* Release: Statically created image to retain all transitive dependencies at the time of creation. MindsDB will not attempt to update on every startup. The PyTorch and MindsDB image is anchored to a specific version on build.
* Beta: Identical to the old image: PyTorch(latest), MindsDB(latest), Base image upgraded. MindsDB always tries to upgrade at startup.

The change has been small so as not to break previous usage. There is a lot of room for improvement in this process.