### PR TITLE
Fix CREATE PREDICTOR Query in tutorials

### DIFF
--- a/docs/mindsdb-docs/docs/sql/tutorials/mindsdb-superset-snowflake.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/mindsdb-superset-snowflake.md
@@ -64,7 +64,7 @@ When a table doesn’t have an exact match the query will return a null value. T
 Let’s create a debt model that allows us to approximate the debt value for any income value. We’ll train this debt model using the income table’s data.
 
 ```sql
-CREATE PREDICTOR debt_model TRAIN FROM income_table PREDICT debt;
+CREATE PREDICTOR debt_model FROM income_table PREDICT debt;
 ```
 
 MindsDB provides the **CREATE PREDICTOR** statement. When we execute this statement, the predictive model works in the background, automatically creating a vector representation of the data that can be visualized as follows.


### PR DESCRIPTION
Fixes #1729

## Please describe what changes you made, in as much detail as possible
  - Fix PREDICTOR query by removing TRAIN keyword:

mindsdb