### PR TITLE
Fixed broken links in documentation

### DIFF
--- a/docs/mindsdb-docs/docs/PredictorInterface.md
+++ b/docs/mindsdb-docs/docs/PredictorInterface.md
@@ -7,7 +7,7 @@ This section goes into detail about each of the methods exposed by Predictor and
 
 ## Predictor
 
->Note: The Predictor in MindsDB's words means Machine Learning Model.
+> Note: The Predictor in MindsDB's words means Machine Learning Model.
 
 ### Constructor
 
@@ -15,9 +15,10 @@ This section goes into detail about each of the methods exposed by Predictor and
 
 Constructs a new mindsdb predictor
 
-* name -- Required argument, the name of the predictor, used for saving the predictor, creating a new predictor with the same name as a previous one loads the data from the old predictor
-* root_folder -- The directory (also known as folder) where the predictor information should be saved
-* log_level -- The log level that the predictor should use, number from 0 to 50, with 0 meaning log everything and 50 meaning log only fatal errors:
+- name -- Required argument, the name of the predictor, used for saving the predictor, creating a new predictor with the same name as a previous one loads the data from the old predictor
+- root_folder -- The directory (also known as folder) where the predictor information should be saved
+- log_level -- The log level that the predictor should use, number from 0 to 50, with 0 meaning log everything and 50 meaning log only fatal errors:
+
 ```python
 DEBUG_LOG_LEVEL = 10
 INFO_LOG_LEVEL = 20
@@ -32,34 +33,34 @@ NO_LOGS_LOG_LEVEL = 50
 
 Teach the predictor to make predictions on a given dataset, extract information about the dataset and extract information about the resulting machine learning model making the predictions. This is the "main" functionality of mindsdb_native together with the "predict" method.
 
-* from_data -- the data that you want to use for training, this can be either a file, a pandas data frame, a url or a mindsdb data source.
+- from_data -- the data that you want to use for training, this can be either a file, a pandas data frame, a url or a mindsdb data source.
 
-* to_predict -- The columns/keys to be predicted (aka the targets, output columns, target variables), can be either a string (when specifying a single column) or a list of strings (when specifying multiple columns).
+- to_predict -- The columns/keys to be predicted (aka the targets, output columns, target variables), can be either a string (when specifying a single column) or a list of strings (when specifying multiple columns).
 
-* test_from_data -- Specify a different data source on which mindsdb should test the machine learning model, by default mindsdb_native takes testing and validation samples from your dataset to use during training and analysis, and only trains the predictive model on ~80% of the data. This might seem sub-optimal if you're not used to machine learning, but trust us, it allows us to have much better confidence in the model we give you.
+- test_from_data -- Specify a different data source on which mindsdb should test the machine learning model, by default mindsdb_native takes testing and validation samples from your dataset to use during training and analysis, and only trains the predictive model on ~80% of the data. This might seem sub-optimal if you're not used to machine learning, but trust us, it allows us to have much better confidence in the model we give you.
 
-*  **timeseries specific parameters**: group_by, window_size, order_by -- For more information on how to use these, please see the [advanced examples section dealing with timeseries](/tutorials/AdvancedExamples#what-is-a-timeseries). Please note, these are currently subject to change, though they will remain backwards compatible until v2.0.
+- **timeseries specific parameters**: group_by, window_size, order_by -- For more information on how to use these, please see the [advanced examples section dealing with timeseries](./tutorials/AdvancedExamples#what-is-a-timeseries). Please note, these are currently subject to change, though they will remain backwards compatible until v2.0.
 
-* ignore_columns -- Ignore certain columns from your data entirely.
+- ignore_columns -- Ignore certain columns from your data entirely.
 
-* stop_training_in_x_seconds -- Stop training the model after this amount of seconds, note, the full amount it takes for mindsdb_native to run might be up to twice the amount you specify in this value. Thought, usually, the model training constitutes ~70-90% of the total mindsdb_native runtime.
+- stop_training_in_x_seconds -- Stop training the model after this amount of seconds, note, the full amount it takes for mindsdb_native to run might be up to twice the amount you specify in this value. Thought, usually, the model training constitutes ~70-90% of the total mindsdb_native runtime.
 
-* stop_training_in_accuracy -- Deprecated argument, left for backwards compatibility, to be removed or revamped in v2.0, refrain from using, it has no effects.
+- stop_training_in_accuracy -- Deprecated argument, left for backwards compatibility, to be removed or revamped in v2.0, refrain from using, it has no effects.
 
-* backend -- The machine learning backend to use in order to train the model. This can be a string equal to `lightwood` (default) or `ludwig`, this can also be a custom model object.
+- backend -- The machine learning backend to use in order to train the model. This can be a string equal to `lightwood` (default) or `ludwig`, this can also be a custom model object.
 
-* rebuild_model -- Defaults to `True`, if this is set to `False` the model will be loaded and the model analysis and data analysis will be re-run, but a new model won't be trained.
+- rebuild_model -- Defaults to `True`, if this is set to `False` the model will be loaded and the model analysis and data analysis will be re-run, but a new model won't be trained.
 
-* use_gpu -- Defaults to `None` (autodetect), set to `True` if you have a GPU and want to make sure it's used or to `False` if you want to train the model on the CPU, this will speed up model training a lot in most situations. Note, that the default learning backend (lightwood) only work with relatively new (2016+) GPUs.
+- use_gpu -- Defaults to `None` (autodetect), set to `True` if you have a GPU and want to make sure it's used or to `False` if you want to train the model on the CPU, this will speed up model training a lot in most situations. Note, that the default learning backend (lightwood) only work with relatively new (2016+) GPUs.
 
-* equal_accuracy_for_all_output_categories -- When you have unbalanced target variable values, this will treat all of them as equally important when training the model. To see more information about this and an example, please see [advanced section](/tutorials/AdvancedExamples#unbalanced-dataset).
+- equal_accuracy_for_all_output_categories -- When you have unbalanced target variable values, this will treat all of them as equally important when training the model. To see more information about this and an example, please see [advanced section](./tutorials/AdvancedExamples#unbalanced-dataset).
 
-* output_categories_importance_dictionary -- A dictionary containing a number representing the importance for each (or some) values from the column to be predicted. An example of how his can be used (assume the column we are predicting is called `is_true` and takes two falues): `{'is_true': {'True':0.6, 'False':1}}`. The bigger the number (maximum value is one), the more important will it be for the model to predict that specific value correctly (usually at the cost of predicting other values correctly and getting more false positives for that value).
+- output_categories_importance_dictionary -- A dictionary containing a number representing the importance for each (or some) values from the column to be predicted. An example of how his can be used (assume the column we are predicting is called `is_true` and takes two falues): `{'is_true': {'True':0.6, 'False':1}}`. The bigger the number (maximum value is one), the more important will it be for the model to predict that specific value correctly (usually at the cost of predicting other values correctly and getting more false positives for that value).
 
-* advanced_args -- A dictionary of advanced arguments. Includes `force_disable_cache`, `force_categorical_encoding`, `handle_foreign_keys`,
-`use_selfaware_model`, `deduplicate_data`.
+- advanced_args -- A dictionary of advanced arguments. Includes `force_disable_cache`, `force_categorical_encoding`, `handle_foreign_keys`,
+  `use_selfaware_model`, `deduplicate_data`.
 
-* sample_settings -- A dictionary of options for sampling from the dataset. Includes `sample_for_analysis`. `sample_for_training`, `sample_margin_of_error`, `sample_confidence_level`, `sample_percentage`, `sample_function`.
+- sample_settings -- A dictionary of options for sampling from the dataset. Includes `sample_for_analysis`. `sample_for_training`, `sample_margin_of_error`, `sample_confidence_level`, `sample_percentage`, `sample_function`.
 
 If you are interested in using advanced_args or sample_settings but you are unsure of how they work, please shot us an email or create a github issue and we will help you.
 
@@ -71,27 +72,28 @@ If you are interested in using advanced_args or sample_settings but you are unsu
 
 Make a prediction about a given dataset.
 
-* when_data -- the data that you want to make the predictions for, this can be either a file, a pandas data frame, a url, a dictionary used for single prediction(column name: value) or a mindsdb data source.
+- when_data -- the data that you want to make the predictions for, this can be either a file, a pandas data frame, a url, a dictionary used for single prediction(column name: value) or a mindsdb data source.
 
-* update_cached_model -- Deprecated argument, left for backwards compatibility, to be removed or revamped in v2.0, refrain from using, it has no effects.
+- update_cached_model -- Deprecated argument, left for backwards compatibility, to be removed or revamped in v2.0, refrain from using, it has no effects.
 
-* use_gpu -- Defaults to `None` (autodetect), set to `True` if you have a GPU and want to make sure it's used or to `False` if you want to train the model on the CPU, this will speed up model training a lot in most situations. Note, that the default learning backend (lightwood) only work with relatively new (2016+) GPUs.
+- use_gpu -- Defaults to `None` (autodetect), set to `True` if you have a GPU and want to make sure it's used or to `False` if you want to train the model on the CPU, this will speed up model training a lot in most situations. Note, that the default learning backend (lightwood) only work with relatively new (2016+) GPUs.
 
-* advanced_args -- A dictionary of advanced arguments. Includes `force_disable_cache`.
+- advanced_args -- A dictionary of advanced arguments. Includes `force_disable_cache`.
 
-* backend -- The machine learning backend to use in order to train the model. This can be a string equal to `lightwood` (default) or `ludwig`, this can also be a custom model object. Note, you shouldn't use a different backend than the one you used to train the model, this will result in undefined behavior in the worst case scenario and most likely lead to a weird error. This defaults to whatever backend was last used when calling `learn` on this predictor.
+- backend -- The machine learning backend to use in order to train the model. This can be a string equal to `lightwood` (default) or `ludwig`, this can also be a custom model object. Note, you shouldn't use a different backend than the one you used to train the model, this will result in undefined behavior in the worst case scenario and most likely lead to a weird error. This defaults to whatever backend was last used when calling `learn` on this predictor.
 
-* run_confidence_variation_analysis -- Run a confidence variation analysis on each of the given input column, currently only works when making single predictions via `when_data`. It provides some more in-depth analysis of a given prediction, by specifying how the confidence would increase/decrease based on which of the columns in the prediction were not present (had null, None or empty values).
+- run_confidence_variation_analysis -- Run a confidence variation analysis on each of the given input column, currently only works when making single predictions via `when_data`. It provides some more in-depth analysis of a given prediction, by specifying how the confidence would increase/decrease based on which of the columns in the prediction were not present (had null, None or empty values).
 
 ## Test
+
 ` predictor.test(when_data=data, accuracy_score_functions='r2_score', score_using='predicted_value', predict_args={'use_gpu': True}):`
 
 Test the overall confidence of the predictor e.g {'rental_price_accuracy': 0.95}.
 
-* when_data -- Use this when you have data in either a file, a pandas data frame, or url to a file that you want to predict from.
-* accuracy_score_functions -- A single function or a dictionary for the form `{f'{target_name}': acc_func}` when multiple targets are used.
-* score_using -- What values from the `explanation` of the target to be used in the score function.
-* predict_args -- Dictionary of arguments to be passed to `predict` (same arguments that predict accepts), e.g: `predict_args={'use_gpu': True}`.
+- when_data -- Use this when you have data in either a file, a pandas data frame, or url to a file that you want to predict from.
+- accuracy_score_functions -- A single function or a dictionary for the form `{f'{target_name}': acc_func}` when multiple targets are used.
+- score_using -- What values from the `explanation` of the target to be used in the score function.
+- predict_args -- Dictionary of arguments to be passed to `predict` (same arguments that predict accepts), e.g: `predict_args={'use_gpu': True}`.
 
 ## Predictor Quality
 

--- a/docs/mindsdb-docs/docs/connect.md
+++ b/docs/mindsdb-docs/docs/connect.md
@@ -1,7 +1,7 @@
 # Connect your data
 
 !!! tip "The recommended way to connect MindsDB to your data store is through MindsDB Studio."
-    
+
     Below is a list of all the integrations we currently support:
 
     | SQL | NoSQL | Streams | Data Warehouse|
@@ -22,20 +22,18 @@
 1. From the left navigation menu, select Database Integration.
 2. Click on the `ADD DATABASE` button.
 3. In the `Connect to Database` modal window:
-    1. Select the Supported Database that you want to connect to.
-    2. Add the Integration name(how you want to name the integration between your database and MindsDB).
-    3. Add the Database name.
-    4. Add the Hostname.
-    5. Add Port.
-    6. Add the database user.
-    7. Add Password for the user.
-    8. Click on `CONNECT`.
+   1. Select the Supported Database that you want to connect to.
+   2. Add the Integration name(how you want to name the integration between your database and MindsDB).
+   3. Add the Database name.
+   4. Add the Hostname.
+   5. Add Port.
+   6. Add the database user.
+   7. Add Password for the user.
+   8. Click on `CONNECT`.
 
-![Connect to database](/assets/sql/datasource.gif)
+![Connect to database](./assets/sql/datasource.gif)
 
 !!! tip "Required inputs"
-    Note: For different type of database there could be different required inputs you need to provide.
+Note: For different type of database there could be different required inputs you need to provide.
 
-After connecting MindsDB and the database, use your SQL client to [connect to MindsDB as a database](/sql/connect/cloud/).
-
-
+After connecting MindsDB and the database, use your SQL client to [connect to MindsDB as a database](./sql/connect/cloud.md).

--- a/docs/mindsdb-docs/docs/contribute.md
+++ b/docs/mindsdb-docs/docs/contribute.md
@@ -6,13 +6,13 @@ Thank you for your interest in contributing to MindsDB. MindsDB is free, open so
 
 We use [GitHub issues](https://github.com/mindsdb/mindsdb/issues) to track bugs and features. Report them by opening a new issue and complete out all of the required inputs: `Your Python version`, `MindsDB version`, `Describe the bug` and `Steps to reproduce`.
 
-![Github Issue](/assets/report-issue.gif)
+![Github Issue](./assets/report-issue.gif)
 
 ## Documentation :book:
 
 We are always trying to improve our documentation. All Pull Requests that improve our grammar or docs structure or fix typos are welcomed.
 
-* Check the [MindsDB Docs](https://github.com/mindsdb/mindsdb-docs) repository and help us.
+- Check the [MindsDB Docs](https://github.com/mindsdb/mindsdb-docs) repository and help us.
 
 ## Easy contribution to issues :wrench:
 
@@ -25,7 +25,7 @@ Most of the issues that are open for contributions will be tagged with `good-fir
 5. Submit a Pull Request so that we can review your changes
 6. Write a commit message
 7. Make sure that the CI tests are GREEN
->NOTE: Be sure to merge the latest from "upstream" before making a Pull Request!
+   > NOTE: Be sure to merge the latest from "upstream" before making a Pull Request!
 
 Pull Request reviews are done on a regular basis. Please make sure you respond to our feedback/questions and sign our CLA.
 

--- a/docs/mindsdb-docs/docs/deployment/cloud.md
+++ b/docs/mindsdb-docs/docs/deployment/cloud.md
@@ -4,16 +4,16 @@ For a quick jumpstart into using MindsDB you can sign up for our Cloud. MindsDB 
 
 1. Create an account by visiting the [cloud.mindsdb.com/signup](https://cloud.mindsdb.com/signup) and filling out the sign-up form.
 
-    ![Sign up](/assets/cloud/login.png)
+   ![Sign up](./assets/cloud/login.png)
 
-2. After sign up, you will get a confirmation email to validate your account.    
+2. After sign up, you will get a confirmation email to validate your account.
 
-    ![Validate](/assets/cloud/email.png)
+   ![Validate](./assets/cloud/email.png)
 
 3. Once your account is validated, you can login to MindsDB Cloud.
 
-    ![Login](/assets/cloud/ready.png)
+   ![Login](./assets/cloud/ready.png)
 
 4. Now, you are ready to use MindsDB Cloud.
 
-    ![GUI](/assets/cloud/gui.png)
+   ![GUI](./assets/cloud/gui.png)

--- a/docs/mindsdb-docs/docs/deployment/docker.md
+++ b/docs/mindsdb-docs/docs/deployment/docker.md
@@ -8,7 +8,6 @@ docker run hello-world
 
 You should see the `Hello from Docker!` message displayed. If not, check the <a href="https://www.docker.com/get-started" target="_blank">Get Started</a> documentation.
 
-
 ### MindsDB container
 
 MindsDB images are uploaded to the <a href="https://hub.docker.com/u/mindsdb" target="_blank">MindsDB repo on docker hub</a> after each release.
@@ -31,9 +30,9 @@ docker pull mindsdb/mindsdb_beta
 
 By default, when you run the MindsDB container, it does not publish any of its ports. To make the ports available you must run the container by providing `-p` flag as:
 
-* `-p 47334:47334` - Map 47334 port which is used by the MindsDB GUI and the HTTP API. 
-* `-p 47335:47335` - Map 47335 to use MindsDB MySQL API.
-* `-p 47336:47336` - Map  47336 port to use MindsDB MongoDB API.
+- `-p 47334:47334` - Map 47334 port which is used by the MindsDB GUI and the HTTP API.
+- `-p 47335:47335` - Map 47335 to use MindsDB MySQL API.
+- `-p 47336:47336` - Map 47336 port to use MindsDB MongoDB API.
 
 #### Start container
 
@@ -43,15 +42,13 @@ Next, run the below command to start the container:
 docker run -p 47334:47334 mindsdb/mindsdb
 ```
 
-![Docker run](/assets/docker-install.gif)
+![Docker run](./assets/docker-install.gif)
 
 That's it. MindsDB should automatically start the Studio on your default browser.
 
 !!! warning "MKL Issues"
-	Note. If you experience any issue related to MKL or if your training process does not complete, please add env var or starter Docker with this command:
-	```
-	docker run --env MKL_SERVICE_FORCE_INTEL=1 -it -p 47334:47334 mindsdb/mindsdb
-	```
+Note. If you experience any issue related to MKL or if your training process does not complete, please add env var or starter Docker with this command:
+` docker run --env MKL_SERVICE_FORCE_INTEL=1 -it -p 47334:47334 mindsdb/mindsdb `
 
 #### Extend config.json
 
@@ -61,4 +58,4 @@ If you want to extend the default configuration, you will be able to send the co
 docker run -e MDB_CONFIG_CONTENT='{"api":{"http": {"host": "0.0.0.0","port": "47334"}}}' mindsdb/mindsdb
 ```
 
-Or, you can pipe `<`  the content of the file to the MDB_CONFIG_CONTENT.
+Or, you can pipe `<` the content of the file to the MDB_CONFIG_CONTENT.

--- a/docs/mindsdb-docs/docs/deployment/linux.md
+++ b/docs/mindsdb-docs/docs/deployment/linux.md
@@ -1,11 +1,11 @@
 # Deploy using pip
 
 !!! warning "Python 3.9"
-    Currently, some of our dependencies have issues with the latest versions of Python 3.9.x. For now, our suggestion is to use Python 3.7.x, or 3.8.x versions.
+Currently, some of our dependencies have issues with the latest versions of Python 3.9.x. For now, our suggestion is to use Python 3.7.x, or 3.8.x versions.
 
 We suggest you to install MindsDB in a virtual environment when using **pip** to avoid dependency issues. Make sure your Python version is **>=3.7** and pip version is **>=19.3**.
 
-1. Create and activate venv:
+1.  Create and activate venv:
 
     ```
     python -m venv mindsdb
@@ -15,64 +15,61 @@ We suggest you to install MindsDB in a virtual environment when using **pip** to
     source mindsdb/bin/activate
     ```
 
-2. Install MindsDB:
+2.  Install MindsDB:
 
     ```
     pip install mindsdb
     ```
 
-3. To verify that mindsdb was installed run:
+3.  To verify that mindsdb was installed run:
 
-    ```
-    pip freeze
-    ```
-You should see a list with the names of installed packages:
+        ```
+        pip freeze
+        ```
 
-![Pip list](/assets/pipfreeze.png)
+    You should see a list with the names of installed packages:
 
+![Pip list](./assets/pipfreeze.png)
 
 # Deploy using Anaconda
 
 !!! warning "Python 3.9"
-    Currently, some of our dependencies have issues with the latest versions of Python 3.9.x. For now, our suggestion is to use Python 3.7.x, or 3.8.x versions.
+Currently, some of our dependencies have issues with the latest versions of Python 3.9.x. For now, our suggestion is to use Python 3.7.x, or 3.8.x versions.
 
 You will need <a href="https://www.anaconda.com/products/individual" target="_blank">Anaconda</a> or <a href="https://conda.io/projects/conda/en/latest/index.html" target="_blank">Conda</a> installed and Python 64bit version. Then open Anaconda Prompt and:
 
 1. Create new virtual environment and install mindsdb:
 
-    ```
-    conda create -n mindsdb
-    ```
+   ```
+   conda create -n mindsdb
+   ```
 
-    ```
-    conda activate mindsdb
-    ```
+   ```
+   conda activate mindsdb
+   ```
 
-    ```
-    pip install mindsdb
-    ```
-
+   ```
+   pip install mindsdb
+   ```
 
 2. To verify that mindsdb was installed run:
 
-    ```
-    conda list
-    ```
+   ```
+   conda list
+   ```
 
 ## Troubleshooting
 
 If the installation fails, don't worry, simply follow the below below instruction which should fix most issues. If none of this works, try using the [docker container]() and create an issue with the installation errors you got on our [Github repository](https://github.com/mindsdb/mindsdb/issues). We'll try to review the issue and give you response within a few hours.
 
-
 !!! failure "`No module named mindsdb`"
-    If you get this error, make sure that your **virtual environment**(where you installed mindsdb) is activated.
-   
+If you get this error, make sure that your **virtual environment**(where you installed mindsdb) is activated.
+
 !!! failure "Installation fail"
-    Note that **Python 64** bit version is required.
+Note that **Python 64** bit version is required.
 
 !!! failure "IOError: [Errno 28] No space left on device while installing MindsDB"
-    MindsDB requires around 3GB of free disk space to install all of its dependencies.
+MindsDB requires around 3GB of free disk space to install all of its dependencies.
 
 !!! failure "Installation fail"
-    If you are using **Python 3.9** you may get installation errors. Some of the MindsDB's dependencies are not working with **Python 3.9**, so please downgrade to older versions for now. We are working on this and **Python 3.9** will be supported soon.
-
+If you are using **Python 3.9** you may get installation errors. Some of the MindsDB's dependencies are not working with **Python 3.9**, so please downgrade to older versions for now. We are working on this and **Python 3.9** will be supported soon.

--- a/docs/mindsdb-docs/docs/deployment/macos.md
+++ b/docs/mindsdb-docs/docs/deployment/macos.md
@@ -1,62 +1,62 @@
 # Deploy using pip
 
 !!! warning "Python 3.9"
-    Currently, some of our dependencies have issues with the latest versions of Python 3.9.x. For now, our suggestion is to use Python 3.7.x, or 3.8.x versions.
-    
+Currently, some of our dependencies have issues with the latest versions of Python 3.9.x. For now, our suggestion is to use Python 3.7.x, or 3.8.x versions.
+
 We suggest you to install MindsDB in a virtual environment when using **pip** to avoid dependency issues. Make sure your Python version is **>=3.7** and pip version **>= 19.3**.
 
 1. Create and activate venv:
 
-    ```
-    python -m venv mindsdb
-    ```
+   ```
+   python -m venv mindsdb
+   ```
 
-    ```
-    source mindsdb/bin/activate
-    ```
+   ```
+   source mindsdb/bin/activate
+   ```
 
 2. Install MindsDB:
 
-    ```
-    pip install mindsdb
-    ```
+   ```
+   pip install mindsdb
+   ```
 
 3. To verify that mindsdb was installed, run:
 
-    ```
-    pip freeze
-    ```
+   ```
+   pip freeze
+   ```
 
 You should see a list with the names of installed packages:
 
-![Pip list](/assets/pipfreeze.png)
+![Pip list](./assets/pipfreeze.png)
 
 # Deploy using Anaconda
 
 !!! warning "Python 3.9"
-    Currently, some of our dependencies have issues with the latest versions of Python 3.9.x. For now, our suggestion is to use Python 3.7.x, or 3.8.x versions.
+Currently, some of our dependencies have issues with the latest versions of Python 3.9.x. For now, our suggestion is to use Python 3.7.x, or 3.8.x versions.
 
 You will need <a href="https://www.anaconda.com/products/individual" target="_blank">Anaconda</a> or <a href="https://conda.io/projects/conda/en/latest/index.html" target="_blank">Conda</a> installed and a Python 64bit version. Then open the Anaconda prompt and:
 
 1. Create a new virtual environment and install mindsdb:
 
-    ```
-    conda create -n mindsdb
-    ```
+   ```
+   conda create -n mindsdb
+   ```
 
-    ```
-    conda activate mindsdb
-    ```
+   ```
+   conda activate mindsdb
+   ```
 
-    ```
-    pip install mindsdb
-    ```
+   ```
+   pip install mindsdb
+   ```
 
 2. To verify that mindsdb was installed, run:
 
-    ```
-    conda list
-    ```
+   ```
+   conda list
+   ```
 
 You should see a list with the names of installed packages.
 
@@ -64,20 +64,17 @@ You should see a list with the names of installed packages.
 
 If the installation fails, don't worry, simply follow the below below instruction which should fix most issues. If none of this works, try using the [docker container]() and create an issue with the installation errors you got on our [Github repository](https://github.com/mindsdb/mindsdb/issues). We'll try to review the issue and give you response within a few hours.
 
-
-!!! failure "numpy.distutils.system_info.NotFoundError: No lapack/blas resources found. Note: Accelerate is no longer supported." 
-    Please downgrade to an older version of Python for now **3.7.x** or **3.8.x**. We are working on this, and **Python 3.9** will be supported soon.
+!!! failure "numpy.distutils.system_info.NotFoundError: No lapack/blas resources found. Note: Accelerate is no longer supported."
+Please downgrade to an older version of Python for now **3.7.x** or **3.8.x**. We are working on this, and **Python 3.9** will be supported soon.
 
 !!! failure "Installation fail"
-    Note that **Python 64** bit version is required.
+Note that **Python 64** bit version is required.
 
 !!! failure "Installation fails because of system dependencies"
-    Try installing MindsDB with [Anaconda](https://www.anaconda.com/products/individual), and run the installation from the **anaconda prompt**.
+Try installing MindsDB with [Anaconda](https://www.anaconda.com/products/individual), and run the installation from the **anaconda prompt**.
 
 !!! failure "`No module named mindsdb`"
-    If you get this error, make sure that your **virtual environment**(where you installed mindsdb) is activated.
+If you get this error, make sure that your **virtual environment**(where you installed mindsdb) is activated.
 
 !!! failure "IOError: [Errno 28] No space left on device while installing MindsDB"
-    MindsDB requires around 3GB of free disk space to install all of its dependencies.
-  
-
+MindsDB requires around 3GB of free disk space to install all of its dependencies.

--- a/docs/mindsdb-docs/docs/deployment/pypi.md
+++ b/docs/mindsdb-docs/docs/deployment/pypi.md
@@ -2,7 +2,7 @@
 
 The recommended way is to always install inside a virtual environment when using `pip`. The `venv` provides an isolated Python environment, which is more practical than installing MindsDB systemwide. Follow below instructions depending on your operating system:
 
-* [Linux](/deployment/linux)
-* [Windows](/deployment/windows)
-* [MacOS](/deployment/macos)
-* [Source code](/deployment/source)
+- [Linux](./deployment/linux.md)
+- [Windows](./deployment/windows.md)
+- [MacOS](./deployment/macos.md)
+- [Source code](./deployment/source.md)

--- a/docs/mindsdb-docs/docs/index.md
+++ b/docs/mindsdb-docs/docs/index.md
@@ -1,20 +1,18 @@
 # What is MindsDB?
 
-MindsDB enables advanced predictive capabilities directly in your Database. This puts sophisticated machine learning techniques into the hands of anyone who knows SQL (data analysts, developers and business intelligence users) without the need for a new tool or significant training. 
+MindsDB enables advanced predictive capabilities directly in your Database. This puts sophisticated machine learning techniques into the hands of anyone who knows SQL (data analysts, developers and business intelligence users) without the need for a new tool or significant training.
 
-Data is the single most important ingredient in machine learning, and your data lives in a database. So why do machine learning anywhere else? 
+Data is the single most important ingredient in machine learning, and your data lives in a database. So why do machine learning anywhere else?
 
-
-![Machine Learning in Database using SQL](/assets/mdb_image.png)
+![Machine Learning in Database using SQL](./assets/mdb_image.png)
 
 ## The Vision:
 
-***A world where people use intelligent databases to make better data-driven decisions.***
+**_A world where people use intelligent databases to make better data-driven decisions._**
 
 ...and we believe the best way to make these decisions is to enable this capability within existing databases without the effort of creating a new one.
 
 (Despite the name we are not actually a database!)
-
 
 ## From Database Tables to Machine Learning Models
 
@@ -27,7 +25,6 @@ Data is the single most important ingredient in machine learning, and your data 
     ![SQFT vs Price](/assets/info/sqft-price.png)
 
 !!! note "You query the database for information in this table and if your search criteria generates a match: you get results:"
-    
 
     ```sql
     SELECT sqft, price FROM home_rentals_table WHERE sqft = 900;
@@ -46,13 +43,12 @@ Data is the single most important ingredient in machine learning, and your data 
 !!! tip "An ML model can be fitted to the data in the home rentals table."
 
     ```sql
-    CREATE PREDICTOR  home_rentals_model FROM home_rentals_table PREDICT price;   
+    CREATE PREDICTOR  home_rentals_model FROM home_rentals_table PREDICT price;
     ```
 
     ![Model](/assets/info/model.png)
 
 !!! success "An ML model can provide approximate answers for searches where there is no exact match in the income table:"
-    
 
     ```sql
     SELECT sqft, price FROM home_rentals_model WHERE sqft = 800;
@@ -60,7 +56,6 @@ Data is the single most important ingredient in machine learning, and your data 
 
     ![Query model](/assets/info/query.png)
 
-
 ## Getting Started
 
-To start using MindsDB, check out our [Getting Started Guide](/info)
+To start using MindsDB, check out our [Getting Started Guide](./info.md)

--- a/docs/mindsdb-docs/docs/info.md
+++ b/docs/mindsdb-docs/docs/info.md
@@ -10,12 +10,12 @@ Follow the below steps to get up and running with MindsDB.
 #### Steps:
 
 1.  Deploy MindsDB:
-    1.  [Docker](./deployment/docker) OR
-    2.  [Pip](./deployment/pypi) OR
-    3.  [MindsDB Cloud](./deployment/cloud)
-2.  [Connect your Data to MindsDB:](/connect)
+    1.  [Docker](./deployment/docker.md) OR
+    2.  [Pip](./deployment/pypi.md) OR
+    3.  [MindsDB Cloud](./deployment/cloud.md)
+2.  [Connect your Data to MindsDB:](/connect.md)
 3.  Connect to MindsDB like it was a Database using your preferred DB Client
-    1. Using [MindsDB Cloud](./sql/connect/cloud) OR
-    2. Using a [Local Deployment](./sql/connect/local)
+    1. Using [MindsDB Cloud](./sql/connect/cloud.md) OR
+    2. Using a [Local Deployment](./sql/connect/local.md)
 4.  CREATE a predictor (model) trained on your data
 5.  Make predictions using your model

--- a/docs/mindsdb-docs/docs/info.md
+++ b/docs/mindsdb-docs/docs/info.md
@@ -9,15 +9,13 @@ Follow the below steps to get up and running with MindsDB.
 
 #### Steps:
 
-1.  Deploy MindsDB: 
-    1.  [Docker](/deployment/docker) OR
-    2.  [Pip](/deployment/pypi) OR
-    3.  [MindsDB Cloud](/deployment/cloud)
-2. [Connect your Data to MindsDB:](/connect)
-3. Connect to MindsDB like it was a Database using your preferred DB Client
-    1. Using [MindsDB Cloud](/sql/connect/cloud) OR
-    2. Using a [Local Deployment](/sql/connect/local)
-4. CREATE a predictor (model) trained on your data
-5. Make predictions using your model
-
- 
+1.  Deploy MindsDB:
+    1.  [Docker](./deployment/docker) OR
+    2.  [Pip](./deployment/pypi) OR
+    3.  [MindsDB Cloud](./deployment/cloud)
+2.  [Connect your Data to MindsDB:](/connect)
+3.  Connect to MindsDB like it was a Database using your preferred DB Client
+    1. Using [MindsDB Cloud](./sql/connect/cloud) OR
+    2. Using a [Local Deployment](./sql/connect/local)
+4.  CREATE a predictor (model) trained on your data
+5.  Make predictions using your model

--- a/docs/mindsdb-docs/docs/info.md
+++ b/docs/mindsdb-docs/docs/info.md
@@ -13,7 +13,7 @@ Follow the below steps to get up and running with MindsDB.
     1.  [Docker](./deployment/docker.md) OR
     2.  [Pip](./deployment/pypi.md) OR
     3.  [MindsDB Cloud](./deployment/cloud.md)
-2.  [Connect your Data to MindsDB:](/connect.md)
+2.  [Connect your Data to MindsDB:](./connect.md)
 3.  Connect to MindsDB like it was a Database using your preferred DB Client
     1. Using [MindsDB Cloud](./sql/connect/cloud.md) OR
     2. Using a [Local Deployment](./sql/connect/local.md)


### PR DESCRIPTION
### Fixes
There were many broken links in the document as they were using absolute paths instead of relative ones (attached a sample screenshot). Fixed them by changing them to relative paths.
Example:
previous: ```[Docker](/deployment/docker)```
changed: ```[Docker](./deployment/docker.md)```
Had to add the file extension because they weren't working otherwise.

### Screenshots:
Documentation:
![mnds 1](https://user-images.githubusercontent.com/53753289/139557134-3f5ea4fd-4a1a-425a-919e-12a180fb0480.JPG)
Page:
 
![mnds 2](https://user-images.githubusercontent.com/53753289/139557137-600c4e7e-2745-497a-97de-1ddc51189e7d.JPG)

