### PR TITLE
Added VScode case in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ my_model.zip
 model.py
 tests/integration_tests/flows/model.py
 tests/integration_tests/flows/my_model.zip
-.vscode
 distributions/docker-compose/*/storage
 venv/*
 root
@@ -22,3 +21,8 @@ tests/prediction_latency_test/*.csv
 storage_dir
 docker/dist/*
 .directory
+
+# VisualStudioCode
+.vscode
+.vscode/*
+.history


### PR DESCRIPTION
Fixed issue #1731.

This commit is to add VS Code statements in the .gitignore file because
many developers currently use the IDE VS Code (https://code.visualstudio.com/)

Signed-off-by: Geunsik Lim <leemgs@gmail.com>
