### PR TITLE
Unbreak `import mindsdb`on Google Colab

### DIFF
--- a/mindsdb/utilities/functions.py
+++ b/mindsdb/utilities/functions.py
@@ -39,13 +39,10 @@ def cast_row_types(row, field_types):
 
 def is_notebook():
     try:
-        shell = get_ipython().__class__.__name__
-        if shell == 'ZMQInteractiveShell':
-            return True   # Jupyter notebook or qtconsole
-        elif shell == 'TerminalInteractiveShell':
-            return False  # Terminal running IPython
+        if 'IPKernelApp' in get_ipython().config:
+            return True
         else:
-            return False  # Other type (?)
+            return False
     except NameError:
         return False      # Probably standard Python interpreter
 


### PR DESCRIPTION
`import  mindsdb` for MindsDB 2.57.0 is broken in Google Colab.

```
usage: ipykernel_launcher.py [-h] [--api API] [--config CONFIG] [--verbose]
                             [--no_studio] [-v] [--ray]
ipykernel_launcher.py: error: unrecognized arguments: -f /root/.local/share/jupyter/runtime/kernel-86875774-eea9-43df-8fac-d91f2925addb.json

An exception has occurred, use %tb to see the full traceback.

SystemExit: 2

/usr/local/lib/python3.7/dist-packages/IPython/core/interactiveshell.py:2890: UserWarning: To exit: use 'exit', 'quit', or Ctrl-D.
  warn("To exit: use 'exit', 'quit', or Ctrl-D.", stacklevel=1)
```

`get_ipython().__class__.__name__` returns just `Shell` there.
This check should cover more possible notebooks.

Fixes #659
Fixes #922

## Please describe what changes you made, in as much detail as possible

Ordinary `ipython` in terminal.
```
In [2]: get_ipython().config
Out[2]: {}
```
JupyterLab.
```
{'IPKernelApp': {'connection_file': '/home/jovyan/.local/share/jupyter/runtime/kernel-25a1cd8e-47d6-43da-9a16-0dd51edd8a66.json'}}
```
Google Colab.
```
{'HistoryManager': {'hist_file': ':memory:'},
 'IPKernelApp': {'connection_file': '/root/.local/share/jupyter/runtime/kernel-86875774-eea9-43df-8fac-d91f2925addb.json',
  'kernel_class': 'google.colab._kernel.Kernel'},
 'InteractiveShellApp': {'exec_lines': [],
  'extensions': ['google.colab'],
  'matplotlib': 'inline',
  'reraise_ipython_extension_failures': True},
 'getdoc': <LazyConfigValue {}>}
```