### PR TITLE
docs(docker): add instructions for docker for mac

### DIFF
--- a/docs/mindsdb-docs/docs/deployment/docker.md
+++ b/docs/mindsdb-docs/docs/deployment/docker.md
@@ -13,6 +13,12 @@ You should see the `Hello from Docker!` message displayed. If not, check the <a 
 
 MindsDB images are uploaded to the <a href="https://hub.docker.com/u/mindsdb" target="_blank">MindsDB repo on docker hub</a> after each release.
 
+#### For "Docker for Mac" Users
+
+By default, Docker for Mac allocates __2.00GB of memory__. This is insufficient for deploying to docker. We recommend increasing the default memory limit to __4.00GB__. 
+
+Please refer to [https://docs.docker.com/desktop/mac/#resources](https://docs.docker.com/desktop/mac/#resources) for more information on how to increase the allocated memory.
+
 #### Pull image
 
 First, run the below command to pull our latest production image:


### PR DESCRIPTION
Fixes #

## Please describe what changes you made, in as much detail as possible

Currently the default docker for mac allocates 2GB of memory which is insufficient to run the mindsdb docker container. The process would fail with a cryptic "KILLED" message.

To rectify this, Docker for Mac users should bump their allocated memory to at least 4GB. 

This PR adds a note to users to do so before installation

mindsdb