### PR TITLE
For completeness sake add database parameter

### DIFF
--- a/docs/mindsdb-docs/docs/databases/MariaDB.md
+++ b/docs/mindsdb-docs/docs/databases/MariaDB.md
@@ -71,7 +71,8 @@ The available configuration options are:
            "password": "password",
            "port": 3306,
            "type": "mariadb",
-           "user": "root"
+           "user": "root",
+           "database":"mindsdb"
         }
     },
     "log": {


### PR DESCRIPTION
The database name may not be the default `mindsdb` (and the parameter seems supported).
