### PR TITLE
Fix 'install_requires' must be a string  error

### DIFF
--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -38,8 +38,8 @@ jobs:
         #python -m pip install --upgrade pip==21.0.1
         pip install 'pymssql >= 2.1.4'
         pip install boto3
-        # pip install --no-cache-dir .
-        pip install -r requirements.txt
+        pip install --no-cache-dir .
+        # pip install -r requirements.txt
       shell: bash
       env:
         ACCESS_KEY:  ${{ secrets.GH_ACCESS_KEY }}

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -38,8 +38,8 @@ jobs:
         #python -m pip install --upgrade pip==21.0.1
         pip install 'pymssql >= 2.1.4'
         pip install boto3
-        pip install --no-cache-dir .
-        # pip install -r requirements.txt
+        # pip install --no-cache-dir .
+        pip install -r requirements.txt
       shell: bash
       env:
         ACCESS_KEY:  ${{ secrets.GH_ACCESS_KEY }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ appdirs >= 1.0.0
 mindsdb-sql == 0.0.33
 dfsql == 0.6.6
 checksumdir >= 1.2.0
-git+https://github.com/mindsdb/mindsdb_streams.git@v0.0.3
+mindsdb_streams @ git+ssh://git@github.com/mindsdb/mindsdb_streams.git@v0.0.3


### PR DESCRIPTION
Fixes
```
'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Parse error at "'+https:/'": Expected stringEnd
```