### PR TITLE
Fix 'rename predictor' endpoint

### DIFF
--- a/mindsdb/interfaces/model/model_controller.py
+++ b/mindsdb/interfaces/model/model_controller.py
@@ -364,6 +364,9 @@ class ModelController():
         db_p = db.session.query(db.Predictor).filter_by(company_id=company_id, name=old_name).first()
         db_p.name = new_name
         db.session.commit()
+        dbw = DatabaseWrapper(company_id)
+        dbw.unregister_predictor(old_name)
+        dbw.register_predictors([self.get_model_data(new_name, company_id)])
 
     @mark_process(name='learn')
     def update_model(self, name: str, company_id: int):

--- a/mindsdb/interfaces/model/model_controller.py
+++ b/mindsdb/interfaces/model/model_controller.py
@@ -360,6 +360,11 @@ class ModelController():
 
         return 0
 
+    def rename_model(self, old_name, new_name, company_id: int):
+        db_p = db.session.query(db.Predictor).filter_by(company_id=company_id, name=old_name).first()
+        db_p.name = new_name
+        db.session.commit()
+
     @mark_process(name='learn')
     def update_model(self, name: str, company_id: int):
         # TODO: Add version check here once we're done debugging

--- a/mindsdb/interfaces/model/model_interface.py
+++ b/mindsdb/interfaces/model/model_interface.py
@@ -30,6 +30,9 @@ class ModelInterface():
     def delete_model(self, *args, **kwargs):
         return self.controller.delete_model(*args, **kwargs)
 
+    def rename_model(self, *args, **kwargs):
+        return self.controller.rename_model(*args, **kwargs)
+
     def update_model(self, *args, **kwargs):
         return self.controller.update_model(*args, **kwargs)
 


### PR DESCRIPTION
Fixes 

`rename` endpoint returns next error:
```
"'ModelInterface' object has no attribute 'rename_model'"
```
Fix it by implementing this method