### PR TITLE
Changed long tutorial name

### DIFF
--- a/docs/mindsdb-docs/mkdocs.yml
+++ b/docs/mindsdb-docs/mkdocs.yml
@@ -57,7 +57,7 @@ markdown_extensions:
       custom_checkbox: true
 nav:
   - What is MindsDB: index.md
-  - Getting Started Guide: 
+  - Getting Started Guide:
     - Getting Started: info.md
     - Docker: deployment/docker.md
     - Pip: deployment/pypi.md
@@ -77,16 +77,16 @@ nav:
     - JOIN: sql/api/join.md
   - Tutorials:
     - AI Tables intro: sql/tutorials/ai-tables.md
-    - Regression: 
+    - Regression:
       - Process Quality: sql/tutorials/process-quality.md
       - Bodyfat Prediction: sql/tutorials/bodyfat.md
       - Insurance Cost: sql/tutorials/insurance-cost-prediction.md
-    - Classification: 
+    - Classification:
       - Crop Recomendation: sql/tutorials/crop-prediction.md
       - Customer Churn: sql/tutorials/customer-churn.md
       - Heart Disease: sql/tutorials/heart-disease.md
-    - Time series: 
-      - AI-powered forecasts in Apache Superset and Snowflake: sql/tutorials/mindsdb-superset-snowflake.md
+    - Time series:
+      - AI powered forecasts with MindsDB: sql/tutorials/mindsdb-superset-snowflake.md
   - Contribution and Community:
       - How to contribute: contribute.md
       - Join our community: community.md


### PR DESCRIPTION
Fixes #1783

## Please describe what changes you made, in as much detail as possible
  - Renamed AI-powered forecasts in Apache Superset and Snowflake to AI powered forecasts with MindsDB in [mkdocs.yml](https://github.com/mindsdb/mindsdb/blob/staging/docs/mindsdb-docs/mkdocs.yml#L89)