### PR TITLE
Add trinods

### DIFF
--- a/mindsdb/integrations/__init__.py
+++ b/mindsdb/integrations/__init__.py
@@ -7,7 +7,7 @@ from .postgres.postgres import PostgreSQLConnectionChecker
 from .redis.redisdb import RedisConnectionChecker
 from .kafka.kafkadb import KafkaConnectionChecker
 from .snowflake.snowflake import SnowflakeConnectionChecker
-
+from .trinodb.trinodb import TrinodbConnectionChecker
 
 try:
     from .scylladb.scylladb import ScyllaDBConnectionChecker
@@ -32,7 +32,8 @@ CHECKERS = {
     "cockroachdb": PostgreSQLConnectionChecker,
     "redis": RedisConnectionChecker,
     "kafka": KafkaConnectionChecker,
-    "snowflake": SnowflakeConnectionChecker
+    "snowflake": SnowflakeConnectionChecker,
+    "trinodb": TrinodbConnectionChecker
 }
 
 

--- a/mindsdb/integrations/trinodb/trinodb.py
+++ b/mindsdb/integrations/trinodb/trinodb.py
@@ -1,0 +1,20 @@
+from mindsdb_datasources import TrinoDS
+
+
+class TrinodbConnectionChecker:
+    def __init__(self, **kwargs):
+        self.user = kwargs.get('user')
+        self.password = kwargs.get('password')
+        self.host = kwargs.get('host')
+        self.port = kwargs.get('port')
+        self.catalog = kwargs.get('catalog')
+        self.schema = kwargs.get('schema')
+
+    def check_connection(self):
+        try:
+            ds = TrinoDS('SELECT 1', self.user, self.password,  self.host, self.port,  self.catalog, self.schema )
+            assert len(ds.df) == 1
+        except Exception as e:
+            return False
+        else:
+            return True

--- a/mindsdb/interfaces/datastore/datastore.py
+++ b/mindsdb/interfaces/datastore/datastore.py
@@ -175,8 +175,22 @@ class DataStore():
 
             if dsClass is None:
                 raise Exception(f'Unsupported datasource: {source_type}, please install required dependencies!')
+
+            if integration['type'] in ['clickhouse']:
+                creation_info = {
+                    'class': dsClass.__name__,
+                    'args': [],
+                    'kwargs': {
+                        'query': source['query'],
+                        'user': integration['user'],
+                        'password': integration['password'],
+                        'host': integration['host'],
+                        'port': integration['port']
+                    }
+                }
+                ds = dsClass(**creation_info['kwargs'])
             
-            if integration['type'] in ['mssql', 'postgres', 'cockroachdb', 'mariadb', 'mysql', 'singlestore', 'cassandra', 'scylladb', 'clickhouse']:
+            elif integration['type'] in ['mssql', 'postgres', 'cockroachdb', 'mariadb', 'mysql', 'singlestore', 'cassandra', 'scylladb']:
                 creation_info = {
                     'class': dsClass.__name__,
                     'args': [],
@@ -220,7 +234,7 @@ class DataStore():
 
                 if 'database' in source:
                     kwargs['database'] = source['database']
-
+                
                 ds = dsClass(**kwargs)
 
             elif integration['type'] == 'snowflake':

--- a/mindsdb/interfaces/datastore/datastore.py
+++ b/mindsdb/interfaces/datastore/datastore.py
@@ -9,7 +9,7 @@ from mindsdb.__about__ import __version__ as mindsdb_version
 from mindsdb.interfaces.model.model_interface import ModelInterface
 from mindsdb_datasources import (
     FileDS, ClickhouseDS, MariaDS, MySqlDS, PostgresDS, MSSQLDS, MongoDS,
-    SnowflakeDS, AthenaDS, CassandraDS, ScyllaDS
+    SnowflakeDS, AthenaDS, CassandraDS, ScyllaDS, TrinoDS
 )
 from mindsdb.utilities.config import Config
 from mindsdb.interfaces.storage.db import session, Datasource, Semaphor, Predictor
@@ -164,7 +164,8 @@ class DataStore():
                 'snowflake': SnowflakeDS,
                 'athena': AthenaDS,
                 'cassandra': CassandraDS,
-                'scylladb': ScyllaDS
+                'scylladb': ScyllaDS,
+                'trinodb': TrinoDS
             }
 
             try:
@@ -174,8 +175,8 @@ class DataStore():
 
             if dsClass is None:
                 raise Exception(f'Unsupported datasource: {source_type}, please install required dependencies!')
-
-            if integration['type'] in ['clickhouse']:
+            
+            if integration['type'] in ['mssql', 'postgres', 'cockroachdb', 'mariadb', 'mysql', 'singlestore', 'cassandra', 'scylladb', 'clickhouse']:
                 creation_info = {
                     'class': dsClass.__name__,
                     'args': [],
@@ -187,21 +188,6 @@ class DataStore():
                         'port': integration['port']
                     }
                 }
-                ds = dsClass(**creation_info['kwargs'])
-
-            elif integration['type'] in ['mssql', 'postgres', 'cockroachdb', 'mariadb', 'mysql', 'singlestore', 'cassandra', 'scylladb']:
-                creation_info = {
-                    'class': dsClass.__name__,
-                    'args': [],
-                    'kwargs': {
-                        'query': source['query'],
-                        'user': integration['user'],
-                        'password': integration['password'],
-                        'host': integration['host'],
-                        'port': integration['port']
-                    }
-                }
-
                 kwargs = creation_info['kwargs']
 
                 integration_folder_name = f'integration_files_{company_id}_{integration["id"]}'
@@ -285,6 +271,23 @@ class DataStore():
                         'access_key': source['access_key'],
                         'secret_key': source['secret_key'],
                         'region_name': source['region_name']
+                    }
+                }
+
+                ds = dsClass(**creation_info['kwargs'])
+            
+            elif integration['type'] == 'trinodb':
+                creation_info = {
+                    'class': dsClass.__name__,
+                    'args': [],
+                    'kwargs': {
+                        'query': source['query'],
+                        'user': integration['user'],
+                        'password': integration['password'],
+                        'host': integration['host'],
+                        'port': integration['port'],
+                        'schema': integration['schema'],
+                        'catalog': integration['catalog']
                     }
                 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ psutil
 sqlalchemy >= 1.3.0
 sentry-sdk
 walrus==0.8.2
-mindsdb_datasources == 1.5.0
+mindsdb_datasources == 1.5.1
 flask-compress >= 1.0.0
 kafka-python >= 2.0.0
 appdirs >= 1.0.0


### PR DESCRIPTION
This PR adds TrinoDB as a supported datasource and upgrades the version of datasources to the latest. 

:information_source: Merge this after https://github.com/mindsdb/datasources/pull/59 PR, so mindsdb can install latest daasources from pypi :information_source: .