### PR TITLE
[Update config.py] | Change mysql deploy host

### DIFF
--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -56,7 +56,7 @@ class Config():
                     "port": "47334"
                 },
                 "mysql": {
-                    "host": "127.0.0.1",
+                    "host": "0.0.0.0",
                     "password": "",
                     "port": "47335",
                     "user": "mindsdb",


### PR DESCRIPTION
Changing mysql deploy host to 0.0.0.0 from 127.0.0.1 (loopback). The change allows the MindsDB MySQL API to listen over all network interfaces and not just localhost.

Fixes #1817 

## Please describe what changes you made, in as much detail as possible
  - Updated the mysql host to 0.0.0.0 so that the mindsdb server host will listen to external server requests over all network interfaces.

mindsdb