### PR TITLE
Move docker deploy to releases

### DIFF
--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -192,20 +192,3 @@ jobs:
         SOURCE_DIR: 'distributions/ver/dist'
         DEST_DIR: 'mindsdb-installer/ver'
 
-
-  deploy_to_dockerhub:
-      runs-on: ubuntu-latest
-      needs: [deploy_to_pypi, create_version_file]
-      if: github.ref == 'refs/heads/stable' && github.actor != 'mindsdbadmin'
-      steps:
-        - uses: actions/checkout@v2
-        - name: Docker Login
-          uses: docker/login-action@v1
-          with:
-            username: ${{ secrets.DOCKER_USERNAME }}
-            password: ${{ secrets.DOCKER_PASSWORD }}
-            
-        - name: Docker build and push
-          run: |
-            cd docker
-            python3 build.py release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,3 +56,20 @@ jobs:
         AWS_REGION: 'us-west-2'
         SOURCE_DIR: 'distributions/ver/dist'
         DEST_DIR: 'mindsdb-installer/ver'
+
+
+  deploy_to_dockerhub:
+      runs-on: ubuntu-latest
+      needs: create_version_file
+      steps:
+        - uses: actions/checkout@v2
+        - name: Docker Login
+          uses: docker/login-action@v1
+          with:
+            username: ${{ secrets.DOCKER_USERNAME }}
+            password: ${{ secrets.DOCKER_PASSWORD }}
+            
+        - name: Docker build and push
+          run: |
+            cd docker
+            python3 build.py release


### PR DESCRIPTION
This PR moves the docker deploy step to releases workflow so it runs after the create_version_file for prod.