### PR TITLE
Make confidence bound optional

### DIFF
--- a/mindsdb/api/mongo/responders/find.py
+++ b/mindsdb/api/mongo/responders/find.py
@@ -109,8 +109,10 @@ class Responce(Responder):
                     row[key + '_confidence'] = explanation[key]['confidence']
                     row[key + '_explain'] = explanation[key]
                 for key in min_max_keys:
-                    row[key + '_min'] = explanation[key]['confidence_lower_bound']
-                    row[key + '_max'] = explanation[key]['confidence_upper_bound']
+                    if 'confidence_lower_bound' in explanation[key]:
+                        row[key + '_min'] = explanation[key]['confidence_lower_bound']
+                    if 'confidence_upper_bound' in explanation[key]:
+                        row[key + '_max'] = explanation[key]['confidence_upper_bound']
                 data.append(row)
 
         else:

--- a/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
+++ b/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
@@ -411,7 +411,9 @@ class MindsDBDataNode(DataNode):
                 if 'anomaly' in explanation[key]:
                     row[key + '_anomaly'] = explanation[key]['anomaly']
             for key in min_max_keys:
-                row[key + '_min'] = explanation[key]['confidence_lower_bound']
-                row[key + '_max'] = explanation[key]['confidence_upper_bound']
+                if 'confidence_lower_bound' in explanation[key]:
+                    row[key + '_min'] = explanation[key]['confidence_lower_bound']
+                if 'confidence_upper_bound' in explanation[key]:
+                    row[key + '_max'] = explanation[key]['confidence_upper_bound']
 
         return data

--- a/mindsdb/interfaces/model/model_controller.py
+++ b/mindsdb/interfaces/model/model_controller.py
@@ -225,16 +225,19 @@ class ModelController():
             explain_arr = []
             dict_arr = []
             for i, row in enumerate(predictions):
-                explain_arr.append({
+                obj = {
                     target: {
                         'predicted_value': row['prediction'],
                         'confidence': row.get('confidence', None),
-                        'confidence_lower_bound': row.get('lower', None),
-                        'confidence_upper_bound': row.get('upper', None),
                         'anomaly': row.get('anomaly', None),
                         'truth': row.get('truth', None)
                     }
-                })
+                }
+                if 'lower' in row:
+                    obj[target]['confidence_lower_bound'] = row.get('lower', None)
+                    obj[target]['confidence_upper_bound'] = row.get('upper', None)
+                    
+                explain_arr.append(obj)
 
                 td = {'predicted_value': row['prediction']}
                 for col in df.columns:


### PR DESCRIPTION
Confidence bounds will *not* be presented to the user at all when they are missing from the model's predictions (rather than being replaced by `None`)