### PR TITLE
Added the mysql port to docker run command

### DIFF
--- a/docs/mindsdb-docs/docs/deployment/docker.md
+++ b/docs/mindsdb-docs/docs/deployment/docker.md
@@ -46,8 +46,9 @@ By default, when you run the MindsDB container, it does not publish any of its p
 Next, run the below command to start the container:
 
 ```
-docker run -p 47334:47334 mindsdb/mindsdb
+docker run -p 47334:47334 -p 47335:47335 mindsdb/mindsdb
 ```
+Note. the above command only have ports for GUI and MYSQL. Please add your desired db port before you run the command. 
 
 ![Docker run](/assets/docker-install.gif)
 


### PR DESCRIPTION
## Fixes 
Added MySQL port to the docker run command and wrote a note to hint about any other DB ports. 

## Please describe what changes you made, in as much detail as possible
Added MySQL port to the tutorial as it shows in the next step to connect to the MySQL and it this step doesn't give any hint of opening the MySQL port. 
This is related to the issue https://github.com/mindsdb/mindsdb/issues/1947

mindsdb