### PR TITLE
removing repetitive variables and nested if statements

### DIFF
--- a/mindsdb/integrations/clickhouse/clickhouse.py
+++ b/mindsdb/integrations/clickhouse/clickhouse.py
@@ -167,12 +167,10 @@ class Clickhouse(Integration, ClickhouseConnectionChecker):
             ORDER BY database, table;
         """
         tables_list = self._query(q)
-        tables = [f"{table[0]}.{table[1]}" for table in tables_list]
-        return tables
+        return [f"{table[0]}.{table[1]}" for table in tables_list]
 
     def get_columns(self, query):
         q = f"SELECT * FROM ({query}) LIMIT 1 FORMAT JSON"
         query_result = self._query(q).json()
         columns_info = query_result['meta']
-        columns = [column['name'] for column in columns_info]
-        return columns
+        return [column['name'] for column in columns_info]

--- a/mindsdb/integrations/kafka/kafkadb.py
+++ b/mindsdb/integrations/kafka/kafkadb.py
@@ -34,9 +34,11 @@ class Kafka(StreamIntegration, KafkaConnectionChecker):
         self.control_connection_info = deepcopy(self.connection_info)
         # don't need to read all records from the beginning of 'control stream'
         # since all active streams are saved in db. Use 'latest' auto_offset_reset for control stream
-        if 'advanced' in self.control_connection_info:
-            if 'consumer' in self.control_connection_info['advanced']:
-                self.control_connection_info['advanced']['consumer']['auto_offset_reset'] = 'latest'
+        if (
+            'advanced' in self.control_connection_info
+            and 'consumer' in self.control_connection_info['advanced']
+        ):
+            self.control_connection_info['advanced']['consumer']['auto_offset_reset'] = 'latest'
 
         StreamIntegration.__init__(
             self,

--- a/mindsdb/integrations/mysql/mysql.py
+++ b/mindsdb/integrations/mysql/mysql.py
@@ -116,11 +116,9 @@ class MySQL(Integration, MySQLConnectionChecker):
         port = self.config['api']['mysql']['port']
 
         if password is None or password == '':
-            connect = f'mysql://{user}@{host}:{port}/mindsdb/{table}'
+            return f'mysql://{user}@{host}:{port}/mindsdb/{table}'
         else:
-            connect = f'mysql://{user}:{password}@{host}:{port}/mindsdb/{table}'
-
-        return connect
+            return f'mysql://{user}:{password}@{host}:{port}/mindsdb/{table}'
 
     def setup(self):
         self._query(f'DROP DATABASE IF EXISTS {self.mindsdb_database}')
@@ -204,12 +202,10 @@ class MySQL(Integration, MySQLConnectionChecker):
         q = f"SELECT * from ({query}) LIMIT 1;"
         query_response = self._query(q)
         if len(query_response) > 0:
-            columns = list(query_response[0].keys())
-            return columns
+            return list(query_response[0].keys())
         else:
             return []
 
     def get_tables_list(self):
         q = "SHOW TABLES;"
-        result = self._query(q)
-        return result
+        return self._query(q)

--- a/mindsdb/interfaces/ai_table/ai_table.py
+++ b/mindsdb/interfaces/ai_table/ai_table.py
@@ -13,14 +13,19 @@ class AITableStore():
     def get_ai_table(self, name):
         ''' get particular ai table
         '''
-        aitable_record = session.query(AITable).filter_by(company_id=self.company_id, name=name.lower()).first()
-        return aitable_record
+        return (
+            session.query(AITable)
+            .filter_by(company_id=self.company_id, name=name.lower())
+            .first()
+        )
 
     def get_ai_tables(self):
         ''' get list of ai tables
         '''
-        aitable_records = [x.__dict__ for x in session.query(AITable).filter_by(company_id=self.company_id)]
-        return aitable_records
+        return [
+            x.__dict__
+            for x in session.query(AITable).filter_by(company_id=self.company_id)
+        ]
 
     def add(self, name, integration_name, integration_query, query_fields, predictor_name, predictor_fields):
         ai_table_record = AITable(

--- a/mindsdb/interfaces/database/database.py
+++ b/mindsdb/interfaces/database/database.py
@@ -58,7 +58,7 @@ class DatabaseWrapper():
                 if y.get('publish') is True
             ]
         else:
-            all_integrations = [x for x in self.datasource_interface.get_db_integrations()]
+            all_integrations = list(self.datasource_interface.get_db_integrations())
         integrations = [self._get_integration(x) for x in all_integrations]
         integrations = [x for x in integrations if x is not True and x is not False]
         return integrations
@@ -93,8 +93,7 @@ class DatabaseWrapper():
                 logger.warning(f"There is no connection to {integration.name}. predictor wouldn't be unregistred")
 
     def check_connections(self):
-        connections = {}
-        for integration in self._get_integrations():
-            connections[integration.name] = integration.check_connection()
-
-        return connections
+        return {
+            integration.name: integration.check_connection()
+            for integration in self._get_integrations()
+        }

--- a/mindsdb/interfaces/database/integrations.py
+++ b/mindsdb/interfaces/database/integrations.py
@@ -74,7 +74,7 @@ class DatasourceController:
             session.commit()
             integration_id = integration_record.id
 
-            if len(files) > 0:
+            if files:
                 integrations_dir = Config()['paths']['integrations']
                 folder_name = f'integration_files_{company_id}_{integration_id}'
                 integration_dir = os.path.join(integrations_dir, folder_name)
@@ -179,9 +179,8 @@ class DatasourceController:
 
     def get_db_integrations(self, company_id=None, sensitive_info=True):
         integration_records = session.query(Integration).filter_by(company_id=company_id).all()
-        integration_dict = {}
-        for record in integration_records:
-            if record is None or record.data is None:
-                continue
-            integration_dict[record.name] = self._get_integration_record_data(record, sensitive_info)
-        return integration_dict
+        return {
+            record.name: self._get_integration_record_data(record, sensitive_info)
+            for record in integration_records
+            if record is not None and record.data is not None
+        }

--- a/mindsdb/interfaces/database/views.py
+++ b/mindsdb/interfaces/database/views.py
@@ -38,7 +38,7 @@ class ViewController:
 
     def get_all(self, company_id=None):
         view_records = session.query(View).filter_by(company_id=company_id).all()
-        views_dict = {}
-        for record in view_records:
-            views_dict[record.name] = self._get_view_record_data(record)
-        return views_dict
+        return {
+            record.name: self._get_view_record_data(record)
+            for record in view_records
+        }

--- a/mindsdb/interfaces/datastore/datastore.py
+++ b/mindsdb/interfaces/datastore/datastore.py
@@ -90,8 +90,7 @@ class DataStore():
         datasource_record = session.query(Datasource).filter_by(company_id=company_id, name=name).first()
         if datasource_record.analysis is None:
             return None
-        analysis = json.loads(datasource_record.analysis)
-        return analysis
+        return json.loads(datasource_record.analysis)
 
     def start_analysis(self, name, company_id=None):
         datasource_record = session.query(Datasource).filter_by(company_id=company_id, name=name).first()
@@ -137,10 +136,10 @@ class DataStore():
         return datasource_arr
 
     def get_data(self, name, where=None, limit=None, offset=None, company_id=None):
-        offset = 0 if offset is None else offset
         ds = self.get_datasource_obj(name, company_id=company_id)
 
         if limit is not None:
+            offset = 0 if offset is None else offset
             # @TODO Add `offset` to the `filter` method of the datasource and get rid of `offset`
             filtered_ds = ds.filter(where=where, limit=limit + offset).iloc[offset:]
         else:


### PR DESCRIPTION
Fixes #

## Changes done
 1. Inline Immediately Returned Variables-_inlining a variable to a **return** in the case when the variable being declared is immediately returned_
 ### example:
* before
```clickhouse.py
def get_columns(self, query):
        q = f"SELECT * FROM ({query}) LIMIT 1 FORMAT JSON"
        query_result = self._query(q).json()
        columns_info = query_result['meta']
        columns = [column['name'] for column in columns_info]
        return columns
```
* After 
```clickhouse.py
def get_columns(self, query):
        q = f"SELECT * FROM ({query}) LIMIT 1 FORMAT JSON"
        query_result = self._query(q).json()
        columns_info = query_result['meta']
        return [column['name'] for column in columns_info]
```

2. Removing nested if-if statements with  **and** to enhance code readability
### example
* before
``` kafka.py
 if 'advanced' in self.control_connection_info:
            if 'consumer' in self.control_connection_info['advanced']:
                self.control_connection_info['advanced']['consumer']['auto_offset_reset'] = 'latest'
```
* After
``` kafka.py
  if (
            'advanced' in self.control_connection_info
            and 'consumer' in self.control_connection_info['advanced']
        ):
            self.control_connection_info['advanced']['consumer']['auto_offset_reset'] = 'latest'
```
mindsdb