### PR TITLE
NLP API

### DIFF
--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -146,6 +146,11 @@ if __name__ == '__main__':
     else:
         api_arr = args.api.split(',')
 
+    with_nlp = False
+    if 'nlp' in args.api:
+        with_nlp = True
+        args.api.remove('nlp')
+        
     apis = {
         api: {
             'port': config['api'][api]['port'],
@@ -166,7 +171,7 @@ if __name__ == '__main__':
         print(f'{api_name} API: starting...')
         try:
             if api_name == 'http':
-                p = ctx.Process(target=start_functions[api_name], args=(args.verbose, args.no_studio))
+                p = ctx.Process(target=start_functions[api_name], args=(args.verbose, args.no_studio, with_nlp))
             else:
                 p = ctx.Process(target=start_functions[api_name], args=(args.verbose,))
             p.start()

--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -147,10 +147,10 @@ if __name__ == '__main__':
         api_arr = args.api.split(',')
 
     with_nlp = False
-    if 'nlp' in args.api:
+    if 'nlp' in api_arr:
         with_nlp = True
-        args.api.remove('nlp')
-        
+        api_arr.remove('nlp')
+
     apis = {
         api: {
             'port': config['api'][api]['port'],

--- a/mindsdb/api/http/start.py
+++ b/mindsdb/api/http/start.py
@@ -10,6 +10,7 @@ from flask import send_from_directory, request, current_app
 from flask_compress import Compress
 
 from mindsdb.api.http.namespaces.predictor import ns_conf as predictor_ns
+from mindsdb.api.nlp.nlp import ns_conf as nlp_ns
 from mindsdb.api.http.namespaces.datasource import ns_conf as datasource_ns
 from mindsdb.api.http.namespaces.util import ns_conf as utils_ns
 from mindsdb.api.http.namespaces.config import ns_conf as conf_ns
@@ -21,7 +22,7 @@ from mindsdb.utilities.config import Config
 from mindsdb.interfaces.storage.db import session
 
 
-def start(verbose, no_studio):
+def start(verbose, no_studio, with_nlp):
     config = Config()
 
     initialize_log(config, 'http', wrap_print=True)
@@ -56,6 +57,8 @@ def start(verbose, no_studio):
     api.add_namespace(utils_ns)
     api.add_namespace(conf_ns)
     api.add_namespace(stream_ns)
+    if with_nlp:
+        api.add_namespace(nlp_ns)
 
     @api.errorhandler(Exception)
     def handle_exception(e):

--- a/mindsdb/api/nlp/nlp.py
+++ b/mindsdb/api/nlp/nlp.py
@@ -13,25 +13,24 @@ class PredictorList(Resource):
     def get(self, query):
         '''Turn a natural language query into a sql query and deliver the response'''
         # For more info on ITG see https://github.com/mindsdb/ITG/tree/staging/itg
-        from itg import itg
-        # @TODO here and/or when this ns is started register all the user db schemas + mindsdb's db schema
-        # itg.register((dataframe, 'db_name'))
-
-        sql = itg(query)
-        print(f'The NLP API got the natural language query "{query}" and will execute the sql query: {sql}')
-
-        con = mysql.connector.connect(
-            host='localhost',
-            port='47335',
-            user='mindsdb',
-            password='',
-            database='mindsdb'
-        )
-
-        cur = con.cursor(dictionary=True, buffered=True)
-        cur.execute(query)
-        res = True
         try:
+            from itg import itg
+            # @TODO here and/or when this ns is started register all the user db schemas + mindsdb's db schema
+            # itg.register((dataframe, 'db_name'))
+
+            sql = itg(query).query
+            print(f'The NLP API got the natural language query "{query}" and will execute the sql query: {sql}')
+
+            con = mysql.connector.connect(
+                host='localhost',
+                port='47335',
+                user='mindsdb',
+                password='',
+                database='mindsdb'
+            )
+
+            cur = con.cursor(dictionary=True, buffered=True)
+            cur.execute(query)
             res = cur.fetchall()
             status = 200
         except Exception as e:

--- a/mindsdb/api/nlp/nlp.py
+++ b/mindsdb/api/nlp/nlp.py
@@ -1,0 +1,43 @@
+from flask_restx import Namespace, Resource
+import mysql.connector
+
+
+ns_conf = Namespace('nlp', description='The NLP API of mindsdb')
+
+
+@ns_conf.route('/<query>')
+@ns_conf.param('query', 'The natural language query')
+@ns_conf.response(404, 'query failed')
+class PredictorList(Resource):
+    @ns_conf.doc('list_predictors')
+    def get(self, query):
+        '''Turn a natural language query into a sql query and deliver the response'''
+        # For more info on ITG see https://github.com/mindsdb/ITG/tree/staging/itg
+        from itg import itg
+        # @TODO here and/or when this ns is started register all the user db schemas + mindsdb's db schema
+        # itg.register((dataframe, 'db_name'))
+
+        sql = itg(query)
+        print(f'The NLP API got the natural language query "{query}" and will execute the sql query: {sql}')
+
+        con = mysql.connector.connect(
+            host='localhost',
+            port='47335',
+            user='mindsdb',
+            password='',
+            database='mindsdb'
+        )
+
+        cur = con.cursor(dictionary=True, buffered=True)
+        cur.execute(query)
+        res = True
+        try:
+            res = cur.fetchall()
+            status = 200
+        except Exception as e:
+            res = {'error': str(e), 'sql_query': sql}
+            status = 400
+        con.commit()
+        con.close()
+
+        return res, status


### PR DESCRIPTION
Added an NLP API to mindsdb using our very own ITG text-to-sql project, still sucks really badly, just here as a placeholder for experimenting.

Currently, the approach is to add an `/nlp` namespace to the HTTP API if `nlp` is specified in the `--api` list, turn nl queries into SQL, execute them on the MySQL API (though TCP conn on localhost, maybe calling some internal function would be better though?) then return the answer and/or resulting error + query.

Example of usage:

`python3 -m mindsdb --api=http,mysql,nlp`
`curl -X GET http://127.0.0.1:47334/api/nlp/select%20every%20row%20from%20the%20home%20rentals%20dataset`