### PR TITLE
Update docs to use db_name.table_name as default syntax.

### DIFF
--- a/docs/mindsdb-docs/docs/sql/api/predictor.md
+++ b/docs/mindsdb-docs/docs/sql/api/predictor.md
@@ -3,7 +3,7 @@
 The `CREATE PREDICTOR` statement is used to train a new model. The basic syntax for training a model is:
 
 ```sql
-CREATE PREDICTOR predictor_name
+CREATE PREDICTOR db_name.predictor_name
 FROM integration_name 
 (SELECT column_name, column_name2 FROM table_name) as ds_name
 PREDICT column_name as column_alias;


### PR DESCRIPTION
- [ ] CREATE PREDICTOR mindsdb.<name> is supported so here: https://docs.mindsdb.com/sql/api/predictor/
- [ ] CREATE PREDICTOR mindsdb.<name> is supported and here: https://docs.mindsdb.com/sql/api/view/
- [ ] CREATE PREDICTOR mindsdb.<name> is supported and updates the tutorials and getting started guides accordingly
- [ ] CREATE PREDICTOR mindsdb.<name> is supported same as here https://docs.mindsdb.com/sql/api/describe/
- [ ] CREATE PREDICTOR mindsdb.<name> is supported that will also simplify how we do https://docs.mindsdb.com/sql/api/select/
- [ ] CREATE PREDICTOR mindsdb.<name> is supported and we may not need: https://docs.mindsdb.com/sql/api/SELECT_Files/