### PR TITLE
added helm chart

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,93 @@
+# mindsdb
+
+[MindsDB](https://mindsdb.com?utm_medium=community&utm_source=github&utm_campaign=mindsdb%20repo) enables you to use ML predictions in your database using SQL.
+
+- Developers can quickly add AI capabilities to your applications.
+- Data Scientists can streamline MLOps by deploying ML models as AI Tables.
+- Data Analysts can easily make forecasts on complex data (like multivariate time-series with high cardinality) and visualize them in BI tools like Tableau.
+
+# Pre-requisites
+
+- Kubernetes
+- Helm 3.0+
+
+# Installing the Chart
+
+```bash
+helm upgrade -i \
+  mindsdb mindsdb \
+  --namespace mindsdb \
+  --create-namespace
+```
+
+# Configuration
+
+All the configurations can be done in the [values.yaml](./mindsdb/values.yaml) file or you can create a seperate YAML file with only the values that you want to override and pass it with a `-f` to the `helm install` command
+
+### Image
+
+| Parameter          | Description                                                                             | Default           |
+| ------------------ | --------------------------------------------------------------------------------------- | ----------------- |
+| `image.repository` | Image to start for this pod                                                             | `mindsdb/mindsbd` |
+| `image.tag`        | [Image tag](https://hub.docker.com/r/mindsdb/mindsdb/tags?page=1&ordering=last_updated) | `latest`          |
+| `image.pullPolicy` | Image pull policy                                                                       | `Always`          |
+
+### Ingress
+
+| Parameter                            | Description                                                                 | Default                                            |
+| ------------------------------------ | --------------------------------------------------------------------------- | -------------------------------------------------- |
+| `ingress.enabled`                    | enable ingress                                                              | `false`                                            |
+| `ingress.annotations`                | add ingress annotations                                                     |                                                    |
+| `ingress.hosts[0].host`              | add hosts for ingress                                                       | `chart-example.local`                              |
+| `ingress.hosts[0].paths[0].path`     | add path for each ingress host                                              | `/`                                                |
+| `ingress.hosts[0].paths[0].pathType` | add ingress path type                                                       | `ImplementationSpecific`                           |
+| `ingress.tls`                        | add ingress tls settings                                                    | `[]`                                               |
+| `ingress.className`                  | add ingress class name. Only used in k8s 1.19+                              |                                                    |
+| `ingress.apiVersion`                 | specify APIVersion of ingress object. Mostly would only be used for argocd. | version indicated by helm's `Capabilities` object. |
+
+### Service
+
+#### Web
+
+| Parameter                               | Description                                                                                                  | Default     |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ----------- |
+| `service.http.enabled`                  | Enable Web service                                                                                           | `true`      |
+| `service.http.type`                     | Kubernetes service type for web traffic                                                                      | `ClusterIP` |
+| `service.http.port`                     | Port for web traffic                                                                                         | `47334`     |
+| `service.http.clusterIP`                | ClusterIP setting for http autosetup for statefulset is None                                                 | `None`      |
+| `service.http.loadBalancerIP`           | LoadBalancer Ip setting                                                                                      |             |
+| `service.http.nodePort`                 | NodePort for http service                                                                                    |             |
+| `service.http.externalTrafficPolicy`    | If `service.http.type` is `NodePort` or `LoadBalancer`, set this to `Local` to enable source IP preservation |             |
+| `service.http.externalIPs`              | http service external IP addresses                                                                           |             |
+| `service.http.loadBalancerSourceRanges` | Source range filter for http loadbalancer                                                                    | `[]`        |
+| `service.http.annotations`              | http service annotations                                                                                     |             |
+
+#### MySQL
+
+| Parameter                               | Description                                                                                                  | Default     |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ----------- |
+| `service.mysql.enabled`                  | Enable MySQL service                                                                                           | `true`      |
+| `service.mysql.type`                     | Kubernetes service type for MySQL traffic                                                                      | `ClusterIP` |
+| `service.mysql.port`                     | Port for MySQL traffic                                                                                         | `47335`     |
+| `service.mysql.clusterIP`                | ClusterIP setting for MySQL autosetup for statefulset is None                                                 | `None`      |
+| `service.mysql.loadBalancerIP`           | LoadBalancer Ip setting                                                                                      |             |
+| `service.mysql.nodePort`                 | NodePort for http service                                                                                    |             |
+| `service.mysql.externalTrafficPolicy`    | If `service.mysql.type` is `NodePort` or `LoadBalancer`, set this to `Local` to enable source IP preservation |             |
+| `service.mysql.externalIPs`              | MySQL service external IP addresses                                                                           |             |
+| `service.mysql.loadBalancerSourceRanges` | Source range filter for MySQL loadbalancer                                                                    | `[]`        |
+| `service.mysql.annotations`              | MySQL service annotations                                                                                     |             |
+
+#### MongoDB
+
+| Parameter                               | Description                                                                                                  | Default     |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ----------- |
+| `service.mongodb.enabled`                  | Enable MongoDB service                                                                                           | `true`      |
+| `service.mongodb.type`                     | Kubernetes service type for MongoDB traffic                                                                      | `ClusterIP` |
+| `service.mongodb.port`                     | Port for MongoDB traffic                                                                                         | `47335`     |
+| `service.mongodb.clusterIP`                | ClusterIP setting for MongoDB autosetup for statefulset is None                                                 | `None`      |
+| `service.mongodb.loadBalancerIP`           | LoadBalancer Ip setting                                                                                      |             |
+| `service.mongodb.nodePort`                 | NodePort for http service                                                                                    |             |
+| `service.mongodb.externalTrafficPolicy`    | If `service.mongodb.type` is `NodePort` or `LoadBalancer`, set this to `Local` to enable source IP preservation |             |
+| `service.mongodb.externalIPs`              | MongoDB service external IP addresses                                                                           |             |
+| `service.mongodb.loadBalancerSourceRanges` | Source range filter for MongoDB loadbalancer                                                                    | `[]`        |
+| `service.mongodb.annotations`              | MongoDB service annotations                                                                                     |             |

--- a/helm/README.md
+++ b/helm/README.md
@@ -83,7 +83,7 @@ All the configurations can be done in the [values.yaml](./mindsdb/values.yaml) f
 | --------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ----------- |
 | `service.mongodb.enabled`                  | Enable MongoDB service                                                                                           | `true`      |
 | `service.mongodb.type`                     | Kubernetes service type for MongoDB traffic                                                                      | `ClusterIP` |
-| `service.mongodb.port`                     | Port for MongoDB traffic                                                                                         | `47335`     |
+| `service.mongodb.port`                     | Port for MongoDB traffic                                                                                         | `47336`     |
 | `service.mongodb.clusterIP`                | ClusterIP setting for MongoDB autosetup for statefulset is None                                                 | `None`      |
 | `service.mongodb.loadBalancerIP`           | LoadBalancer Ip setting                                                                                      |             |
 | `service.mongodb.nodePort`                 | NodePort for http service                                                                                    |             |

--- a/helm/mindsdb/.helmignore
+++ b/helm/mindsdb/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/mindsdb/Chart.yaml
+++ b/helm/mindsdb/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: mindsdb
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/helm/mindsdb/templates/NOTES.txt
+++ b/helm/mindsdb/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.http.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "mindsdb.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.http.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "mindsdb.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "mindsdb.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.http.port }}
+{{- else if contains "ClusterIP" .Values.service.http.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mindsdb.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/helm/mindsdb/templates/_helpers.tpl
+++ b/helm/mindsdb/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mindsdb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mindsdb.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mindsdb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mindsdb.labels" -}}
+helm.sh/chart: {{ include "mindsdb.chart" . }}
+{{ include "mindsdb.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mindsdb.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mindsdb.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mindsdb.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mindsdb.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/mindsdb/templates/deployment.yaml
+++ b/helm/mindsdb/templates/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mindsdb.fullname" . }}
+  labels:
+    {{- include "mindsdb.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "mindsdb.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "mindsdb.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "mindsdb.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.http.port }}
+              protocol: TCP
+            - name: mysql
+              containerPort: {{ .Values.service.mysql.port }}
+              protocol: TCP
+            - name: mongodb
+              containerPort: {{ .Values.service.mongodb.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/mindsdb/templates/hpa.yaml
+++ b/helm/mindsdb/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "mindsdb.fullname" . }}
+  labels:
+    {{- include "mindsdb.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "mindsdb.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/mindsdb/templates/http-service.yaml
+++ b/helm/mindsdb/templates/http-service.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.service.http.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mindsdb.fullname" . }}-http
+  labels:
+    {{- include "mindsdb.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.http.type }}
+  {{- if and .Values.service.http.loadBalancerIP (eq .Values.service.http.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.service.http.loadBalancerIP  }}
+  {{- end }}
+  {{- if .Values.service.http.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range .Values.service.http.loadBalancerSourceRanges }}
+    - {{ . }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.service.http.externalIPs }}
+  externalIPs:
+    {{- toYaml .Values.service.http.externalIPs | nindent 4 }}
+  {{- end }}
+  {{- if .Values.service.http.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.http.externalTrafficPolicy }}
+  {{- end }}
+  {{- if and .Values.service.http.clusterIP (eq .Values.service.http.type "ClusterIP") }}
+  clusterIP: {{ .Values.service.http.clusterIP }}
+  {{- end }}
+  ports:
+  - name: http
+    port: {{ .Values.service.http.port }}
+    {{- if  .Values.service.http.nodePort }}
+    nodePort: {{ .Values.service.http.nodePort }}
+    {{- end }}
+    targetPort: {{ .Values.service.http.port }}
+  selector:
+    {{- include "mindsdb.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/mindsdb/templates/ingress.yaml
+++ b/helm/mindsdb/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "mindsdb.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "mindsdb.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/mindsdb/templates/mongodb-service.yaml
+++ b/helm/mindsdb/templates/mongodb-service.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.service.mongodb.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mindsdb.fullname" . }}-mongodb
+  labels:
+    {{- include "mindsdb.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.mongodb.type }}
+  {{- if and .Values.service.mongodb.loadBalancerIP (eq .Values.service.mongodb.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.service.mongodb.loadBalancerIP  }}
+  {{- end }}
+  {{- if .Values.service.mongodb.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range .Values.service.mongodb.loadBalancerSourceRanges }}
+    - {{ . }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.service.mongodb.externalIPs }}
+  externalIPs:
+    {{- toYaml .Values.service.mongodb.externalIPs | nindent 4 }}
+  {{- end }}
+  {{- if .Values.service.mongodb.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.mongodb.externalTrafficPolicy }}
+  {{- end }}
+  {{- if and .Values.service.mongodb.clusterIP (eq .Values.service.mongodb.type "ClusterIP") }}
+  clusterIP: {{ .Values.service.mongodb.clusterIP }}
+  {{- end }}
+  ports:
+  - name: http
+    port: {{ .Values.service.mongodb.port }}
+    {{- if  .Values.service.mongodb.nodePort }}
+    nodePort: {{ .Values.service.mongodb.nodePort }}
+    {{- end }}
+    targetPort: {{ .Values.service.mongodb.port }}
+  selector:
+    {{- include "mindsdb.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/mindsdb/templates/mysql-service.yaml
+++ b/helm/mindsdb/templates/mysql-service.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.service.mysql.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mindsdb.fullname" . }}-mysql
+  labels:
+    {{- include "mindsdb.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.mysql.type }}
+  {{- if and .Values.service.mysql.loadBalancerIP (eq .Values.service.mysql.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.service.mysql.loadBalancerIP  }}
+  {{- end }}
+  {{- if .Values.service.mysql.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range .Values.service.mysql.loadBalancerSourceRanges }}
+    - {{ . }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.service.mysql.externalIPs }}
+  externalIPs:
+    {{- toYaml .Values.service.mysql.externalIPs | nindent 4 }}
+  {{- end }}
+  {{- if .Values.service.mysql.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.mysql.externalTrafficPolicy }}
+  {{- end }}
+  {{- if and .Values.service.mysql.clusterIP (eq .Values.service.mysql.type "ClusterIP") }}
+  clusterIP: {{ .Values.service.mysql.clusterIP }}
+  {{- end }}
+  ports:
+  - name: http
+    port: {{ .Values.service.mysql.port }}
+    {{- if  .Values.service.mysql.nodePort }}
+    nodePort: {{ .Values.service.mysql.nodePort }}
+    {{- end }}
+    targetPort: {{ .Values.service.mysql.port }}
+  selector:
+    {{- include "mindsdb.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/mindsdb/templates/serviceaccount.yaml
+++ b/helm/mindsdb/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mindsdb.serviceAccountName" . }}
+  labels:
+    {{- include "mindsdb.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/mindsdb/templates/tests/test-connection.yaml
+++ b/helm/mindsdb/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "mindsdb.fullname" . }}-test-connection"
+  labels:
+    {{- include "mindsdb.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "mindsdb.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/helm/mindsdb/values.yaml
+++ b/helm/mindsdb/values.yaml
@@ -1,0 +1,114 @@
+# Default values for mindsdb.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: mindsdb/mindsdb
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+  
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  http:
+    enabled: true
+    type: ClusterIP
+    port: 47334
+    clusterIP: None
+    #loadBalancerIP:
+    #nodePort:
+    #externalTrafficPolicy:
+    #externalIPs:
+    loadBalancerSourceRanges: []
+    annotations:
+  mysql:
+    enabled: true
+    type: ClusterIP
+    port: 47335
+    clusterIP: None
+    #loadBalancerIP:
+    #nodePort:
+    #externalTrafficPolicy:
+    #externalIPs:
+    #hostPort:
+    loadBalancerSourceRanges: []
+    annotations:
+  mongodb:
+    enabled: true
+    type: ClusterIP
+    port: 47336
+    clusterIP: None
+    #loadBalancerIP:
+    #nodePort:
+    #externalTrafficPolicy:
+    #externalIPs:
+    #hostPort:
+    loadBalancerSourceRanges: []
+    annotations:
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Fixes #2053 

## Please describe what changes you made, in as much detail as possible
  - added the helm chart for `mindsdb`
  - helm chart consists of 1 `Deployment`, 3 `Services` and 1 `Ingress`
  - exposes 3 services, by default, can be enabled or disabled
 
![image](https://user-images.githubusercontent.com/53267275/159041694-621b1903-32bd-403a-9e9c-5390b09da38d.png)

