### PR TITLE
Fixes to import/export predictor

### DIFF
--- a/mindsdb/api/http/namespaces/predictor.py
+++ b/mindsdb/api/http/namespaces/predictor.py
@@ -295,5 +295,4 @@ class PredictorExport(Resource):
 @ns_conf.response(404, 'predictor not found')
 class PredictorExport(Resource):
     def put(self, name):
-        serialized_predictor = request.json.get('serialized_predictor')
-        request.model_interface.import_predictor(name, serialized_predictor)
+        request.model_interface.import_predictor(name, request.json)

--- a/mindsdb/interfaces/model/model_controller.py
+++ b/mindsdb/interfaces/model/model_controller.py
@@ -619,10 +619,10 @@ class ModelController():
         return json.dumps(predictor_record_serialized, default=json_serialiser)
 
     def import_predictor(self, name: str, payload: json, company_id: int) -> None:
-        prs = json.loads(json.loads(payload))
+        prs = json.loads(payload)
 
         predictor_record = db.Predictor(
-            name=prs['name'],
+            name=name,
             data=prs['data'],
             to_predict=prs['to_predict'],
             company_id=company_id,

--- a/tests/integration_tests/flows/test_http.py
+++ b/tests/integration_tests/flows/test_http.py
@@ -314,14 +314,14 @@ class HTTPTest(unittest.TestCase):
         # Export the predictor as a binary
         res = requests.get(f'{root}/predictors/test_99_{pred_name}/export')
         assert res.status_code == 200
-        exported_predictor = res.text
+        exported_predictor = json.loads(res.text)  # undo the extra wrapping done by requests
 
         # Delete the predictor
         res = requests.delete(f'{root}/predictors/test_99_{pred_name}')
         assert res.status_code == 200
 
         # Import the predictor from the previous export
-        res = requests.put(f'{root}/predictors/test_99_{pred_name}/import', json={'serialized_predictor': exported_predictor})
+        res = requests.put(f'{root}/predictors/test_99_{pred_name}/import', json=exported_predictor)
         assert res.status_code == 200
 
         # Test that it still exists and that it can make predictions


### PR DESCRIPTION
- Fix test to be consistent with SDK usage
- Support predictor renaming based on `name` arg pased via API endpoint
- Fix wrong key retrieval inside `import`