### PR TITLE
created list_databases endpoint 

### DIFF
--- a/mindsdb/api/http/namespaces/sql.py
+++ b/mindsdb/api/http/namespaces/sql.py
@@ -18,23 +18,23 @@ class Query(Resource):
         try:
             result = mysql_proxy.process_query(query)
             if result.type == SQL_ANSWER_TYPE.ERROR:
-                query_response = {
+                listing_query_response = {
                     'type': 'error',
                     'error_code': result.error_code,
                     'error_message': result.error_message
                 }
             elif result.type == SQL_ANSWER_TYPE.OK:
-                query_response = {
+                listing_query_response = {
                     'type': 'ok'
                 }
             elif result.type == SQL_ANSWER_TYPE.TABLE:
-                query_response = {
+                listing_query_response = {
                     'type': 'table',
                     'data': result.data,
                     'column_names': [x['alias'] or x['name'] if 'alias' in x else x['name'] for x in result.columns]
                 }
         except Exception as e:
-            query_response = {
+            listing_query_response = {
                 'type': 'error',
                 'error_code': 0,
                 'error_message': str(e)
@@ -42,6 +42,39 @@ class Query(Resource):
 
         context = mysql_proxy.get_context(context)
 
-        query_response['context'] = context
+        listing_query_response['context'] = context
 
-        return query_response, 200
+        return listing_query_response, 200
+
+
+@ns_conf.route('/list_databases')
+@ns_conf.param('list_databases', 'lists databases of mindsdb')
+class ListDatabases(Resource):
+    @ns_conf.doc('list_databases')
+    def get(self):
+        listing_query = 'SHOW DATABASES'
+        mysql_proxy = FakeMysqlProxy(company_id=request.company_id)
+        try:
+            result = mysql_proxy.process_query(listing_query)
+            if result.type == SQL_ANSWER_TYPE.ERROR:
+                listing_query_response = {
+                    'type': 'error',
+                    'error_code': result.error_code,
+                    'error_message': result.error_message
+                }
+            elif result.type == SQL_ANSWER_TYPE.OK:
+                listing_query_response = {
+                    'type': 'ok'
+                }
+            elif result.type == SQL_ANSWER_TYPE.TABLE:
+                listing_query_response = {
+                    'data': result.data,
+                }
+        except Exception as e:
+            listing_query_response = {
+                'type': 'error',
+                'error_code': 0,
+                'error_message': str(e)
+            }
+        
+        return listing_query_response, 200

--- a/mindsdb/api/http/namespaces/sql.py
+++ b/mindsdb/api/http/namespaces/sql.py
@@ -56,6 +56,10 @@ class ListDatabases(Resource):
         mysql_proxy = FakeMysqlProxy(company_id=request.company_id)
         try:
             result = mysql_proxy.process_query(listing_query)
+
+            # iterate over result.data and perform a query on each item to get the name of the tables
+           
+
             if result.type == SQL_ANSWER_TYPE.ERROR:
                 listing_query_response = {
                     'type': 'error',
@@ -68,8 +72,8 @@ class ListDatabases(Resource):
                 }
             elif result.type == SQL_ANSWER_TYPE.TABLE:
                 listing_query_response = {
-                    'data': result.data,
-                }
+                'data': [{'name': x[0], 'tables': mysql_proxy.process_query('SHOW TABLES FROM `{}`'.format(x[0])).data} for x in result.data]
+            }
         except Exception as e:
             listing_query_response = {
                 'type': 'error',


### PR DESCRIPTION
for listing the tree of databases on mindsdb, specially for the GUI

## Please describe what changes you made, in as much detail as possible

Endpoint 
/list_databases

returns an object equivalent to: 
`SHOW DATABASES` + `SHOW TABLES FROM {_each_database_}'`


In an object form as: 
```{
    "data": [
        {
            "name": "information_schema",
            "tables": []
        },
        {
            "name": "mindsdb",
            "tables": [
                [
                    "predictors"
                ],
                [
                    "commands"
                ],
                [
                    "databases"
                ]
            ]
        },
        {
            "name": "files",
            "tables": []
        },
        {
            "name": "views",
            "tables": []
        },
        {
            "name": "example_db",
            "tables": []
        }
    ],
    "type": "ok"
}```

mindsdb