### PR TITLE
Fix typo in error: Only one field can be in 'ORDER BY'

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
+++ b/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
@@ -723,7 +723,7 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
         if statement.order_by is not None:
             struct['order_by'] = [x.field.parts[-1] for x in statement.order_by]
             if len(struct['order_by']) > 1:
-                raise SqlApiException("Only one field can be in 'OPRDER BY'")
+                raise SqlApiException("Only one field can be in 'ORDER BY'")
         if statement.group_by is not None:
             struct['group_by'] = [x.parts[-1] for x in statement.group_by]
         if statement.window is not None:


### PR DESCRIPTION
Fix typo in error message.

Old: Only one field can be in 'OPRDER BY'
New: Only one field can be in 'ORDER BY'
