### PR TITLE
Make CREATE DATABASE ENGINE case-insensitive

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
+++ b/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
@@ -1386,7 +1386,7 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
         if type(statement) == CreateDatasource:
             struct = {
                 'datasource_name': statement.name,
-                'database_type': statement.engine,
+                'database_type': statement.engine.lower(),
                 'connection_args': statement.parameters
             }
             return self.answer_create_datasource(struct)


### PR DESCRIPTION
This trivial change makes the engine name lovercase before passing it to `answer_create_datasource()`. So a statement like this now works (at least in my tests):

```
CREATE DATABASE ... WITH ENGINE='MariaDB' ...
```
