### PR TITLE
docs(helm readme): fix typo seperate -> separate

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -22,7 +22,7 @@ helm upgrade -i \
 
 # Configuration
 
-All the configurations can be done in the [values.yaml](./mindsdb/values.yaml) file or you can create a seperate YAML file with only the values that you want to override and pass it with a `-f` to the `helm install` command
+All the configurations can be done in the [values.yaml](./mindsdb/values.yaml) file or you can create a separate YAML file with only the values that you want to override and pass it with a `-f` to the `helm install` command
 
 ### Image
 


### PR DESCRIPTION
Fixes #

## Please describe what changes you made, in as much detail as possible
  - Helm Readme typo: seperate -> separate

mindsdb