### PR TITLE
Handle T = Latest syntax for TS predictors

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
+++ b/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
@@ -740,15 +740,20 @@ class SQLQuery():
                 where_data = [{key[1]: value for key, value in row.items()} for row in where_data]
 
                 is_timeseries = self.planner.predictor_metadata[predictor]['timeseries']
-                _mdb_make_predictions = None
+                _mdb_forecast_offset = None
                 if is_timeseries:
-                    if 'LATEST' in self.query_str:
-                        _mdb_make_predictions = False
+                    if '> LATEST' in self.query_str:
+                        # stream mode -- if > LATEST, forecast starts on inferred next timestamp
+                        _mdb_forecast_offset = 1
+                    elif '= LATEST' in self.query_str:
+                        # override: when = LATEST, forecast starts on last provided timestamp instead of inferred next time
+                        _mdb_forecast_offset = 0
                     else:
-                        _mdb_make_predictions = True
+                        # normal mode -- emit a forecast ($HORIZON data points on each) for each provided timestamp
+                        _mdb_forecast_offset = None
                     for row in where_data:
-                        if '__mdb_make_predictions' not in row:
-                            row['__mdb_make_predictions'] = _mdb_make_predictions
+                        if '__mdb_forecast_offset' not in row:
+                            row['__mdb_forecast_offset'] = _mdb_forecast_offset
 
                 for row in where_data:
                     for key in row:
@@ -1139,7 +1144,7 @@ class SQLQuery():
             for table in step_data['columns']:
                 new_table_columns = []
                 for column in step_data['columns'][table]:
-                    if column[-1] not in ('__mindsdb_row_id', '__mdb_make_predictions'):
+                    if column[-1] not in ('__mindsdb_row_id', '__mdb_forecast_offset'):
                         new_table_columns.append(column)
                 step_data['columns'][table] = new_table_columns
             # endregion

--- a/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
+++ b/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
@@ -333,7 +333,7 @@ class MindsDBDataNode(DataNode):
         keys = [x for x in pred_dicts[0] if x in columns]
         min_max_keys = []
         for col in predicted_columns:
-            if model['dtype_dict'][col] in (dtype.integer, dtype.float):
+            if model['dtype_dict'][col] in (dtype.integer, dtype.float, dtype.num_tsarray):
                 min_max_keys.append(col)
 
         data = []

--- a/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
+++ b/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/mindsdb_datanode.py
@@ -196,7 +196,7 @@ class MindsDBDataNode(DataNode):
             row = where_data[0]
             col_name_map = {}
             for i, col_name in enumerate(row):
-                if col_name in ('__mindsdb_row_id', '__mdb_make_predictions'):
+                if col_name in ('__mindsdb_row_id', '__mdb_forecast_offset'):
                     continue
                 new_col_name = get_column_in_case(columns, col_name)
                 if new_col_name is not None and col_name != new_col_name:
@@ -237,7 +237,7 @@ class MindsDBDataNode(DataNode):
         timeseries_settings = model['problem_definition']['timeseries_settings']
 
         if timeseries_settings['is_timeseries'] is True:
-            __mdb_make_predictions = set([row.get('__mdb_make_predictions', True) for row in where_data]) == {True}
+            __no_forecast_offset = set([row.get('__mdb_forecast_offset', None) for row in where_data]) == {None}
 
             predict = model['predict']
             group_by = timeseries_settings['group_by'] or []
@@ -298,7 +298,7 @@ class MindsDBDataNode(DataNode):
                     if horizon > 1:
                         new_row[predict] = new_row[predict][i]
                         new_row[order_by_column] = new_row[order_by_column][i]
-                    if '__mindsdb_row_id' in new_row and (i > 0 or __mdb_make_predictions is False):
+                    if '__mindsdb_row_id' in new_row and (i > 0 or __no_forecast_offset):
                         new_row['__mindsdb_row_id'] = None
                     rows.append(new_row)
 


### PR DESCRIPTION
## Why

To enable live anomaly detection from queries that filter to the most recent known data point (i.e. `WHERE T = LATEST`).

## How
* Rename `__mdb_make_predictions` to `__mdb_forecast_offset`. For more details, see [here](https://github.com/mindsdb/lightwood/pull/894).
* Set appropriate offset in the respective column, and pass modified DF to lightwood as before.

NOTE: will only pass once # is merged into lightwood staging

NOTE: the new changes in lightwood mean that now `WHERE T = LATEST - K` would also be possible, but this is not implemented in this PR because it's likely not a useful behavior.