### PR TITLE
docker: Add `--no-cache` to force `pip install`

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -11,7 +11,7 @@ https://pypi.org/project/MindsDB/ so no files in parent dir are used.
 To build `release` image using version reported at
 https://public.api.mindsdb.com/installer/release/docker___success___None
 
-    docker build -f release -t mindsdb/mindsdb
+    docker build -f release --no-cache -t mindsdb/mindsdb
 
 To build `release` image with specific MindsDB version.
 


### PR DESCRIPTION
Otherwise `docker build` caches last run and doesn't check URL for newest release version.