### PR TITLE
Added support of the JSON encoder for Decimal Type -> float

### DIFF
--- a/mindsdb/utilities/json_encoder.py
+++ b/mindsdb/utilities/json_encoder.py
@@ -1,6 +1,6 @@
 import base64
 from datetime import datetime, date, timedelta
-
+from decimal import Decimal
 import numpy as np
 from flask.json import JSONEncoder
 
@@ -17,7 +17,7 @@ class CustomJSONEncoder(JSONEncoder):
             return bool(obj)
         if isinstance(obj, np.int8) or isinstance(obj, np.int16) or isinstance(obj, np.int32) or isinstance(obj, np.int64):
             return int(obj)
-        if isinstance(obj, np.float16) or isinstance(obj, np.float32) or isinstance(obj, np.float64) or isinstance(obj, np.float128):
+        if isinstance(obj, np.float16) or isinstance(obj, np.float32) or isinstance(obj, np.float64) or isinstance(obj, np.float128) or isinstance(obj, Decimal):
             return float(obj)
 
         return JSONEncoder.default(self, obj)


### PR DESCRIPTION

Error:

Yes sure. I tried to connect Postgres which I was using in version https://hub.docker.com/layers/mindsdb/mindsdb/mindsdb/22.6.2.2/images/sha256-19daa967f0dbaf8396c5713cd0ef09eb9d84595e8b039fec05b6b1ff97a9cda6?context=explore.
When I tried to create a predictor I encountered the following error:
2022-07-14 06:55:58,027 - ERROR - http exception: Object of type Decimal is not JSON serializable

```
Traceback (most recent call last):

  File "/opt/conda/lib/python3.7/site-packages/flask/app.py", line 1950, in full_dispatch_request

    rv = self.dispatch_request()

  File "/opt/conda/lib/python3.7/site-packages/flask/app.py", line 1936, in dispatch_request

    return self.view_functions[rule.endpoint](**req.view_args)

  File "/opt/conda/lib/python3.7/site-packages/flask_restx/api.py", line 407, in wrapper

    return self.make_response(data, code, headers=headers)

  File "/opt/conda/lib/python3.7/site-packages/flask_restx/api.py", line 430, in make_response

    resp = self.representations[mediatype](data, *args, **kwargs)

  File "/opt/conda/lib/python3.7/site-packages/mindsdb/api/http/initialize.py", line 39, in custom_output_json

    resp = make_response(dumps(data), code)

  File "/opt/conda/lib/python3.7/site-packages/flask/json/__init__.py", line 211, in dumps

    rv = _json.dumps(obj, **kwargs)

  File "/opt/conda/lib/python3.7/json/__init__.py", line 238, in dumps

    **kw).encode(obj)

  File "/opt/conda/lib/python3.7/json/encoder.py", line 199, in encode

    chunks = self.iterencode(o, _one_shot=True)

  File "/opt/conda/lib/python3.7/json/encoder.py", line 257, in iterencode

    return _iterencode(o, 0)

  File "/opt/conda/lib/python3.7/site-packages/mindsdb/utilities/json_encoder.py", line 23, in default

    return JSONEncoder.default(self, obj)

  File "/opt/conda/lib/python3.7/site-packages/flask/json/__init__.py", line 100, in default

    return _json.JSONEncoder.default(self, o)

  File "/opt/conda/lib/python3.7/json/encoder.py", line 179, in default

    raise TypeError(f'Object of type {o.__class__.__name__} '

TypeError: Object of type Decimal is not JSON serializable

ERROR:mindsdb.api.http.initialize:Exception on /api/sql/query [POST]
```

Added isintance() of decimal and encode it to float

