### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/mindsdb-docs/docs/sql/tutorials/byom.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/byom.md
@@ -432,7 +432,7 @@ conda_env = {
 }
 ```
 
-Finally, to actually store the model you need to provide the wrapper class that will 1) load all produced artifacts into an accesible "context" and 2) implement all required inference logic:
+Finally, to actually store the model you need to provide the wrapper class that will 1) load all produced artifacts into an accessible "context" and 2) implement all required inference logic:
 
 ```python
 class Model(mlflow.pyfunc.PythonModel):

--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -103,7 +103,7 @@ if __name__ == '__main__':
     print(f'Configuration file:\n   {config.config_path}')
     print(f"Storage path:\n   {config['paths']['root']}")
 
-    # @TODO Backwards compatibiltiy for tests, remove later
+    # @TODO Backwards compatibility for tests, remove later
     model_interface = WithKWArgsWrapper(ModelInterface(), company_id=COMPANY_ID)
     integration_controller = WithKWArgsWrapper(IntegrationController(), company_id=COMPANY_ID)
     for handler_name, handler_meta in integration_controller.get_handlers_import_status().items():
@@ -183,7 +183,7 @@ if __name__ == '__main__':
         del stream_controller
 
     del model_interface
-    # @TODO Backwards compatibiltiy for tests, remove later
+    # @TODO Backwards compatibility for tests, remove later
 
     if args.api is None:
         api_arr = ['http', 'mysql']

--- a/mindsdb/api/mongo/responders/list_collections.py
+++ b/mindsdb/api/mongo/responders/list_collections.py
@@ -41,7 +41,7 @@ class Responce(Responder):
             })
 
         cursor = {
-            'id': Int64(0),  # should we save id somethere?
+            'id': Int64(0),  # should we save id somewhere?
             'ns': 'qwe.$cmd.listCollections',
             'firstBatch': tables
         }

--- a/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/join_utils.py
+++ b/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/join_utils.py
@@ -67,7 +67,7 @@ def get_ts_join_input(query, model, data_handler, data_side):
             groups[gcol] = list(data_handler.query(groups_query).data_frame.squeeze().values)
 
         partition_keys = list(groups.keys())
-        all_partitions = list(product(*[v for k, v in groups.items()]))  # TODO: check for better retrival then project?
+        all_partitions = list(product(*[v for k, v in groups.items()]))  # TODO: check for better retrieval then project?
 
         for group in all_partitions:
             group_time_selects = copy.deepcopy(time_selects)

--- a/mindsdb/interfaces/model/model_controller.py
+++ b/mindsdb/interfaces/model/model_controller.py
@@ -439,7 +439,7 @@ class ModelController():
         """
         Similar to `get_model_data` but meant to be seen directly by the user, rather than parsed by something like the Studio predictor view.
 
-        Uses `get_model_data` to compose this, but in the future we might want to make this independent if we deprected `get_model_data`
+        Uses `get_model_data` to compose this, but in the future we might want to make this independent if we deprecated `get_model_data`
 
         :returns: Dictionary of the analysis (meant to be foramtted by the APIs and displayed as json/yml/whatever)
         """ # noqa

--- a/tests/integration_tests/flows/test_http.py
+++ b/tests/integration_tests/flows/test_http.py
@@ -366,7 +366,7 @@ class HTTPTest(unittest.TestCase):
                 print(f'Error in query: {query}')
                 raise
 
-        # show databaes should be same as show schemas
+        # show database should be same as show schemas
         try:
             query = 'show databases'
             resp = self.sql_via_http(query, RESPONSE_TYPE.TABLE)

--- a/tests/prediction_latency_test/README.md
+++ b/tests/prediction_latency_test/README.md
@@ -7,7 +7,7 @@
     - `database` - db connection info (required)
     - `datasets` - datasets info:
         - `target` - prediction column (required)
-        - `handler_file` - .py file with initial data hanlder. Some data may require it, to add/remove some data. handler is a function with next signature `handler(df) where df is a pandas.DataFrame` (optional)
+        - `handler_file` - .py file with initial data handler. Some data may require it, to add/remove some data. handler is a function with next signature `handler(df) where df is a pandas.DataFrame` (optional)
 
 - `schemal.py` - describes dataset table structures
 - `prepare.py` - all code to create/train models and to set up test environment (launch docker with db, create tables, upload data to db, launch mindsdb)


### PR DESCRIPTION
There are small typos in:
- docs/mindsdb-docs/docs/sql/tutorials/byom.md
- mindsdb/__main__.py
- mindsdb/api/mongo/responders/list_collections.py
- mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/join_utils.py
- mindsdb/interfaces/model/model_controller.py
- tests/integration_tests/flows/test_http.py
- tests/prediction_latency_test/README.md

Fixes:
- Should read `compatibility` rather than `compatibiltiy`.
- Should read `somewhere` rather than `somethere`.
- Should read `retrieval` rather than `retrival`.
- Should read `handler` rather than `hanlder`.
- Should read `deprecated` rather than `deprected`.
- Should read `database` rather than `databaes`.
- Should read `accessible` rather than `accesible`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md