### PR TITLE
Add CockroachDB handler

### DIFF
--- a/mindsdb/integrations/handlers/cockroach_handler/README.md
+++ b/mindsdb/integrations/handlers/cockroach_handler/README.md
@@ -1,0 +1,42 @@
+# CockroachDB Handler
+
+This is the implementation of the CockroachDB handler for MindsDB.
+
+## CockroachDB
+
+CockroachDB was architected for complex, high performant distributed writes and delivers scale-out read capability. CockroachDB delivers simple relational SQL transactions and obscures complexity away from developers. CockroachDB is wire-compatible with PostgreSQL and provides a familiar, easy interface for developers. For more info check https://www.cockroachlabs.com/docs/
+
+## Implementation
+
+Since, CockroachDB is wire-compatible with PostgreSQL this implementation was pretty straight-forward by just extending PostgreSQL handler.
+
+The required arguments to establish a connection are:
+
+* `host`: the host name or IP address of the CockroachDB
+* `database`: the name of the database to connect to
+* `user`: the user to authenticate with
+* `port`: the port to use when connecting 
+* `password`: the password to authenticate the user
+
+## Usage
+
+In order to make use of this handler and connect to a CockroachDB server in MindsDB, the following syntax can be used,
+
+```sql
+CREATE DATABASE cockroachdb
+WITH
+engine='cockroachdb',
+parameters={
+    "host": "localhost",
+    "database": "dbname",
+    "user": "admin",
+    "password": "password",
+    "port": "5432"
+};
+```
+
+Now, you can use this established connection to query your database as follows:
+
+```sql
+SELECT * FROM cockroachdb.public.db;
+```

--- a/mindsdb/integrations/handlers/cockroach_handler/__about__.py
+++ b/mindsdb/integrations/handlers/cockroach_handler/__about__.py
@@ -1,0 +1,9 @@
+__title__ = 'MindsDB Cockroach handler'
+__package_name__ = 'mindsdb_cockroach_handler'
+__version__ = '0.0.1'
+__description__ = "MindsDB handler for CockroachDB"
+__author__ = 'MindsDB Inc'
+__github__ = 'https://github.com/mindsdb/mindsdb'
+__pypi__ = 'https://pypi.org/project/mindsdb/'
+__license__ = 'GPL-3.0'
+__copyright__ = 'Copyright 2022- mindsdb'

--- a/mindsdb/integrations/handlers/cockroach_handler/__init__.py
+++ b/mindsdb/integrations/handlers/cockroach_handler/__init__.py
@@ -1,0 +1,18 @@
+from mindsdb.integrations.libs.const import HANDLER_TYPE
+
+from .__about__ import __version__ as version, __description__ as description
+try:
+    from .cockroach_handler import CockroachHandler as Handler
+    import_error = None
+except Exception as e:
+    Handler = None
+    import_error = e
+
+title = 'CockroachDB'
+name = 'cockroach'
+type = HANDLER_TYPE.DATA
+
+__all__ = [
+    'Handler', 'version', 'name', 'type', 'title',
+    'description', 'import_error'
+]

--- a/mindsdb/integrations/handlers/cockroach_handler/__init__.py
+++ b/mindsdb/integrations/handlers/cockroach_handler/__init__.py
@@ -9,7 +9,7 @@ except Exception as e:
     import_error = e
 
 title = 'CockroachDB'
-name = 'cockroach'
+name = 'cockroachdb'
 type = HANDLER_TYPE.DATA
 
 __all__ = [

--- a/mindsdb/integrations/handlers/cockroach_handler/cockroach_handler.py
+++ b/mindsdb/integrations/handlers/cockroach_handler/cockroach_handler.py
@@ -1,0 +1,11 @@
+from mindsdb.integrations.handlers.postgres_handler import PostgresHandler
+
+
+class CockroachHandler(PostgresHandler):
+    """
+    This handler handles connection and execution of the Cockroachdb statements.
+    """
+    name = 'cockroachdb'
+
+    def __init__(self, name=None, **kwargs):
+        super().__init__(name, **kwargs)

--- a/mindsdb/integrations/handlers/cockroach_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/cockroach_handler/requirements.txt
@@ -1,0 +1,1 @@
+psycopg[binary] >= 1.15.3

--- a/mindsdb/integrations/handlers/cockroach_handler/tests/test_cockroachdb_handler.py
+++ b/mindsdb/integrations/handlers/cockroach_handler/tests/test_cockroachdb_handler.py
@@ -1,0 +1,36 @@
+import unittest
+from mindsdb.integrations.handlers.cockroach_handler.cockroach_handler import CockroachHandler
+from mindsdb.api.mysql.mysql_proxy.libs.constants.response_type import RESPONSE_TYPE
+
+
+class CockroachHandlerTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.kwargs = {
+            "host": "localhost",
+            "port": "5432",
+            "user": "mindsdb",
+            "password": "mindsdb",
+            "database": "postgres"
+        }
+        cls.handler = CockroachHandler('test_cockroach_handler', **cls.kwargs)
+
+    def test_0_check_connection(self):
+        assert self.handler.check_connection()
+
+    def test_1_describe_table(self):
+        described = self.handler.describe_table("test_mdb")
+        assert described['type'] is not RESPONSE_TYPE.ERROR
+
+    def test_2_get_tables(self):
+        tables = self.handler.get_tables()
+        assert tables['type'] is not RESPONSE_TYPE.ERROR
+
+    def test_3_get_views(self):
+        views = self.handler.get_views()
+        assert views['type'] is not RESPONSE_TYPE.ERROR
+
+    def test_4_select_query(self):
+        query = "SELECT * FROM data.test_mdb WHERE 'id'='1'"
+        result = self.handler.query(query)
+        assert result['type'] is RESPONSE_TYPE.TABLE


### PR DESCRIPTION
This PR adds a new handler for connecting to CockroachDB that as an initial handler extends the PostgreSQL one since CockroachDB is wire-compatible with PostgreSQL.