### PR TITLE
Add CH driver to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ mindsdb-streams == 0.1.1
 duckdb == 0.3.1
 requests >= 2.0.0
 mysql-connector-python
+clickhouse-driver


### PR DESCRIPTION
This PR adds cliclhouse-driver in the main requirements #2569 . For now, by default install dependencies for : 

- MySQL, MariaDB, SingleStore (mysql client)

- PostgreSQL,CockroachDB, CKAN, Questdb (psycopg)

- ClickHouse(clickhouse-driver)

