### PR TITLE
fix broken links  in mindsdb-docs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ MindsDB works with most of the SQL and NoSQL databases and data Streams for real
 
 ## Quickstart
 
-To get your hands on MindsDB, we recommend using the [Docker image](https://docs.mindsdb.com/deployment/docker/?utm_medium=community&utm_source=github&utm_campaign=mindsdb%20repo) or simply sign up for a [free cloud account](https://cloud.mindsdb.com/signup?utm_medium=community&utm_source=github&utm_campaign=mindsdb%20repo).
+To get your hands on MindsDB, we recommend using the [Docker image](https://docs.mindsdb.com/setup/self-hosted/docker/?utm_medium=community&utm_source=github&utm_campaign=mindsdb%20repo) or simply sign up for a [free cloud account](https://cloud.mindsdb.com/signup?utm_medium=community&utm_source=github&utm_campaign=mindsdb%20repo).
 Feel free to browse [documentation](https://docs.mindsdb.com?utm_medium=community&utm_source=github&utm_campaign=mindsdb%20repo) for other installation methods and tutorials.
 
 ## Documentation

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 ### Docker images for MindsDB
 
-* https://docs.mindsdb.com/deployment/docker/
+* https://docs.mindsdb.com/setup/self-hosted/docker/
 * https://hub.docker.com/u/mindsdb
 
 ## Building

--- a/docs/mindsdb-docs/docs/sql/tutorials/bitcoin-forecasting.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/bitcoin-forecasting.md
@@ -12,7 +12,7 @@ DISCLAIMER: Please note that predicting Bitcoin price is just an example for sho
 ## Pre-requisites
 
 First, you need MindsDB installed. If you want to use MindsDB locally, you need to install MindsDB with
-[Docker](https://docs.mindsdb.com/deployment/docker/) or [Python](https://docs.mindsdb.com/deployment/pypi/). 
+[Docker](https://docs.mindsdb.com/setup/self-hosted/docker/) or [Python](https://docs.mindsdb.com/setup/self-hosted/pip/windows/). 
 However, if you want to use MindsDB without installing it locally, you can use [Cloud Mindsdb](https://cloud.mindsdb.com/signup). 
 In this tutorial, I'm using MindsDB Cloud, because it is easy to set up in just 2 minutes and it has a great free tier.
 

--- a/docs/mindsdb-docs/docs/sql/tutorials/crop-prediction.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/crop-prediction.md
@@ -12,7 +12,7 @@ In this tutorial, you will learn how to predict the best crop type based on fiel
 
 Before you start make sure you have:
 
-1. Access to MindsDB. In this tutorial, we will use [MindsDB Cloud GUI](https://docs.mindsdb.com/deployment/cloud/). If you want you can also deploy mindsdb on your premises, Check out the installation guide for [Docker](https://docs.mindsdb.com/deployment/docker/) or [PyPi](https://docs.mindsdb.com/deployment/pypi/). 
+1. Access to MindsDB. In this tutorial, we will use [MindsDB Cloud GUI](https://docs.mindsdb.com/deployment/cloud/). If you want you can also deploy mindsdb on your premises, Check out the installation guide for [Docker](https://docs.mindsdb.com/setup/self-hosted/docker/) or [PyPi](https://docs.mindsdb.com/setup/self-hosted/pip/windows/). 
 
 2. Downloaded the dataset. You can get it from [Kaggle](https://www.kaggle.com/atharvaingle/crop-recommendation-dataset).
 

--- a/docs/mindsdb-docs/docs/sql/tutorials/crop-prediction.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/crop-prediction.md
@@ -12,7 +12,7 @@ In this tutorial, you will learn how to predict the best crop type based on fiel
 
 Before you start make sure you have:
 
-1. Access to MindsDB. In this tutorial, we will use [MindsDB Cloud GUI](https://docs.mindsdb.com/deployment/cloud/). If you want you can also deploy mindsdb on your premises, Check out the installation guide for [Docker](https://docs.mindsdb.com/setup/self-hosted/docker/) or [PyPi](https://docs.mindsdb.com/setup/self-hosted/pip/windows/). 
+1. Access to MindsDB. In this tutorial, we will use [MindsDB Cloud GUI](https://docs.mindsdb.com/setup/cloud/). If you want you can also deploy mindsdb on your premises, Check out the installation guide for [Docker](https://docs.mindsdb.com/setup/self-hosted/docker/) or [PyPi](https://docs.mindsdb.com/setup/self-hosted/pip/windows/). 
 
 2. Downloaded the dataset. You can get it from [Kaggle](https://www.kaggle.com/atharvaingle/crop-recommendation-dataset).
 

--- a/docs/mindsdb-docs/docs/sql/tutorials/heart-disease.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/heart-disease.md
@@ -14,7 +14,7 @@ You can follow this tutorial by connecting to your own database and using differ
 
 ## Pre-requisites
 
-If you want to install MindsDB locally, check out the installation guide for [Docker](https://docs.mindsdb.com/deployment/docker/) or [PyPi](https://docs.mindsdb.com/deployment/pypi/) and you can follow this tutorial.
+If you want to install MindsDB locally, check out the installation guide for [Docker](https://docs.mindsdb.com/setup/self-hosted/docker/) or [PyPi](https://docs.mindsdb.com/setup/self-hosted/pip/windows/) and you can follow this tutorial.
 If you are OK with using MindsDB cloud, then simply [create a free account](https://cloud.mindsdb.com/signup) and you will be up and running in just one minute. 
  
 Second, you will need to have a mysql client like DBeaver, MySQL Workbench etc. installed locally to connect to the MindsDB MySQL API. MindsDB contains a SQL Editor which can be accessed on MindsDB cloud or the URL 127.0.0.1:47334/.

--- a/docs/mindsdb-docs/docs/sql/tutorials/mindsdb-superset-snowflake.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/mindsdb-superset-snowflake.md
@@ -12,7 +12,7 @@ Let’s see how we can use machine learning with MindsDB to optimize the number 
 
 ## Set Up MindsDB
 
-First things first! You need to connect your database to MindsDB. One of the easy ways to do so is to create a [MindsDB cloud](https://docs.mindsdb.com/deployment/cloud/) account. If you prefer to deploy MindsDB locally, please refer to installation instructions via [Docker](https://docs.mindsdb.com/deployment/docker/) or [PyPI](https://docs.mindsdb.com/deployment/pypi/).
+First things first! You need to connect your database to MindsDB. One of the easy ways to do so is to create a [MindsDB cloud](https://docs.mindsdb.com/deployment/cloud/) account. If you prefer to deploy MindsDB locally, please refer to installation instructions via [Docker](https://docs.mindsdb.com/setup/self-hosted/docker/) or [PyPI](https://docs.mindsdb.com/setup/self-hosted/pip/windows/).
 
 Once an account is created you can connect to Snowflake using standard parameters like database name (in this case the Chicago Transit Authority), host, port, username, password, etc.
 

--- a/docs/mindsdb-docs/docs/sql/tutorials/mindsdb-superset-snowflake.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/mindsdb-superset-snowflake.md
@@ -12,7 +12,7 @@ Let’s see how we can use machine learning with MindsDB to optimize the number 
 
 ## Set Up MindsDB
 
-First things first! You need to connect your database to MindsDB. One of the easy ways to do so is to create a [MindsDB cloud](https://docs.mindsdb.com/deployment/cloud/) account. If you prefer to deploy MindsDB locally, please refer to installation instructions via [Docker](https://docs.mindsdb.com/setup/self-hosted/docker/) or [PyPI](https://docs.mindsdb.com/setup/self-hosted/pip/windows/).
+First things first! You need to connect your database to MindsDB. One of the easy ways to do so is to create a [MindsDB cloud](https://docs.mindsdb.com/setup/cloud/) account. If you prefer to deploy MindsDB locally, please refer to installation instructions via [Docker](https://docs.mindsdb.com/setup/self-hosted/docker/) or [PyPI](https://docs.mindsdb.com/setup/self-hosted/pip/windows/).
 
 Once an account is created you can connect to Snowflake using standard parameters like database name (in this case the Chicago Transit Authority), host, port, username, password, etc.
 

--- a/docs/mindsdb-docs/docs/sql/tutorials/mushrooms.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/mushrooms.md
@@ -10,7 +10,7 @@ We will explore how MindsDB's machine learning predictive model can make it easi
 
 To ensure you can complete all the steps, make sure you have access to the following tools:
 
-1. A MindsDB instance. Check out the installation guide for [Docker](https://docs.mindsdb.com/deployment/docker/) or [PyPi](https://docs.mindsdb.com/deployment/pypi/). You can also use [MindsDB Cloud](https://docs.mindsdb.com/deployment/cloud/).
+1. A MindsDB instance. Check out the installation guide for [Docker](https://docs.mindsdb.com/setup/self-hosted/docker/) or [PyPi](https://docs.mindsdb.com/setup/self-hosted/pip/windows/). You can also use [MindsDB Cloud](https://docs.mindsdb.com/deployment/cloud/).
 2. Downloaded the dataset. You can get it from [Kaggle](https://www.kaggle.com/uciml/mushroom-classification)
 3. Optional: Access to ngrok. You can check the installation details at the [ngrok website](https://ngrok.com/).
 

--- a/docs/mindsdb-docs/docs/sql/tutorials/mushrooms.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/mushrooms.md
@@ -10,7 +10,7 @@ We will explore how MindsDB's machine learning predictive model can make it easi
 
 To ensure you can complete all the steps, make sure you have access to the following tools:
 
-1. A MindsDB instance. Check out the installation guide for [Docker](https://docs.mindsdb.com/setup/self-hosted/docker/) or [PyPi](https://docs.mindsdb.com/setup/self-hosted/pip/windows/). You can also use [MindsDB Cloud](https://docs.mindsdb.com/deployment/cloud/).
+1. A MindsDB instance. Check out the installation guide for [Docker](https://docs.mindsdb.com/setup/self-hosted/docker/) or [PyPi](https://docs.mindsdb.com/setup/self-hosted/pip/windows/). You can also use [MindsDB Cloud](https://docs.mindsdb.com/setup/cloud/).
 2. Downloaded the dataset. You can get it from [Kaggle](https://www.kaggle.com/uciml/mushroom-classification)
 3. Optional: Access to ngrok. You can check the installation details at the [ngrok website](https://ngrok.com/).
 


### PR DESCRIPTION
Fixes #

fix broken links for Docker, PyPI and mindsdb-cloud in the following pages -

README files
and
https://docs.mindsdb.com/sql/tutorials/bitcoin-forecasting/
https://docs.mindsdb.com/sql/tutorials/crop-prediction/
https://docs.mindsdb.com/sql/tutorials/heart-disease/
https://docs.mindsdb.com/sql/tutorials/mushrooms/
https://docs.mindsdb.com/sql/tutorials/mindsdb-superset-snowflake/
