### PR TITLE
Mongodb handler: unnesting keys in collections

### DIFF
--- a/mindsdb/api/mongo/responders/find.py
+++ b/mindsdb/api/mongo/responders/find.py
@@ -67,6 +67,11 @@ class Responce(Responder):
             )
             table_select.parentheses = True
 
+            modifiers = query['filter'].get('modifiers')
+            if modifiers is not None and hasattr(ast_query, 'modifiers'):
+                for modifier in modifiers:
+                    table_select.modifiers.append(modifier)
+
             # convert to join
             right_table = ast_query.from_table
 
@@ -87,6 +92,10 @@ class Responce(Responder):
                 limit=query.get('limit'),
                 skip=query.get('skip'),
             )
+            modifiers = query['filter'].get('modifiers')
+            if modifiers is not None and hasattr(ast_query, 'modifiers'):
+                for modifier in modifiers:
+                    ast_query.modifiers.append(modifier)
 
         data = run_sql_command(mindsdb_env, ast_query)
 

--- a/mindsdb/api/mongo/server.py
+++ b/mindsdb/api/mongo/server.py
@@ -302,10 +302,10 @@ class MongoRequestHandler(SocketServer.BaseRequestHandler):
         except Exception as e:
             log.error(e)
             response = {
-                '$err': {
-                    'title': str(e),
-                    'info': traceback.format_exc()
-                }
+                "ok": 0,
+                "errmsg": f'{str(e)} : {traceback.format_exc()}',
+                "code": 2,
+                "codeName": "BadValue"
             }
             return responder.to_bytes(response, request_id, is_error=True)
 

--- a/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
+++ b/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
@@ -829,6 +829,10 @@ class SQLQuery():
                     raise ErNotSupportedYet('At this moment supported only JOIN without condition')
                 if step.query.join_type.upper() not in ('LEFT JOIN', 'JOIN'):
                     raise ErNotSupportedYet('At this moment supported only JOIN and LEFT JOIN')
+
+                if len(left_data['tables']) == 0 or len(right_data['tables']) == 0:
+                    raise ErLogicError('Table for join is not found')
+
                 if (
                         len(left_data['tables']) != 1 or len(right_data['tables']) != 1
                         or left_data['tables'][0] == right_data['tables'][0]

--- a/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/information_schema_datanode.py
+++ b/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/information_schema_datanode.py
@@ -119,8 +119,7 @@ class InformationSchemaDataNode(DataNode):
                 if (
                     type(arg) == BinaryOperation and arg.op == '='
                     and type(arg.args[0]) == Identifier
-                    and arg.args[0].parts[0].upper() == 'TABLES'
-                    and arg.args[0].parts[1].upper() == 'TABLE_SCHEMA'
+                    and arg.args[0].parts[-1].upper() == 'TABLE_SCHEMA'
                     and type(arg.args[1]) == Constant
                 ):
                     target_table = arg.args[1].value

--- a/mindsdb/integrations/handlers/mongodb_handler/utils/mongodb_parser.py
+++ b/mindsdb/integrations/handlers/mongodb_handler/utils/mongodb_parser.py
@@ -13,7 +13,7 @@ class MongodbParser:
     '''
 
     def from_string(self, call_str):
-        tree = py_ast.parse(call_str, mode='eval')
+        tree = py_ast.parse(call_str.strip(), mode='eval')
         calls = self.process(tree.body)
         # first call contents collection
         method1 = calls[0]['method']

--- a/mindsdb/integrations/handlers/mongodb_handler/utils/mongodb_render.py
+++ b/mindsdb/integrations/handlers/mongodb_handler/utils/mongodb_render.py
@@ -77,6 +77,12 @@ class MongodbRender:
 
         method = 'aggregate'
         arg = []
+
+        # mongodb related pipeline steps for aggregate method
+        if node.modifiers is not None:
+            for modifier in node.modifiers:
+                arg.append(modifier)
+
         if filters:
             arg.append({"$match": filters})
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ walrus==0.8.2
 flask-compress >= 1.0.0
 kafka-python >= 2.0.0
 appdirs >= 1.0.0
-mindsdb-sql >= 0.3.10, < 0.4.0
+mindsdb-sql >= 0.3.11, < 0.4.0
 checksumdir >= 1.2.0
 mindsdb-streams == 0.1.1
 duckdb == 0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ walrus==0.8.2
 flask-compress >= 1.0.0
 kafka-python >= 2.0.0
 appdirs >= 1.0.0
-mindsdb-sql >= 0.3.11, < 0.4.0
+mindsdb-sql >= 0.3.12, < 0.4.0
 checksumdir >= 1.2.0
 mindsdb-streams == 0.1.1
 duckdb == 0.3.1

--- a/tests/unit/test_mongodb_server.py
+++ b/tests/unit/test_mongodb_server.py
@@ -103,12 +103,14 @@ class TestMongoDBServer(unittest.TestCase):
 
                 mock_sqlquery.reset_mock()
 
+                modifiers = [{'$unwind': '$hist_data'}]
                 res = client_con.mindsdb.house_sales_model_h1w4.find(
                     {
                         "collection": "example_mongo.house_sales2",
                         "query": {
                             "$where": "this.saledate > latest and this.type = 'house' and this.bedrooms=2"
                         },
+                        "modifiers": modifiers,
                     },
                     {
                         "house_sales_model_h1w4.saledate": "date",
@@ -130,6 +132,8 @@ class TestMongoDBServer(unittest.TestCase):
                 '''
                 assert parse_sql(expected_sql, 'mindsdb').to_string() == ast.to_string()
 
+                # check modifiers
+                assert ast.from_table.left.modifiers == modifiers
                 # ==== test datetime ===
 
                 mock_sqlquery.reset_mock()


### PR DESCRIPTION
Changes:
1. Added key for input modifiers of data from mongo:
```
db.sales_model.find(
{
    "collection": "mongo_int.house_sales", 
    "query":  { 
        "$where": "this.sale_date > latest and this.type = 'house'" 
    },
    'modifiers': [
        {'$unwind': '$hist_data'},
        {'$project': {'sale_price': '$hist_data.sale_price', 'saledate': '$hist_data.saledate', 'type': 1}}
    ]
},
```
2. Return human readable error message
3. fix: "SHOW tables FROM mindsdb" reads list tables from other integrations