### PR TITLE
Refactored the JSON block parameters to multiple lines

### DIFF
--- a/docs/mindsdb-docs/docs/setup/self-hosted/docker.md
+++ b/docs/mindsdb-docs/docs/setup/self-hosted/docker.md
@@ -38,15 +38,34 @@ The default configuration for MindsDB's Docker image is represented as a JSON bl
 {
  "config_version":"1.4",
  "storage_dir": "/root/mdb_storage",
- "log":
-  { "level": { "console": "ERROR", "file": "WARNING", "db": "WARNING" } },
+ "log": { 
+     "level": {
+         "console": "ERROR",
+	 "file": "WARNING",
+	 "db": "WARNING"
+	      } 
+        },
  "debug": false,
  "integrations": {},
  "api":
   {
-   "http": { "host": "0.0.0.0", "port": "47334" },
-   "mysql": { "host": "0.0.0.0", "password": "", "port": "47335", "user": "mindsdb", "database": "mindsdb", "ssl": true },
-   "mongodb": { "host": "0.0.0.0", "port": "47336", "database": "mindsdb" }
+   "http": {
+       "host": "0.0.0.0",
+       "port": "47334"
+           },
+   "mysql": {
+       "host": "0.0.0.0",
+       "password": "",
+       "port": "47335",
+       "user": "mindsdb",
+       "database": "mindsdb",
+       "ssl": true
+            },
+   "mongodb": {
+       "host": "0.0.0.0",
+       "port": "47336",
+       "database": "mindsdb"
+              }
   }
 }
 


### PR DESCRIPTION
Fixes #2665

## Please describe what changes you made, in as much detail as possible
  - This PR refactors the JSON block in the Docker Docs page to improve the readability for users by splitting the JSON parameters into multiple lines.

