### PR TITLE
Fix Scylla bundle error

### DIFF
--- a/mindsdb/integrations/handlers/scylla_handler/README.md
+++ b/mindsdb/integrations/handlers/scylla_handler/README.md
@@ -24,20 +24,18 @@ The required arguments to establish a connection are:
 In order to make use of this handler and connect to a Scylla server in MindsDB, the following syntax can be used:
 
 ```sql
-CREATE DATABASE sc
-WITH ENGINE = "scylladb",
-PARAMETERS = {
-    "host": "127.0.0.1",
-    "port": "9042",
-    "user": "user",
-    "password": "pass",
-    "keyspace": "test_data",
-    "protocol_version": 4
-    }
+CREATE DATABASE scylladb_datasource
+WITH ENGINE='scylladb',
+PARAMETERS={
+  "user":"user@mindsdb.com",
+  "password": "pass",
+  "secure_connect_bundle": "/home/zoran/Downloads/secure-connect.zip"
+};
 ```
+> Note protocol version is 4 by default. If you want to change it add "protocol_version": 5 to the above query.
 
 Now, you can use this established connection to query your database as follows:
 
 ```sql
-SELECT * FROM sc.example_table LIMIT 10;
+SELECT * FROM scylladb_datasource.keystore.example_table LIMIT 10;
 ```

--- a/mindsdb/integrations/handlers/scylla_handler/scylla_handler.py
+++ b/mindsdb/integrations/handlers/scylla_handler/scylla_handler.py
@@ -41,10 +41,7 @@ class ScyllaHandler(DatabaseHandler):
         connection_props = {
             'auth_provider': auth_provider
         }
-
-        if self.connection_args['protocol_version'] is not None:
-            connection_props['protocol_version'] = self.connection_args['protocol_version']
-
+        connection_props['protocol_version'] = self.connection_args.get('protocol_version', 4)
         secure_connect_bundle = self.connection_args.get('secure_connect_bundle')
 
         if secure_connect_bundle is not None:
@@ -58,7 +55,7 @@ class ScyllaHandler(DatabaseHandler):
             connection_props['port'] = int(self.connection_args['port'])
 
         cluster = Cluster(**connection_props)
-        session = cluster.connect(self.connection_args['keyspace'])
+        session = cluster.connect(self.connection_args.get('keyspace'))
 
         self.is_connected = True
         self.session = session

--- a/mindsdb/integrations/handlers/scylla_handler/scylla_handler.py
+++ b/mindsdb/integrations/handlers/scylla_handler/scylla_handler.py
@@ -44,14 +44,14 @@ class ScyllaHandler(DatabaseHandler):
 
         if self.connection_args['protocol_version'] is not None:
             connection_props['protocol_version'] = self.connection_args['protocol_version']
- 
+
         secure_connect_bundle = self.connection_args.get('secure_connect_bundle')
 
         if secure_connect_bundle is not None:
-            if os.path.isfile(self.secure_connect_bundle) is False:
+            if os.path.isfile(secure_connect_bundle) is False:
                 raise Exception("Secure_connect_bundle' must be path to the file")
             connection_props['cloud'] = {
-                'secure_connect_bundle': self.secure_connect_bundle
+                'secure_connect_bundle': secure_connect_bundle
             }
         else:
             connection_props['contact_points'] = [self.connection_args['host']]


### PR DESCRIPTION
This PR 
* Fixes #2677 when using secure connect bundle to connect
* Adds default protocol version if not provided
* Makes keystore as optional parameter. Users can switch between keystores using [datasource].[keystore] query.
