### PR TITLE
Fix for compass 1.32.6

### DIFF
--- a/mindsdb/api/mongo/responders/buildinfo.py
+++ b/mindsdb/api/mongo/responders/buildinfo.py
@@ -9,7 +9,8 @@ class Responce(Responder):
         )
 
     result = {
-        'version': '3.6',
+        'version': '3.6.8',
+        'versionArray': [3, 6, 8, 0],
         'ok': 1
     }
 


### PR DESCRIPTION

Fix: 'predictor' collection does not open in compass  1.32.6


