### PR TITLE
Expose connection_args of handlers

### DIFF
--- a/mindsdb/integrations/handlers/cassandra_handler/__init__.py
+++ b/mindsdb/integrations/handlers/cassandra_handler/__init__.py
@@ -1,7 +1,7 @@
 from mindsdb.integrations.libs.const import HANDLER_TYPE
 
 try:
-    from .cassandra_handler import CassandraHandler as Handler
+    from .cassandra_handler import CassandraHandler as Handler,  connection_args
     import_error = None
 except Exception as e:
     Handler = None
@@ -16,5 +16,5 @@ icon_path = 'logo.png'
 
 __all__ = [
     'Handler', 'version', 'name', 'type', 'title', 'description',
-    'import_error', 'icon_path'
+    'connection_args', 'import_error', 'icon_path'
 ]

--- a/mindsdb/integrations/handlers/couchbase_handler/__init__.py
+++ b/mindsdb/integrations/handlers/couchbase_handler/__init__.py
@@ -1,7 +1,11 @@
 from mindsdb.integrations.libs.const import HANDLER_TYPE
 
 try:
-    from .couchbase_handler import CouchbaseHandler as Handler
+    from .couchbase_handler import (
+        CouchbaseHandler as Handler,
+        connection_args,
+        connection_args_example
+    )
     import_error = None
 except Exception as e:
     Handler = None
@@ -16,5 +20,5 @@ icon_path = 'icon.svg'
 
 __all__ = [
     'Handler', 'version', 'name', 'type', 'title', 'description',
-    'import_error', 'icon_path'
+    'connection_args', 'connection_args_example', 'import_error', 'icon_path'
 ]

--- a/mindsdb/integrations/handlers/datastax_handler/__init__.py
+++ b/mindsdb/integrations/handlers/datastax_handler/__init__.py
@@ -1,7 +1,7 @@
 from mindsdb.integrations.libs.const import HANDLER_TYPE
 
 try:
-    from .datastax_handler import DatastaxHandler as Handler
+    from .datastax_handler import DatastaxHandler as Handler, connection_args
     import_error = None
 except Exception as e:
     Handler = None
@@ -16,5 +16,5 @@ icon_path = 'logo.png'
 
 __all__ = [
     'Handler', 'version', 'name', 'type', 'title', 'description',
-    'import_error', 'icon_path'
+    'connection_args', 'import_error', 'icon_path'
 ]

--- a/mindsdb/integrations/handlers/datastax_handler/datastax_handler.py
+++ b/mindsdb/integrations/handlers/datastax_handler/datastax_handler.py
@@ -1,5 +1,4 @@
-from ..scylla_handler import Handler as ScyllaHandler
-
+from ..scylla_handler import Handler as ScyllaHandler, connection_args
 
 class DatastaxHandler(ScyllaHandler):
     """

--- a/mindsdb/integrations/handlers/db2_handler/__init__.py
+++ b/mindsdb/integrations/handlers/db2_handler/__init__.py
@@ -1,7 +1,11 @@
 from mindsdb.integrations.libs.const import HANDLER_TYPE
 
 try:
-    from .db2_handler import DB2Handler as Handler
+    from .db2_handler import (
+        DB2Handler as Handler,
+        connection_args,
+        connection_args_example,
+    )
     import_error = None
 except Exception as e:
     Handler = None
@@ -16,5 +20,5 @@ icon_path = 'icon.png'
 
 __all__ = [
     'Handler', 'version', 'name', 'type', 'title', 'description',
-    'import_error', 'icon_path'
+    'connection_args', 'connection_args_example', 'import_error', 'icon_path'
 ]

--- a/mindsdb/integrations/handlers/scylla_handler/__init__.py
+++ b/mindsdb/integrations/handlers/scylla_handler/__init__.py
@@ -1,7 +1,10 @@
 from mindsdb.integrations.libs.const import HANDLER_TYPE
 
 try:
-    from .scylla_handler import ScyllaHandler as Handler
+    from .scylla_handler import (
+        ScyllaHandler as Handler,
+        connection_args
+    )
     import_error = None
 except Exception as e:
     Handler = None
@@ -16,5 +19,5 @@ icon_path = 'logo.png'
 
 __all__ = [
     'Handler', 'version', 'name', 'type', 'title', 'description',
-    'import_error', 'icon_path'
+    'connection_args', 'import_error', 'icon_path'
 ]


### PR DESCRIPTION
Enables creating astra handler using url for secure bundle
` "secure_connect_bundle": {"url":  '...'}`

It's enabled by exposing connection_args property of handler
The same change done in handlers:
- scylla
- db2
- couchbase
- cassandra
