### PR TITLE
Handlers - Remove select_into()

### DIFF
--- a/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
+++ b/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
@@ -720,19 +720,6 @@ class LightwoodHandler(PredictiveHandler):
         model_input.columns = get_aliased_columns(list(model_input.columns), model_alias, stmt.targets, mode='input')
         predictions.columns = get_aliased_columns(list(predictions.columns), model_alias, stmt.targets, mode='output')
 
-        if into:
-            try:
-                dtypes = {}
-                for col in predictions.columns:
-                    if model.dtype_dict.get(col, False):
-                        dtypes[col] = self.lw_dtypes_to_sql.get(col, sqlalchemy.Text)
-                    else:
-                        dtypes[col] = self.lw_dtypes_overrides.get(col, sqlalchemy.Text)
-
-                data_handler.select_into(into, predictions, dtypes=dtypes)
-            except Exception:
-                print("Error when trying to store the JOIN output in data handler.")
-
         return predictions
 
     def _get_model(self, model_name):

--- a/mindsdb/integrations/handlers/ludwig_handler/ludwig_handler.py
+++ b/mindsdb/integrations/handlers/ludwig_handler/ludwig_handler.py
@@ -181,7 +181,7 @@ class LudwigHandler(PredictiveHandler):
         )
         return r
 
-    def join(self, stmt, data_handler, into: Optional[str]) -> HandlerResponse:
+    def join(self, stmt, data_handler) -> HandlerResponse:
         """
         Batch prediction using the output of a query passed to a data handler as input for the model.
         """  # noqa
@@ -195,17 +195,6 @@ class LudwigHandler(PredictiveHandler):
         predictions = self._call_model(model_input, model)
         model_input.columns = get_aliased_columns(list(model_input.columns), model_alias, stmt.targets, mode='input')
         predictions.columns = get_aliased_columns(list(predictions.columns), model_alias, stmt.targets, mode='output')
-
-        if into:
-            try:
-                dtypes = {}
-                for col in predictions.columns:
-                    if model.dtype_dict.get(col, False):
-                        dtypes[col] = self.dtypes_to_sql.get(col, sqlalchemy.Text)
-
-                data_handler.select_into(into, predictions, dtypes=dtypes)
-            except Exception as e:
-                print("Error when trying to store the JOIN output in data handler.")
 
         r = HandlerResponse(
             RESPONSE_TYPE.TABLE,

--- a/mindsdb/integrations/handlers/mlflow_handler/mlflow_handler/mlflow_handler.py
+++ b/mindsdb/integrations/handlers/mlflow_handler/mlflow_handler/mlflow_handler.py
@@ -146,8 +146,7 @@ class MLflowHandler(PredictiveHandler):
         df = pd.DataFrame.from_dict({stmt.where.args[0].parts[0]: [stmt.where.args[1].value]})
         return self._call_model(df, model_url)
 
-
-    def join(self, stmt, data_handler: BaseHandler, into: Optional[str] = None) -> pd.DataFrame:
+    def join(self, stmt, data_handler: BaseHandler) -> pd.DataFrame:
         """
         Batch prediction using the output of a query passed to a data handler as input for the model.
         """  # noqa
@@ -198,12 +197,6 @@ class MLflowHandler(PredictiveHandler):
             if col.parts[0] == model_alias and col.alias is not None:
                 aliased_columns[aliased_columns.index('prediction')] = str(col.alias)
         predictions.columns = aliased_columns
-
-        if into:
-            try:
-                data_handler.select_into(into, predictions)
-            except Exception as e:
-                print("Error when trying to store the JOIN output in data handler.")
 
         return predictions
 

--- a/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
+++ b/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
@@ -164,18 +164,6 @@ class MySQLHandler(DatabaseHandler):
         result = self.native_query(q)
         return result
 
-    def select_into(self, table, dataframe: pd.DataFrame, dtypes=None):
-        """
-        TODO: Update this
-        """
-        try:
-            con = create_engine(f'mysql://{self.host}:{self.port}/{self.database}', echo=False)
-            dataframe.to_sql(table, con=con, if_exists='append', index=False, dtype=dtypes)
-            return True
-        except Exception as e:
-            print(e)
-            raise Exception(f"Could not select into table {table}, aborting.")
-
 
 connection_args = OrderedDict(
     user={

--- a/mindsdb/integrations/libs/base_handler.py
+++ b/mindsdb/integrations/libs/base_handler.py
@@ -115,13 +115,11 @@ class PredictiveHandler(BaseHandler):
     def __init__(self, name: str):
         super().__init__(name)
 
-    def join(self, stmt, data_handler, into: Optional[str]) -> pd.DataFrame:
+    def join(self, stmt, data_handler) -> pd.DataFrame:
         """
         Join the output of some entity in the handler with output from some other handler.
 
         Data from the external handler should be retrieved via the `select_query` method.
-
-        `into`: if provided, the resulting output will be stored in the specified data handler table via `handler.select_into()`. 
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
For API consistency, this PR removes the old experimental `select_into()` method and its usage within `PredictiveHandler.select_into()`.