### PR TITLE
Changed `cloud-mysql.mindsdb.com` to `cloud.mindsdb.com`

### DIFF
--- a/docs/mindsdb-docs/docs/connect/dbeaver.md
+++ b/docs/mindsdb-docs/docs/connect/dbeaver.md
@@ -31,7 +31,7 @@ There are two options, as below.
     ```text
     Hostname: `cloud.mindsdb.com`
     Port: `3306`
-    Username: *your MindsDB Cloud username*
+    Username: *your MindsDB Cloud username*  # your Mindsdb Cloud email address is your username
     Password: *your MindsDB Cloud password*
     Database: *leave it empty*
     ```

--- a/docs/mindsdb-docs/docs/connect/dbeaver.md
+++ b/docs/mindsdb-docs/docs/connect/dbeaver.md
@@ -29,7 +29,7 @@ There are two options, as below.
     You can connect to your MindsDB Cloud account. To do that, please use the connection details below:<br/>
 
     ```text
-    Hostname: `cloud-mysql.mindsdb.com`
+    Hostname: `cloud.mindsdb.com`
     Port: `3306`
     Username: *your MindsDB Cloud username*
     Password: *your MindsDB Cloud password*

--- a/docs/mindsdb-docs/docs/connect/dbt.md
+++ b/docs/mindsdb-docs/docs/connect/dbt.md
@@ -52,7 +52,7 @@ You can install the [dbt-mindsdb](https://github.com/mindsdb/dbt-mindsdb) adapte
           host: 'cloud.mindsdb.com'
           port: 3306
           schema: '[dbt schema]'
-          username: '[mindsdb cloud username]'
+          username: '[mindsdb cloud username]'   # your Mindsdb Cloud email address is your username
           password: '[mindsdb cloud password]'
       target: dev
     ```

--- a/docs/mindsdb-docs/docs/connect/mysql-client.md
+++ b/docs/mindsdb-docs/docs/connect/mysql-client.md
@@ -21,7 +21,7 @@ Here are the commands that allow you to connect to either a local MindsDB instal
 === "MindsDB Cloud"
 
     ```bash
-    mysql -h cloud-mysql.mindsdb.com --port 3306 -u [mindsdb_cloud_username] -p [mindsdb_cloud_password]
+    mysql -h cloud.mindsdb.com --port 3306 -u [mindsdb_cloud_username] -p [mindsdb_cloud_password]
     ```
 
 On execution, we get:

--- a/docs/mindsdb-docs/docs/connect/sql-alchemy.md
+++ b/docs/mindsdb-docs/docs/connect/sql-alchemy.md
@@ -13,7 +13,7 @@ Please follow the instructions below to connect your MindsDB to SQL Alchemy.
     ```python
     from sqlalchemy import create_engine
 
-    user = 'MindsDB Cloud username' # replace this value
+    user = 'MindsDB Cloud username' # your Mindsdb Cloud email address is your username
     password = 'MindsDB Cloud password' # replace this value
     host = 'cloud.mindsdb.com'
     port = 3306
@@ -34,7 +34,7 @@ Please follow the instructions below to connect your MindsDB to SQL Alchemy.
 
     Please note that we use the following connection details:
 
-    - Username is your MindsDB Cloud username
+    - Username is your MindsDB Cloud email address
     - Password is your MindsDB Cloud password
     - Host is `cloud.mindsdb.com`
     - Port is `3306`
@@ -85,6 +85,9 @@ Please follow the instructions below to connect your MindsDB to SQL Alchemy.
     ```bash
     Connection to the 127.0.0.1 for user mindsdb created successfully.
     ```
+!!! note
+    The Sqlachemy `create_engine` is lazy. This implies any human error when entering the connection details would be undetectable until an action becomes necessary, such as when calling the `execute` method to execute SQL commands.
+
 
 ## What's Next?
 

--- a/docs/mindsdb-docs/docs/connect/sql-alchemy.md
+++ b/docs/mindsdb-docs/docs/connect/sql-alchemy.md
@@ -15,7 +15,7 @@ Please follow the instructions below to connect your MindsDB to SQL Alchemy.
 
     user = 'MindsDB Cloud username' # replace this value
     password = 'MindsDB Cloud password' # replace this value
-    host = 'cloud-mysql.mindsdb.com'
+    host = 'cloud.mindsdb.com'
     port = 3306
     database = ''
 
@@ -36,14 +36,14 @@ Please follow the instructions below to connect your MindsDB to SQL Alchemy.
 
     - Username is your MindsDB Cloud username
     - Password is your MindsDB Cloud password
-    - Host is `cloud-mysql.mindsdb.com`
+    - Host is `cloud.mindsdb.com`
     - Port is `3306`
     - Database name is left empty
 
     To create a database connection, execute the code above. On success, the following output is expected:
 
     ```bash
-    Connection to the cloud-mysql.mindsdb.com for user MindsDB-Cloud-Username created successfully.
+    Connection to the cloud.mindsdb.com for user MindsDB-Cloud-Username created successfully.
     ```
 
 === "Connecting Local MindsDB to SQL Alchemy"

--- a/docs/mindsdb-docs/docs/index.md
+++ b/docs/mindsdb-docs/docs/index.md
@@ -21,7 +21,7 @@ You can use the MindsDB Cloud SQL Editor or open your preferred SQL client, such
     To connect to MindsDB from a third-party SQL client, use the connection details below.
 
     ```txt
-      "user":[your_mindsdb_cloud_username],
+      "user":[your_mindsdb_cloud_username],   # your Mindsdb Cloud email address is your username
       "password":[your_mindsdb_cloud_password],
       "host":"cloud.mindsdb.com",
       "port":"3306"

--- a/docs/mindsdb-docs/docs/index.md
+++ b/docs/mindsdb-docs/docs/index.md
@@ -23,7 +23,7 @@ You can use the MindsDB Cloud SQL Editor or open your preferred SQL client, such
     ```txt
       "user":[your_mindsdb_cloud_username],
       "password":[your_mindsdb_cloud_password],
-      "host":"cloud-mysql.mindsdb.com",
+      "host":"cloud.mindsdb.com",
       "port":"3306"
     ```
 


### PR DESCRIPTION
Fixes #

- Changed `cloud-mysql.mindsdb.com` to `cloud.mindsdb.com` following error from a GUI client: Dbeaver ( `unable to read response from server. Expected to read 4 bytes, read 0 bytes before connection was unexpectedly lost.`)
-  I noticed the `Mindsdb Cloud Username` is the same as the `email address` so I pointed that out with a comment. 
- Then, adding a note on the behaviour of Sqlalchemy `create_engine` to the documentation