### PR TITLE
Null rows in TS prediction result

### DIFF
--- a/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
+++ b/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
@@ -621,11 +621,11 @@ class LightwoodHandler(PredictiveHandler):
             if predictor_record.dtype_dict[order_by_column] == dtype.date:
                 for row in pred_dicts:
                     if isinstance(row[order_by_column], (int, float)):
-                        row[order_by_column] = str(datetime.fromtimestamp(row[order_by_column]).date())
+                        row[order_by_column] = datetime.fromtimestamp(row[order_by_column]).date()
             elif predictor_record.dtype_dict[order_by_column] == dtype.datetime:
                 for row in pred_dicts:
                     if isinstance(row[order_by_column], (int, float)):
-                        row[order_by_column] = str(datetime.fromtimestamp(row[order_by_column]))
+                        row[order_by_column] = datetime.fromtimestamp(row[order_by_column])
 
             explain_arr = explanations
         # endregion

--- a/tests/unit/executor_test_base.py
+++ b/tests/unit/executor_test_base.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import tempfile
 import os
@@ -115,7 +116,9 @@ class BaseTestCase:
         # add predictor to table
         r = self.db.Predictor(
             name=predictor['name'],
-            data={},
+            data={
+                'dtypes': predictor['dtypes']
+            },
             learn_args=predictor['problem_definition'],
             to_predict=predictor['predict'],
             integration_id=self.lw_integration_id
@@ -139,6 +142,7 @@ class BaseTestCase:
                 'anomaly': None
             }
 
+            data = copy.deepcopy(data)
             for row in data:
                 # row = row.copy()
                 exp_row = {'predicted_value': predictor['predicted_value'],


### PR DESCRIPTION
- Added filtration of prediction results. Filter is step.output_time_filter from planner
  - if date in filter is string it converts to datetime
- changed logic of JoinStep. 
  - if it is simple join and predictor is one of tables: keep only predictor rows and join table rows to in (left join if predictor is from left and right if it is from right)
  - else keep original type of join from select

[#2501](https://github.com/mindsdb/mindsdb/issues/2501)
[#2435](https://github.com/mindsdb/mindsdb/issues/2435)
[#2264](https://github.com/mindsdb/mindsdb/issues/2264)