### PR TITLE
Trino ldap

### DIFF
--- a/docs/mindsdb-docs/docs/sql/create/databases.md
+++ b/docs/mindsdb-docs/docs/sql/create/databases.md
@@ -1344,7 +1344,7 @@ Follow the [Mongo API documentation](/mongo/collection-structure/) for details.
 
     ```sql
     CREATE DATABASE trino_datasource          --- display name for the database
-    WITH ENGINE='trinodb',                    --- name of the MindsDB handler
+    WITH ENGINE='trino',                      --- name of the MindsDB handler
     PARAMETERS={
       "host": " ",                            --- host name or IP address
       "port": ,                               --- port used to make TCP/IP connection
@@ -1359,7 +1359,7 @@ Follow the [Mongo API documentation](/mongo/collection-structure/) for details.
 
     ```sql
     CREATE DATABASE trino_datasource
-    WITH ENGINE='trinodb',
+    WITH ENGINE='trino',
     PARAMETERS={
       "host": "127.0.0.1",
       "port": 8080,

--- a/mindsdb/api/mysql/mysql_proxy/executor/executor_commands.py
+++ b/mindsdb/api/mysql/mysql_proxy/executor/executor_commands.py
@@ -672,7 +672,7 @@ class ExecuteCommands:
             handlers_meta = self.session.integration_controller.get_handlers_import_status()
             handler_meta = handlers_meta[engine]
             if handler_meta.get('import', {}).get('success') is not True:
-                raise SqlApiException(f"Hanbdler '{engine}' can not be used")
+                raise SqlApiException(f"Handler '{engine}' can not be used")
 
             accept_connection_args = handler_meta.get('connection_args')
             if accept_connection_args is not None:

--- a/mindsdb/integrations/handlers/trino_handler/trino_handler.py
+++ b/mindsdb/integrations/handlers/trino_handler/trino_handler.py
@@ -55,7 +55,7 @@ class TrinoHandler(DatabaseHandler):
 
         # option configuration
         http_scheme='http'
-        auth='basic'
+        auth=None
         auth_config=None
         password=None
 

--- a/mindsdb/integrations/handlers/trino_handler/trino_handler.py
+++ b/mindsdb/integrations/handlers/trino_handler/trino_handler.py
@@ -52,16 +52,42 @@ class TrinoHandler(DatabaseHandler):
         """
         if self.is_connected is True:
             return self.connection
-        conn = connect(
-            host=self.connection_data['host'],
-            port=self.connection_data['port'],
-            user=self.connection_data['user'],
-            catalog=self.connection_data['catalog'],
-            schema=self.connection_data['schema'],
-            # @TODO: Implement Kerberos or Basic auth
-            # http_scheme='https',
-            # auth=BasicAuthentication(self.connection_data['user'], self.connection_data['password'])
-        )
+
+        # option configuration
+        http_scheme='http'
+        auth='basic'
+        auth_config=None
+        password=None
+
+        if 'auth' in self.connection_data:
+            auth=self.connection_data['auth']
+        if 'password' in self.connection_data:
+            password=self.connection_data['password']
+        if 'http_scheme' in self.connection_data:
+           http_scheme=self.connection_data['http_scheme']
+
+        if password and auth=='kerberos':
+            raise Exception("Kerberos authorization doesn't support password.")
+        elif password:
+            auth_config=BasicAuthentication(self.connection_data['user'], password)
+
+        if auth:
+            conn = connect(
+                host=self.connection_data['host'],
+                port=self.connection_data['port'],
+                user=self.connection_data['user'],
+                catalog=self.connection_data['catalog'],
+                schema=self.connection_data['schema'],
+                http_scheme=http_scheme,
+                auth=auth_config)
+        else:
+            conn = connect(
+                host=self.connection_data['host'],
+                port=self.connection_data['port'],
+                user=self.connection_data['user'],
+                catalog=self.connection_data['catalog'],
+                schema=self.connection_data['schema'])
+
         self.is_connected = True
         self.connection = conn
         return conn


### PR DESCRIPTION
Fixes #

- add http_scheme and basic auth (password) to trino handler/integration
- fix engine name in the document

sample config with http_scheme and basic auth
```
CREATE DATABASE trino_datasource
WITH ENGINE='trino',
PARAMETERS={
  "user": "trino_user",
  "http_scheme": "https",
  "port": 443,
  "password": "trino_password",
  "host": "trino_host",
  "catalog": "trino_catalog",
  "schema": "trino_schema"
};
```
