### PR TITLE
Drop database fix

### DIFF
--- a/tests/integration_tests/flows/test_mysql_api.py
+++ b/tests/integration_tests/flows/test_mysql_api.py
@@ -50,7 +50,14 @@ class TestScenario:
             db_type.upper(),
             db_type,
             json.dumps(self.db_creds[db_type]))
-        return self.query(_query)
+
+        self.query(_query)
+        # and try to drop one of the datasources
+        if db_type == 'mysql':
+
+            self.query(f'drop datasource {db_type};')
+            # and create again
+            self.query(_query)
 
     @staticmethod
     def upload_ds(df, name):
@@ -152,9 +159,6 @@ class TestScenario:
             with self.subTest(msg=req):
                 print(f"\nExecuting {self._testMethodName} ({__name__}.{self.__class__.__name__}) [{req}]")
                 self.query(req)
-
-    def test_6_drop_datasource(self):
-        self.query('drop datasource MYSQL;')
 
     def test_7_train_predictor_from_files(self):
         df = pd.DataFrame({

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -213,6 +213,18 @@ class Test(BaseExecutorTest):
                    ''', dialect='mindsdb'))
         except SqlApiException as e:
             assert 'not exists' in str(e)
+        else:
+            raise Exception('SqlApiException expected')
+
+        # try files
+        try:
+            self.command_executor.execute_command(parse_sql(f'''
+                    drop database files
+                   ''', dialect='mindsdb'))
+        except Exception as e:
+            assert 'is system database' in str(e)
+        else:
+            raise Exception('SqlApiException expected')
 
 
 class TestCompexQueries(BaseExecutorTest):


### PR DESCRIPTION
Unable to drop if:
- is system database ('files', 'views', 'lightwood') 
- linked predictors exist
#2930
