### PR TITLE
Changing MindsDB hostname values

### DIFF
--- a/docs/mindsdb-docs/docs/connect/mysql-client.md
+++ b/docs/mindsdb-docs/docs/connect/mysql-client.md
@@ -40,7 +40,7 @@ MySQL [(none)]>
 In this example, we connect to the MindsDB Cloud instance, as below.
 
 ``` bash
-mysql -h cloud-mysql.mindsdb.com --port 3306 -u zoran@mindsdb.com -p
+mysql -h cloud.mindsdb.com --port 3306 -u zoran@mindsdb.com -p
 ```
 
 On execution, we get:


### PR DESCRIPTION


Fixes #2972

## Please describe what changes you made, in as much detail as possible
  -Changing MindsDB hostname values from cloud-mysql.mindsdb.com to cloud.mindsdb.com

mindsdb