### PR TITLE
TS filter: accept float in order field

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
+++ b/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
@@ -1682,19 +1682,63 @@ class SQLQuery():
 
         def get_date_format(samples):
             # dateinfer reads sql date 2020-04-01 as yyyy-dd-mm. workaround for in
-            if re.match('[\d]{4}-[\d]{2}-[\d]{2}', samples[0]):
-                # suggested format
-                date_format = '%Y-%m-%d'
-                for sample in samples:
-                    try:
-                        dt.datetime.strptime(sample, date_format)
-                    except ValueError:
-                        date_format = None
-                        break
-                if date_format is not None:
-                    return date_format
+            for date_format, pattern in (
+                    ('%Y-%m-%d', '[\d]{4}-[\d]{2}-[\d]{2}'),
+                    # ('%Y', '[\d]{4}')
+            ):
+                if re.match(pattern, samples[0]):
+                    # suggested format
+                    for sample in samples:
+                        try:
+                            dt.datetime.strptime(sample, date_format)
+                        except ValueError:
+                            date_format = None
+                            break
+                    if date_format is not None:
+                        return date_format
 
             return dateinfer.infer(samples)
+
+        if self.model_types.get(order_col) in ('float', 'integer'):
+            # convert strings to digits
+            fnc = {
+                'integer': int,
+                'float': float
+            }[self.model_types[order_col]]
+
+
+            # convert predictor_data
+            if len(predictor_data) > 0:
+                if isinstance(predictor_data[0][order_col], str):
+
+                    for row in predictor_data:
+                        row[order_col] = fnc(row[order_col])
+                elif isinstance(predictor_data[0][order_col], dt.date):
+                    # convert to datetime
+                    for row in predictor_data:
+                        row[order_col] = fnc(row[order_col])
+
+            # convert predictor_data
+            if isinstance(table_data[0][order_col], str):
+
+                for row in table_data:
+                    row[order_col] = fnc(row[order_col])
+            elif isinstance(table_data[0][order_col], dt.date):
+                # convert to datetime
+                for row in table_data:
+                    row[order_col] = fnc(row[order_col])
+
+            # convert args to date
+            samples = [
+                arg.value
+                for arg in filter_args
+                if isinstance(arg, Constant) and isinstance(arg.value, str)
+            ]
+            if len(samples) > 0:
+
+                for arg in filter_args:
+                    if isinstance(arg, Constant) and isinstance(arg.value, str):
+                        arg.value = fnc(arg.value)
 
         if self.model_types.get(order_col) in ('date', 'datetime'):
             # convert strings to date

--- a/tests/unit/executor_test_base.py
+++ b/tests/unit/executor_test_base.py
@@ -90,11 +90,13 @@ class BaseExecutorTest(BaseUnitTest):
         from mindsdb.api.mysql.mysql_proxy.executor.executor_commands import ExecuteCommands
         from mindsdb.interfaces.database.integrations import IntegrationController
         from mindsdb.interfaces.database.views import ViewController
+        from mindsdb.interfaces.file.file_controller import FileController
 
         server_obj = type('', (), {})()
 
         integration_controller = IntegrationController()
         view_controller = ViewController()
+        self.file_controller = FileController()
         self.mock_model_controller = mock.Mock()
 
         # no predictors yet

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -1,8 +1,11 @@
+import os.path
 from unittest.mock import patch
 import pandas as pd
 import datetime as dt
 import pytest
+import tempfile
 
+import numpy as np
 from lightwood.api import dtype
 
 from mindsdb_sql import parse_sql
@@ -194,6 +197,70 @@ class Test(BaseExecutorTest):
         assert ret_df.shape[0] == 2
         assert ret_df.t.min() == dt.datetime(2020, 1, 2)
         assert ret_df.t.max() == dt.datetime(2020, 1, 3)
+
+    def test_ts_predictor_file(self):
+        # set integration data
+
+        # save as file
+        df = pd.DataFrame([
+            {'a': 1, 't': '2021', 'g': 'x'},
+            {'a': 2, 't': '2022', 'g': 'x'},
+            {'a': 3, 't': '2023', 'g': 'x'},
+        ])
+
+        file_path = tempfile.mkstemp(prefix='file_')[1]
+
+        df.to_csv(file_path)
+
+        self.file_controller.save_file('tasks', file_path, 'tasks')
+
+        # --- use TS predictor ---
+
+        predictor = {
+            'name': 'task_model',
+            'predict': 'a',
+            'problem_definition': {
+                'timeseries_settings': {
+                    'is_timeseries': True,
+                    'window': 2,
+                    'order_by': 't',
+                    'group_by': 'g',
+                    'horizon': 3
+                }
+            },
+            'dtypes': {
+                'a': dtype.integer,
+                't': dtype.float,
+                'g': dtype.categorical,
+            },
+            'predicted_value': ''
+        }
+        self.set_predictor(predictor)
+
+        # set predictor output
+        predict_result = [
+            # window
+            {'a': 2, 't': np.float64(2022.), 'g': 'x', '__mindsdb_row_id': 2},
+            {'a': 3, 't': np.float64(2023.), 'g': 'x', '__mindsdb_row_id': 3},
+            # horizon
+            {'a': 1, 't': np.float64(2024.), 'g': 'x', '__mindsdb_row_id': None},
+            {'a': 1, 't': np.float64(2024.), 'g': 'x', '__mindsdb_row_id': None},
+            {'a': 1, 't': np.float64(2025.), 'g': 'x', '__mindsdb_row_id': None},
+        ]
+        self.mock_predict.side_effect = lambda *a, **b: predict_result
+
+        # > latest ______________________
+        ret = self.command_executor.execute_command(parse_sql(f'''
+                select p.* from files.tasks t
+                join mindsdb.task_model p
+                where t.t > latest
+            ''', dialect='mindsdb'))
+        assert ret.error_code is None
+
+        ret_df = self.ret_to_df(ret)
+        assert ret_df.shape[0] == 3
+        assert ret_df.t.min() == 2024.
+
 
     @patch('mindsdb.integrations.handlers.postgres_handler.Handler')
     def test_drop_database(self, mock_handler):
@@ -619,7 +686,7 @@ class TestWithNativeQuery(BaseExecutorTest):
             'dtypes': {
                 'p': dtype.categorical,
                 'a': dtype.integer,
-                't': dtype.integer,
+                't': dtype.date,
                 'g': dtype.categorical,
             },
             'predicted_value': predicted_value


### PR DESCRIPTION
Fix of bug:
- If datasource is file with column contents number (year)
- And created predictor by this column
- Using of predictor caused and error:
'>' not supported between instances of 'numpy.ndarray'
mindsdb