### PR TITLE
[i3039] Reconstruct RayServe Handler.

### DIFF
--- a/mindsdb/integrations/handlers/rayserve_handler/__about__.py
+++ b/mindsdb/integrations/handlers/rayserve_handler/__about__.py
@@ -1,0 +1,9 @@
+__title__ = 'MindsDB RayServe handler'
+__package_name__ = 'mindsdb_rayserve_handler'
+__version__ = '0.0.1'
+__description__ = "MindsDB handler for RayServe"
+__author__ = 'Franklin Zhi'
+__github__ = 'https://github.com/mindsdb/mindsdb'
+__pypi__ = 'https://pypi.org/project/mindsdb/'
+__license__ = 'GPL-3.0'
+__copyright__ = 'Copyright 2022- mindsdb'

--- a/mindsdb/integrations/handlers/rayserve_handler/__init__.py
+++ b/mindsdb/integrations/handlers/rayserve_handler/__init__.py
@@ -1,0 +1,18 @@
+from mindsdb.integrations.libs.const import HANDLER_TYPE
+
+from .__about__ import __version__ as version, __description__ as description
+try:
+    from .rayserve_handler import RayServeHandler as Handler
+    import_error = None
+except Exception as e:
+    Handler = None
+    import_error = e
+
+title = 'RayServe'
+name = 'rayserve'
+type = HANDLER_TYPE.ML
+permanent = True
+
+__all__ = [
+    'Handler', 'version', 'name', 'type', 'title', 'description', 'import_error'
+]

--- a/mindsdb/integrations/handlers/rayserve_handler/rayserve_handler.py
+++ b/mindsdb/integrations/handlers/rayserve_handler/rayserve_handler.py
@@ -1,0 +1,101 @@
+import base64
+import json
+import pickle
+from typing import Optional, Dict
+
+import pandas as pd
+import requests
+
+from mindsdb.integrations.libs.base import BaseMLEngine
+from mindsdb.utilities import log
+from mindsdb.interfaces.storage import db
+
+
+class RayServeHandler(BaseMLEngine):
+    name = 'rayserve'
+
+    ARG_TARGET = "target"
+    ARG_COLUMN_SEQUENCE = "column_sequence"
+    ARG_TRAIN_URL = "train_url"
+    ARG_PREDICT_URL = "predict_url"
+    ARG_PREDICTOR_ID = "predictor_id"
+    ARG_PREDICTOR_NAME = "predictor_name"
+
+    KWARGS_DF = "df"
+
+    PERSIST_ARGS_KEY_IN_JSON_STORAGE = "rayserve_args"
+
+    def create(self, target, args=None, **kwargs):
+        # prepare arguments
+        using_args = args.get("using", dict())
+        train_url = using_args.get("train_url", None)
+        predict_url = using_args.get("predict_url", None)
+        if train_url is None:
+            raise Exception("Missing required argument: using.train_url")
+        if predict_url is None:
+            raise Exception("Missing required argument: using.predict_url")
+
+        predictor_id = self.model_storage.predictor_id
+        predictor_name = db.Predictor.query.get(predictor_id).name
+        # prepare args to serialize
+        serialize_args = dict()
+        serialize_args[self.ARG_TARGET] = target
+        serialize_args[self.ARG_TRAIN_URL] = train_url
+        serialize_args[self.ARG_PREDICT_URL] = predict_url
+        serialize_args[self.ARG_PREDICTOR_ID] = predictor_id
+        serialize_args[self.ARG_PREDICTOR_NAME] = predictor_name
+        # check df
+        df: pd.DataFrame = kwargs.get(self.KWARGS_DF, None)
+        if df is None:
+            raise Exception("missing required key in args: " + self.KWARGS_DF)
+        else:
+            column_sequence = sorted(list(df.columns.values))
+            df = df[column_sequence]
+            serialize_args[self.ARG_COLUMN_SEQUENCE] = column_sequence
+
+        try:
+            resp_status_code = ""
+            log.logger.info(F"Training model by RayServe, target: {target}, "
+                            F"train_url: {train_url}, predict_url: {predict_url}")
+            encoded_df = base64.encodebytes(pickle.dumps(df))
+            resp = requests.post(train_url, json={'df': encoded_df, 'target': target,
+                                                  "predictor_id": predictor_id, "predictor_name": predictor_name})
+            resp_status_code = resp.status_code
+            assert resp.status_code == 200
+            log.logger.info(F"Training model by RayServe success.")
+        except Exception as e:
+            raise Exception("Training failed: " + repr(e) + ", status_code: ", str(resp_status_code))
+        self.model_storage.json_set(self.PERSIST_ARGS_KEY_IN_JSON_STORAGE, serialize_args)
+        log.logger.info("Model args saved.")
+
+    def predict(self, df: pd.DataFrame, args: Optional[Dict] = None) -> pd.DataFrame:
+        # read model args from storage
+        deserialize_args = self.model_storage.json_get(self.PERSIST_ARGS_KEY_IN_JSON_STORAGE)
+
+        # resolve args
+        target = deserialize_args[self.ARG_TARGET]
+        feature_column_sequence = list(deserialize_args[self.ARG_COLUMN_SEQUENCE])
+        if target in feature_column_sequence:
+            feature_column_sequence.remove(target)
+        predict_url = deserialize_args[self.ARG_PREDICT_URL]
+        predictor_id = deserialize_args[self.ARG_PREDICTOR_ID]
+        predictor_name = deserialize_args[self.ARG_PREDICTOR_NAME]
+
+        df_send = df[feature_column_sequence]
+        encoded_df = base64.encodebytes(pickle.dumps(df_send))
+        resp = requests.post(predict_url, json={'df': encoded_df, 'target': target,
+                                                "predictor_id": predictor_id, "predictor_name": predictor_name})
+        pred_result = json.loads(resp.content)
+        if target not in pred_result:
+            raise Exception(F"Target column doesn't exist: {target}")
+        if len(pred_result[target]) != len(df_send):
+            raise Exception(F"Line number of pre diction doesn't equal with the one of input.")
+        rt = df.copy(deep=True)
+        pred_df = pd.DataFrame(index=rt.index, data=pred_result)
+        if target in set(rt.columns):
+            rt.drop(columns=[target], inplace=True)
+        rt = rt.join(pred_df, how="left")
+        return rt
+
+if __name__=="__main__":
+    print()

--- a/mindsdb/integrations/handlers/rayserve_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/rayserve_handler/requirements.txt
@@ -1,0 +1,5 @@
+mindsdb>=22.6.2.1
+mindsdb_sql >= 0.4.0
+pandas <=1.4.3
+
+salesforce-merlion>=1.2.0,<=1.3.1

--- a/mindsdb/integrations/handlers/rayserve_handler/setup.py
+++ b/mindsdb/integrations/handlers/rayserve_handler/setup.py
@@ -1,0 +1,28 @@
+from setuptools import setup, find_packages
+
+from setup import install_deps
+from .__about__ import __dict__ as about
+
+pkgs, new_links = install_deps()
+
+setup(
+    name=about['__title__'],
+    version=about['__version__'],
+    url=about['__github__'],
+    download_url=about['__pypi__'],
+    license=about['__license__'],
+    author=about['__author__'],
+    author_email=about['__email__'],
+    description=about['__description__'],
+    long_description=F"{about['__title__']} version:{about['__version__']}",
+    long_description_content_type="text/markdown",
+    packages=find_packages(),
+    install_requires=pkgs,
+    dependency_links=new_links,
+    include_package_data=True,
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent",
+    ],
+    python_requires=">=3.7"
+)

--- a/tests/unit/executor_test_base.py
+++ b/tests/unit/executor_test_base.py
@@ -91,6 +91,8 @@ class BaseUnitTest:
         db.session.add(r)
         r = db.Integration(name='merlion', data={}, engine='merlion')
         db.session.add(r)
+        r = db.Integration(name='rayserve', data={}, engine='rayserve')
+        db.session.add(r)
         r = db.Integration(name='lightwood', data={}, engine='lightwood')
         db.session.add(r)
         db.session.flush()

--- a/tests/unit/test_rayserve_handler.py
+++ b/tests/unit/test_rayserve_handler.py
@@ -1,0 +1,148 @@
+# How to run:
+#   env PYTHONPATH=./ pytest tests/unit/test_rayserve_handler.py
+import pandas as pd
+from flask import Flask, jsonify, request
+import multiprocessing
+import requests
+import time
+from unittest.mock import patch
+import json
+import pickle
+import base64
+
+
+from mindsdb_sql import parse_sql
+from .executor_test_base import BaseExecutorTest
+
+
+app = Flask(__name__)
+mock_server_port = 8129
+
+@app.route('/ready', methods=['POST'])
+def ready():
+    rt = {"success": True}
+    return json.dumps(rt)
+
+@app.route('/my_model/train', methods=['POST'])
+def train():
+    data_dic = json.loads(request.data)
+    df_bytes = base64.decodebytes(data_dic["df"].encode())
+    df = pickle.loads(df_bytes)
+    column_set = set(df.columns)
+    assert 3 == len(column_set)
+    assert 'col1' in column_set
+    assert 'col2' in column_set
+    assert 'label' in column_set
+    assert "label" == data_dic["target"]
+    assert isinstance(data_dic["predictor_id"], int)
+    assert "rayserve_predictor" == data_dic["predictor_name"]
+    rt = {"success": True}
+    return json.dumps(rt)
+
+
+@app.route('/my_model/predict', methods=['POST'])
+def predict():
+    data_dic = json.loads(request.data)
+    df_bytes = base64.decodebytes(data_dic["df"].encode())
+    df = pickle.loads(df_bytes)
+    column_set = set(df.columns)
+    assert 2 == len(column_set)
+    assert 'col1' in column_set
+    assert 'col2' in column_set
+    assert "label" == data_dic["target"]
+    assert isinstance(data_dic["predictor_id"], int)
+    assert "rayserve_predictor" == data_dic["predictor_name"]
+    rt = {data_dic["target"]: [1] * len(df)}
+    return json.dumps(rt)
+
+
+class TestRayServe(BaseExecutorTest):
+    global mock_server_port
+
+    def setup_class(cls):
+        BaseExecutorTest.setup_class(cls)
+        processor = multiprocessing.Process(target=app.run, kwargs={"debug": True,
+                                                                    "host": "0.0.0.0", "port": mock_server_port})
+        processor.daemon = True
+        processor.start()
+        i = 0
+        while i < 30:
+            try:
+                resp = requests.post(f"http://127.0.0.1:{mock_server_port}/ready")
+                if 200 == resp.status_code:
+                    break
+            except Exception as e:
+                print("wait mock server to start")
+            time.sleep(1)
+            i += 1
+        assert i < 30, "launch mock server failed"
+
+    def set_project(self):
+        r = self.db.Project.query.filter_by(name='mindsdb').first()
+        if r is not None:
+            self.db.session.delete(r)
+
+        r = self.db.Project(
+            id=1,
+            name='mindsdb',
+        )
+        self.db.session.add(r)
+        self.db.session.commit()
+
+    def run_mindsdb_sql(self, sql):
+        return self.command_executor.execute_command(
+            parse_sql(sql, dialect='mindsdb')
+        )
+
+    @patch('mindsdb.integrations.handlers.postgres_handler.Handler')
+    def test_rayserve_create_and_query_sql(self, mock_handler):
+        self.set_project()
+        # prepare data
+        fake_train = pd.DataFrame(data={"col1": [1, 2, 3], "col2": [4, 5, 6], "label": [1, 0, 1]})
+        fake_pred = pd.DataFrame(data={"col1": [2, 3, 5], "col2": [3, 2, 6]})
+        self.set_handler(mock_handler, name='pg', tables={'fake_train': fake_train, 'fake_pred': fake_pred})
+        # test create predictor
+        create_sql = f'''
+                            CREATE PREDICTOR mindsdb.rayserve_predictor
+                            FROM pg
+                            (select col1, col2, label from fake_train)
+                            PREDICT label
+                            USING engine='rayserve', train_url='http://127.0.0.1:{mock_server_port}/my_model/train',
+                                    predict_url='http://127.0.0.1:{mock_server_port}/my_model/predict'
+                            '''
+        ret = self.run_mindsdb_sql(sql=create_sql)
+        assert ret.error_code != 200, "train failed: rayserve_predictor"
+        self.wait_training(model_name=f'rayserve_predictor')
+
+        # test create predictor
+        create_sql = f'''
+                                select t.col1, t.col2, p.label
+                                from rayserve_predictor p
+                                inner join pg.fake_pred t;
+                            '''
+        ret = self.run_mindsdb_sql(sql=create_sql)
+        assert "col1" == ret.columns[0].name, "prediction result missing column col1"
+        assert "col2" == ret.columns[1].name, "prediction result missing column col2"
+        assert "label" == ret.columns[2].name, "prediction result missing column label"
+        assert [2, 3, 1] == ret.data[0], "wrong prediction result line 0"
+        assert [3, 2, 1] == ret.data[1], "wrong prediction result line 1"
+        assert [5, 6, 1] == ret.data[2], "wrong prediction result line 2"
+
+    def wait_training(self, model_name):
+        # wait
+        done = False
+        for attempt in range(900):
+            ret = self.run_mindsdb_sql(
+                f"select status from mindsdb.predictors where name='{model_name}'"
+            )
+            if len(ret.data) > 0:
+                if ret.data[0][0] == 'complete':
+                    done = True
+                    break
+                elif ret.data[0][0] == 'error':
+                    break
+            time.sleep(0.5)
+        if not done:
+            raise RuntimeError("predictor didn't created: " + model_name)
+
+

--- a/tests/unit/test_rayserve_handler.py
+++ b/tests/unit/test_rayserve_handler.py
@@ -15,6 +15,7 @@ from mindsdb_sql import parse_sql
 from .executor_test_base import BaseExecutorTest
 
 
+# The interface of flask implemented belows has been verified to have the same actions as RayServe.
 app = Flask(__name__)
 mock_server_port = 8129
 


### PR DESCRIPTION
Hey,  the RayServe in the latest version has been removed. I've discussed it with you team and know that you want to reconstruct it.

Now I've implemented it. In fact, I think there two several ways to implement it, I try to write a full ml handler at first, nearly finished, but I found it too complex, maybe result in some problems in stability. So I implement it in a light weight way, which only a few codes modified and it has been tested. 

Usage:

**create predictor**
```
CREATE PREDICTOR ray_serve_pred1
FROM test_mindsdb_proxy
   (SELECT dayofweek, hour, minute, cmp_mean_norm, anomaly_tag FROM trend_period_noisy_with_features_csv where column1 < 6000 and column1 > 60) 
PREDICT anomaly_tag
USING
    format='rayserve',
    url.train = 'http://127.0.0.1:8000/my_model/train',
    url.predict = 'http://127.0.0.1:8000/my_model/predict';
```
 
**use predictor**
```
SELECT c.dayofweek, c.hour, c.minute, c.cmp_mean_norm, p.anomaly_tag
FROM test_mindsdb_proxy.trend_period_noisy_with_features_csv c
join ray_serve_pred1 p
where c.column1 > 8000;   
```


