### PR TITLE
Remove AS {name} from all the CREATE PREDICTOR commands

### DIFF
--- a/docs/mindsdb-docs/docs/sql/create/view.md
+++ b/docs/mindsdb-docs/docs/sql/create/view.md
@@ -45,8 +45,8 @@ Below is the query that creates and trains the `home_rentals_model` model to pre
 ```sql
 CREATE PREDICTOR mindsdb.home_rentals_model
 FROM integration
-    (SELECT * FROM house_rentals_data) AS rentals
-PREDICT rental_price AS price;
+    (SELECT * FROM house_rentals_data)
+PREDICT rental_price;
 ```
 
 On execution, we get:


### PR DESCRIPTION

Fixes #2948

## Please describe what changes you made, in as much detail as possible
  -Remove AS {name} from all the CREATE PREDICTOR commands

mindsdb