### PR TITLE
Add SQL style prefix to tutorials (continued from yesterday)

### DIFF
--- a/docs/mindsdb-docs/docs/sql/create/predictor.md
+++ b/docs/mindsdb-docs/docs/sql/create/predictor.md
@@ -28,7 +28,7 @@ Where:
 | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `[predictor_name]`                              | Name of the model to be created.                                                                                                                |
 | `[integration_name]`                            | Name of the integration created using the [`#!sql CREATE DATABASE`](/sql/create/databases/) statement or [file upload](/sql/api/select_files/). |
-| `(SELECT [column_name, ...] FROM [table_name])` | `SELECT` statement for selecting data to be used for training and validation.                                                                   |
+| `(SELECT [column_name, ...] FROM [table_name])` | `#!sql SELECT` statement for selecting data to be used for training and validation.                                                                   |
 | `PREDICT [target_column]`                       | `target_column` is the column to be predicted.                                                                                                  |
 
 !!! TIP "Checking Model Status"
@@ -265,10 +265,10 @@ Where:
 
 | Expressions                              | Description                                                                                                                                                                                                                                                        |
 | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ORDER BY [sequential_column]`           | The column by which time series is ordered. It can be a date or anything that defines the sequence of events.                                                                                                                                                      |
-| `GROUP BY [partition_column]`            | It is optional. The column by which rows that make a partition are grouped. For example, if you want to forecast the inventory for all items in the store, you can partition the data by `product_id`, so each distinct `product_id` has its own time series.      |
-| `WINDOW [int]`                           | The number of rows to look back at when making a prediction. It comes after the rows are ordered by the column defined in `ORDER BY` and split into groups by the column(s) defined in `GROUP BY`. This could be interpreted as "Always use the previous 10 rows". |
-| `HORIZON [int]`                          | It is optional. The number of future predictions (it is 1 by default).                                                                                                                                                                                             |
+| `#!sql ORDER BY [sequential_column]`           | The column by which time series is ordered. It can be a date or anything that defines the sequence of events.                                                                                                                                                      |
+| `#!sql GROUP BY [partition_column]`            | It is optional. The column by which rows that make a partition are grouped. For example, if you want to forecast the inventory for all items in the store, you can partition the data by `product_id`, so each distinct `product_id` has its own time series.      |
+| `#!sql WINDOW [int]`                           | The number of rows to look back at when making a prediction. It comes after the rows are ordered by the column defined in `#!sql ORDER BY` and split into groups by the column(s) defined in `#!sql GROUP BY`. This could be interpreted as "Always use the previous 10 rows". |
+| `#!sql HORIZON [int]`                          | It is optional. The number of future predictions (it is 1 by default).                                                                                                                                                                                             |
 
 !!! warning "Getting a Prediction from a Time Series Model"
     Due to the nature of time series forecasting, you need to use the [`#!sql JOIN`](/sql/api/join) statement to get results.

--- a/docs/mindsdb-docs/docs/sql/create/predictor.md
+++ b/docs/mindsdb-docs/docs/sql/create/predictor.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The `CREATE PREDICTOR` statement creates and trains a new ML model.
+The `#!sql CREATE PREDICTOR` statement creates and trains a new ML model.
 
 ## Syntax
 

--- a/docs/mindsdb-docs/docs/sql/create/table.md
+++ b/docs/mindsdb-docs/docs/sql/create/table.md
@@ -6,14 +6,14 @@ The `#!sql CREATE TABLE` statement creates a table and fills it with a subselect
 
 ## Syntax
 
-You can use the usual `CREATE TABLE` statement:
+You can use the usual `#!sql CREATE TABLE` statement:
 
 ```sql
 CREATE TABLE [integration_name].[table_name]
     (SELECT ...);
 ```
 
-Or the `CREATE OR REPLACE TABLE` statement:
+Or the `#!sql CREATE OR REPLACE TABLE` statement:
 
 ```sql
 CREATE OR REPLACE TABLE [integration_name].[table_name]
@@ -23,7 +23,7 @@ CREATE OR REPLACE TABLE [integration_name].[table_name]
 Here are the steps followed by the syntax:
 
 - It executes a subselect query to get the output dataset.
-- In the case of the `CREATE OR REPLACE TABLE` statement, the `[integration_name].[table_name]` table is dropped before recreating it.
+- In the case of the `#!sql CREATE OR REPLACE TABLE` statement, the `[integration_name].[table_name]` table is dropped before recreating it.
 - It (re)creates the `[integration_name].[table_name]` table inside the `#!sql [integration_name]` integration.
 - It uses the [`#!sql INSERT INTO`](/sql/api/insert/) statement to insert the output of the `#!sql (SELECT ...)` query into the `[integration_name].[table_name]`.
 

--- a/docs/mindsdb-docs/docs/sql/create/view.md
+++ b/docs/mindsdb-docs/docs/sql/create/view.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The `#!sql CREATE VIEW` statement creates a view, which is a saved `SELECT` statement executed every time we call this view, as opposed to a table that stores its data in columns and rows.
+The `#!sql CREATE VIEW` statement creates a view, which is a saved `#!sql SELECT` statement executed every time we call this view, as opposed to a table that stores its data in columns and rows.
 
 In MindsDB, the `#!sql CREATE VIEW` statement is commonly used to create **AI Tables**. An AI Table is a virtual table created by joining the data source table with the prediction model.
 
@@ -40,7 +40,7 @@ Where:
 
 ## Example
 
-Below is the query that creates and trains the `home_rentals_model` model to predict the `rental_price` value. The inner `SELECT` statement provides all real estate listing data used to train the model.
+Below is the query that creates and trains the `home_rentals_model` model to predict the `rental_price` value. The inner `#!sql SELECT` statement provides all real estate listing data used to train the model.
 
 ```sql
 CREATE PREDICTOR mindsdb.home_rentals_model
@@ -55,9 +55,9 @@ On execution, we get:
 Query OK, 0 rows affected (x.xxx sec)
 ```
 
-Now, we can [`#!sql JOIN`](/sql/api/join/) the `home_rentals_data` table with the `home_rentals_model` model to make predictions. By creating a view (using the `#!sql CREATE VIEW` statement) that is based on the `SELECT` statement joining the data and model tables, we create an AI Table.
+Now, we can [`#!sql JOIN`](/sql/api/join/) the `home_rentals_data` table with the `home_rentals_model` model to make predictions. By creating a view (using the `#!sql CREATE VIEW` statement) that is based on the `#!sql SELECT` statement joining the data and model tables, we create an AI Table.
 
-Here, the `SELECT` statement joins the data source table and the model table. The input data for making predictions consists of the `sqft`, `number_of_bathrooms`, and `location` columns. These are joined with the `rental_price` column that stores predicted values.
+Here, the `#!sql SELECT` statement joins the data source table and the model table. The input data for making predictions consists of the `sqft`, `number_of_bathrooms`, and `location` columns. These are joined with the `rental_price` column that stores predicted values.
 
 ```sql
 CREATE VIEW mindsdb.home_rentals_predictions AS (
@@ -78,7 +78,7 @@ Query OK, 0 rows affected (x.xxx sec)
 ```
 
 !!! tip "Dataset for Training and Dataset for Joining"
-    In this example, we used the same dataset (`integration.home_rentals_data`) for training the model (see the `CREATE PREDICTOR` statement above) and for joining with the model to make predictions (see the `CREATE VIEW` statement above). It doesn't happen like that in real-world scenarios.
+    In this example, we used the same dataset (`integration.home_rentals_data`) for training the model (see the `#!sql CREATE PREDICTOR` statement above) and for joining with the model to make predictions (see the `#!sql CREATE VIEW` statement above). It doesn't happen like that in real-world scenarios.
     Normally, you use the old data to train the model, and then you join the new data with this model to make predictions.
 
     Consider the `old_data` dataset that stores data from the years 2019-2021 and the `new_data` dataset that stores data from the year 2022.

--- a/docs/mindsdb-docs/docs/sql/data-insights.md
+++ b/docs/mindsdb-docs/docs/sql/data-insights.md
@@ -10,7 +10,7 @@ It lets you explore the queried data by initially displaying and analyzing a sub
 
 The data used here comes from one of our tutorials. For details, click [here](/sql/tutorials/home-rentals/).
 
-Before you see the Data Insights pane, you must run a `SELECT` query on your dataset. Let's have a look at the available features.
+Before you see the Data Insights pane, you must run a `#!sql SELECT` query on your dataset. Let's have a look at the available features.
 
 ## Features
 
@@ -56,7 +56,7 @@ It is helpful to determine the exact data value counts from the histograms.
 
 Let's do a full data analysis step by step.
 
-First, we need to query data for analysis in the MindsDB Cloud editor. Please note that you need to query your dataset without using a `LIMIT` keyword to be able to perform a complete data analysis.
+First, we need to query data for analysis in the MindsDB Cloud editor. Please note that you need to query your dataset without using a `#!sql LIMIT` keyword to be able to perform a complete data analysis.
 
 ```sql
 SELECT *

--- a/docs/mindsdb-docs/docs/sql/tutorials/ai-tables.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/ai-tables.md
@@ -63,7 +63,7 @@ Let’s create a debt model that allows us to approximate the debt value for any
 CREATE PREDICTOR mindsdb.debt_model FROM income_table PREDICT debt;
 ```
 
-MindsDB provides the **CREATE PREDICTOR** statement. When we execute this statement, the predictive model works in the background, automatically creating a vector representation of the data that can be visualized as follows.
+MindsDB provides the `#!sql CREATE PREDICTOR` statement. When we execute this statement, the predictive model works in the background, automatically creating a vector representation of the data that can be visualized as follows.
 
 ![Income vs Debt model](/assets/sql/tutorials/snowflake-superset/7-debt-income-query-ml.jpg)
 

--- a/docs/mindsdb-docs/docs/sql/tutorials/bodyfat.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/bodyfat.md
@@ -65,7 +65,7 @@ Once you have confirmed the file has successfully uploaded and the data can be r
 
 ## Create and train a machine learning model.
 
-With the CREATE PREDICTOR statement, we can create a machine learning model:
+With the `#!sql CREATE PREDICTOR` statement, we can create a machine learning model:
 
 ```sql
 CREATE PREDICTOR mindsdb.predictor_name
@@ -143,7 +143,7 @@ As you can see, with around 99% confidence, MindsDB predicted the body fat perce
 
 ### Making Batch Predictions using the JOIN syntax
 
-The above example showed how to make predictions for a single individual's bodyfat, but what if you had a table of bodypart measurements for a number of individuals, and wanted to make predictions for them all?  This is possible using the [JOIN command](https://docs.mindsdb.com/sql/api/join/), which allows for the combining of rows from a database table and the prediction model table on a related column.  
+The above example showed how to make predictions for a single individual's bodyfat, but what if you had a table of bodypart measurements for a number of individuals, and wanted to make predictions for them all?  This is possible using the [`#!sql JOIN` command](https://docs.mindsdb.com/sql/api/join/), which allows for the combining of rows from a database table and the prediction model table on a related column.  
 
 The basic syntax to use the JOIN syntax is:
 

--- a/docs/mindsdb-docs/docs/sql/tutorials/byom.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/byom.md
@@ -327,7 +327,7 @@ dtype_dict={"text": "rich_text", "target": "integer"},
 format='ray_server';
 ```
 
-Training will take a while given that this model is a neural network rather than a simple logistic regression. You can check its status with the query `SELECT * FROM mindsdb.predictors WHERE name = 'byom_ray_serve_nlp';`, much like you'd do with a "normal" MindsDB predictor.
+Training will take a while given that this model is a neural network rather than a simple logistic regression. You can check its status with the query `#!sql SELECT * FROM mindsdb.predictors WHERE name = 'byom_ray_serve_nlp';`, much like you'd do with a "normal" MindsDB predictor.
 
 Once the predictor's status becomes `trained` we can query it for predictions as usual:
 
@@ -374,7 +374,7 @@ format='mlflow',
 data_dtype={"0": "integer", "1": "integer"}
 ```
 
-We can now run predictions as usual, by using the `WHERE` statement or joining on a data table with an appropriate schema:
+We can now run predictions as usual, by using the `#!sql WHERE` statement or joining on a data table with an appropriate schema:
 
 ```sql
 SELECT `1` FROM byom_mlflow WHERE `0`=2;
@@ -475,7 +475,7 @@ USING
     dtype_dict={"text": "rich text", "target": "binary"};
 ```
 
-To get predictions, you can directly pass input data using the `WHERE` clause:
+To get predictions, you can directly pass input data using the `#!sql WHERE` clause:
 
 ```sql
 SELECT target
@@ -483,7 +483,7 @@ FROM mindsdb.byom_mlflow_nlp
 WHERE text='The tsunami is coming, seek high ground';
 ```
 
-Or you can `JOIN` with a data table. For this, you should ensure the table actually exists and that the database it belongs to has been connected to your MindsDB instance. For more details, refer to the same steps in the Ray Serve example (section 1.2).
+Or you can `#!sql JOIN` with a data table. For this, you should ensure the table actually exists and that the database it belongs to has been connected to your MindsDB instance. For more details, refer to the same steps in the Ray Serve example (section 1.2).
 
 ```sql
 SELECT

--- a/docs/mindsdb-docs/docs/sql/tutorials/customer-churn.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/customer-churn.md
@@ -152,7 +152,7 @@ Now, if the status of our predictor says `complete`, we can start making predict
 
 ## Making Predictions
 
-You can make predictions by querying the predictor as if it were a table. The [`SELECT`](/sql/api/select/) syntax lets you make predictions for the label based on the chosen features.
+You can make predictions by querying the predictor as if it were a table. The [`#!sql SELECT`](/sql/api/select/) syntax lets you make predictions for the label based on the chosen features.
 
 ```sql
 SELECT Churn, Churn_confidence, Churn_explain
@@ -176,7 +176,7 @@ On execution, we get:
 +-------+---------------------+-------------------------------------------------------------------------------------------------+
 ```
 
-To get more accurate predictions, we should provide as much data as possible in the `WHERE` clause. Let's run another query.
+To get more accurate predictions, we should provide as much data as possible in the `#!sql WHERE` clause. Let's run another query.
 
 ```sql
 SELECT Churn, Churn_confidence, Churn_explain

--- a/docs/mindsdb-docs/docs/sql/tutorials/heart-disease.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/heart-disease.md
@@ -74,7 +74,7 @@ Select the `Run` button or Shift+Enter to execute the syntax. Once the Database 
 
 We can create a machine learning predictive model by using simple SQL statements executed in the SQL Editor.
 
-To create and train a new machine learning model we will need to use the CREATE PREDICTOR statement:
+To create and train a new machine learning model we will need to use the `#!sql CREATE PREDICTOR` statement:
 
 ```sql
 CREATE PREDICTOR mindsdb.predictor_name
@@ -116,7 +116,7 @@ The complete status means that the model training has successfully finished.
  
 ## Using SQL Statements to make predictions
 
-The next steps would be to query the model and predict the heart disease risk. Let’s imagine a patient. This patient’s age is 30, she has a cholesterol level of 177 mg/dl, with slope of the peak exercise ST segment as 2, and thal as 2. Add all of this information to the `WHERE` clause.
+The next steps would be to query the model and predict the heart disease risk. Let’s imagine a patient. This patient’s age is 30, she has a cholesterol level of 177 mg/dl, with slope of the peak exercise ST segment as 2, and thal as 2. Add all of this information to the `#!sql WHERE` clause.
 
 ```sql
 SELECT target AS prediction,

--- a/docs/mindsdb-docs/docs/sql/tutorials/home-rentals.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/home-rentals.md
@@ -150,7 +150,7 @@ Now, if the status of our predictor says `complete`, we can start making predict
 
 ### Making a Single Prediction
 
-You can make predictions by querying the predictor as if it were a table. The [`SELECT`](/sql/api/select/) statement lets you make predictions for the label based on the chosen features.
+You can make predictions by querying the predictor as if it were a table. The [`#!sql SELECT`](/sql/api/select/) statement lets you make predictions for the label based on the chosen features.
 
 ```sql
 SELECT rental_price, rental_price_explain

--- a/docs/mindsdb-docs/docs/sql/tutorials/house-sales-forecasting.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/house-sales-forecasting.md
@@ -152,7 +152,7 @@ Now, if the status of our predictor says `complete`, we can start making predict
 
 ## Making Predictions
 
-You can make predictions by querying the predictor joined with the data table. The [`SELECT`](/sql/api/select/) statement lets you make predictions for the label based on the chosen features for a given time period. Usually, you want to know what happens right after the latest training data point that was fed. We have a special keyword for that, the `LATEST` keyword.
+You can make predictions by querying the predictor joined with the data table. The [`#!sql SELECT`](/sql/api/select/) statement lets you make predictions for the label based on the chosen features for a given time period. Usually, you want to know what happens right after the latest training data point that was fed. We have a special keyword for that, the `LATEST` keyword.
 
 ```sql
 SELECT m.saledate AS date, m.MA AS forecast, MA_explain
@@ -177,7 +177,7 @@ On execution, we get:
 +-------------+-------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ```
 
-Please note that in the [`SELECT`](/sql/api/select/) statement, we select `m.saledate` instead of `t.saledate` because we make predictions for future dates that are not in the data table.
+Please note that in the [`#!sql SELECT`](/sql/api/select/) statement, we select `m.saledate` instead of `t.saledate` because we make predictions for future dates that are not in the data table.
 
 Now, try changing the `type` column value to *unit*, or the `bedrooms` column value to any number between 1 to 5, and check how the forecasts vary. This is because MindsDB recognizes each grouping as being its own different time series.
 

--- a/docs/mindsdb-docs/docs/sql/tutorials/mindsdb-superset-snowflake.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/mindsdb-superset-snowflake.md
@@ -84,8 +84,8 @@ PREDICT RIDES ORDER BY DATE GROUP BY ROUTE
 WINDOW 10 HORIZON 7;
 ```
 
-Let’s discuss the statement above. We create a predictor table using the `CREATE PREDICTOR` statement and specifying the database from which the training data comes. The code in `yellow` selects the filtered training data. After that, we use the `PREDICT` keyword to define the column whose data we want to forecast.
-Next, there are standard SQL clauses, such as `ORDER BY, GROUP BY, WINDOW, and HORIZON`. We use the `ORDER BY` clause and the DATE column as its argument. By doing so, we emphasize that we deal with a time-series problem. We order the rows by date. The `GROUP BY` clause divides the data into partitions. Here, each of them relates to a particular bus route. We take into account just the last ten rows for every given prediction. Hence, we use `WINDOW` 10. To prepare the forecast of the number of bus rides for the next week, we define `HORIZON` 7.
+Let’s discuss the statement above. We create a predictor table using the `#!sql CREATE PREDICTOR` statement and specifying the database from which the training data comes. The code in `yellow` selects the filtered training data. After that, we use the `#!sql PREDICT` keyword to define the column whose data we want to forecast.
+Next, there are standard SQL clauses, such as `#!sql ORDER BY, GROUP BY, WINDOW, and HORIZON`. We use the `#!sql ORDER BY` clause and the DATE column as its argument. By doing so, we emphasize that we deal with a time-series problem. We order the rows by date. The `#!sql GROUP BY` clause divides the data into partitions. Here, each of them relates to a particular bus route. We take into account just the last ten rows for every given prediction. Hence, we use `#!sql WINDOW` 10. To prepare the forecast of the number of bus rides for the next week, we define `#!sql HORIZON` 7.
 Now, you can execute the CREATE PREDICTOR statement and wait until your predictive model is complete. The MINDSDB.PREDICTORS table stores its name as rides_forecaster_demo and its status as training. Once your predictive model is ready, the status changes to complete.
 
 ## Step 3: Getting the Forecasts

--- a/docs/mindsdb-docs/docs/sql/tutorials/mushrooms.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/mushrooms.md
@@ -99,7 +99,7 @@ Once the database integration is successful we can query the table from the data
 
 Now we are ready to create our own predictor. We will start by using the SQL Editor to execute simple SQL syntax to create and train a machine learning predictive model.
 
-The predictor we will and be trained to determine if a mushroom is edible or poisonous.The following CREATE PREDICTOR statement is used to create predictors:
+The predictor we will and be trained to determine if a mushroom is edible or poisonous.The following `#!sql CREATE PREDICTOR` statement is used to create predictors:
 
 ```sql
 CREATE PREDICTOR mindsdb.predictor_name

--- a/docs/mindsdb-docs/docs/sql/tutorials/spam_emails_tutorial.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/spam_emails_tutorial.md
@@ -40,7 +40,7 @@ First we need to switch to using the mindsdb database.
 USE mindsdb;
 ```
 
-We will start by training a model with the CREATE PREDICTOR command using all columns from the dataset we uploaded.
+We will start by training a model with the `#!sql CREATE PREDICTOR` command using all columns from the dataset we uploaded.
 
 ```sql
 CREATE PREDICTOR mindsdb.spam_predictor


### PR DESCRIPTION
Fixes #2947 

## Please describe what changes you made, in as much detail as possible
  - Yesterday I couldn't finish going through all of the document files, so I did another pass through the files and add the `#!sql` prefix to enforce SQL style to commands and keywords as described in #2947 
  - I'm pretty sure I went through all of the files in [/sql](https://github.com/mindsdb/mindsdb/tree/staging/docs/mindsdb-docs/docs/sql), but skipped making changes to some files because I didn't see the command or wasn't sure about the change.

mindsdb