### PR TITLE
Making JSON statements more uniform in documentation

### DIFF
--- a/docs/mindsdb-docs/docs/sql/tutorials/bitcoin-forecasting.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/bitcoin-forecasting.md
@@ -127,7 +127,7 @@ Now you are in the last step of this tutorial, creating the prediction. To creat
 
 ```sql
 SELECT target_variable, target_variable_explain FROM model_table 
-WHERE when_data='{"column3": "value", "column2": "value"}';
+WHERE when_data={"column3": "value", "column2": "value"};
 ```
 
 And you need to set these values:


### PR DESCRIPTION
Removing single quotations from documentation containing JSON in documentation

Fixes #2949

## Please describe what changes you made, in as much detail as possible
  -Making JSON statements more uniform in documentation

mindsdb