### PR TITLE
Remove AS {name} from Process Quality Tutorial

### DIFF
--- a/docs/mindsdb-docs/docs/sql/tutorials/process-quality.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/process-quality.md
@@ -72,7 +72,7 @@ FROM files (
            flotation_column_07_level, iron_concentrate, silica_concentrate
     FROM process_quality
     LIMIT 5000
-) PREDICT silica_concentrate AS quality;
+) PREDICT silica_concentrate;
 ```
 
 On execution, we get:


### PR DESCRIPTION
Remove "AS quality" from Process Quality Tutorial

Fixes #3080

## Please describe what changes you made, in as much detail as possible
  -Remove AS {name} from Process Quality Tutorial

mindsdb