### PR TITLE
Remove AS {name} from Insurance Cost Tutorial

### DIFF
--- a/docs/mindsdb-docs/docs/sql/tutorials/insurance-cost-prediction.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/insurance-cost-prediction.md
@@ -98,7 +98,7 @@ To train a new machine learning model we will need to CREATE PREDICTOR as a new 
 CREATE PREDICTOR mindsdb.predictor_name
 FROM integration_name
     (SELECT column_name, column_name2 FROM table_name) AS ds_name
-PREDICT column_name AS column_alias;
+PREDICT column_name;
 ```
 
 The values that we need to provide are:


### PR DESCRIPTION
Remove " AS column_alias" from Insurance Cost Tutorial

Fixes #3079

## Please describe what changes you made, in as much detail as possible
  -Remove AS {name} from Insurance Cost Tutorial

mindsdb