### PR TITLE
Remove AS {name} from the CREATE PREDICTOR

### DIFF
--- a/docs/mindsdb-docs/docs/sql/tutorials/crop-prediction.md
+++ b/docs/mindsdb-docs/docs/sql/tutorials/crop-prediction.md
@@ -60,7 +60,7 @@ In the SQL Editor, type in the below syntax to create and train a machine learni
 CREATE PREDICTOR crop_predictor
 FROM files
     (SELECT * FROM crops)
-PREDICT label AS crop_type;
+PREDICT label;
 ```
 
 Select the button `Run` or Shift+Enter to execute the code. If the predictor is successfully created the console will display a message `Query successfully completed`.


### PR DESCRIPTION
Fixes #3081 

## Please describe what changes you made, in as much detail as possible
  - Remove AS {name} from the CREATE PREDICTOR command in Crop Recommendation Tutorial Page under Community Tutorial Section 


mindsdb