### PR TITLE
minor: fix typo in docs/contribute/integrations

### DIFF
--- a/docs/mindsdb-docs/docs/contribute/integrations.md
+++ b/docs/mindsdb-docs/docs/contribute/integrations.md
@@ -232,7 +232,7 @@ Each database handler should inherit from the [`DatabaseHandler`](https://github
 
 * Implementing the `get_columns()` method:
 
-    The `get_tables()` method lists all columns of a specified table.
+    The `get_columns()` method lists all columns of a specified table.
 
     ```py
     def get_columns(self, table_name: str) -> HandlerStatusResponse:


### PR DESCRIPTION
While working on a new database handler, came across a minor typo in the docs for building integrations. Minor change.

## Please describe what changes you made, in as much detail as possible
  - fixed a minor typo in docs

mindsdb