### PR TITLE
Referencing community tutorial from chandrevdw31

### DIFF
--- a/docs/mindsdb-docs/docs/tutorials.md
+++ b/docs/mindsdb-docs/docs/tutorials.md
@@ -4,3 +4,4 @@
 * [How To Visualize MindsDB Predictions with Tableau](https://dev.to/ephraimx/how-to-visualize-mindsdb-predictions-with-tableau-2bpd) by [Ephraimx](https://dev.to/ephraimx)
 * [Predicting Supermarket Future Sales Using Machine Learning with MindsDB](https://dev.to/ephraimx/predicting-future-sales-using-machine-learning-with-mindsdb-3p70) by [Ephraimx](https://dev.to/ephraimx)
 * [Predicting Home Rental Prices with MindsDB in Python](https://curiousprogrammer.hashnode.dev/predicting-home-rental-prices-with-mindsdb-in-python) by [Temidayo](https://hashnode.com/@Temicoder)
+* [MindsDB: Your introduction to creating machine learning predictive models.](https://dev.to/chandrevdw31/mindsdb-your-introduction-to-creating-machine-learning-predictive-models-12d3) by [Chandre Van Der Westhuizen](https://dev.to/chandrevdw31)


### PR DESCRIPTION
Adding "MindsDB: Your introduction to creating machine learning predictive models." to list of centralized community tutorials

Fixes #3095

## Please describe what changes you made, in as much detail as possible
  -Referencing community tutorial from chandrevdw31

mindsdb