### PR TITLE
[minor] Use SAP HANA Dialect Implementation for `get_columns()`

### DIFF
--- a/mindsdb/integrations/handlers/hana_handler/hana_handler.py
+++ b/mindsdb/integrations/handlers/hana_handler/hana_handler.py
@@ -205,12 +205,7 @@ class HanaHandler(DatabaseHandler):
         :return: returns the columns in the table
         """
 
-        return self.native_query(f"""
-            SELECT COLUMN_NAME    AS "Field",
-                   DATA_TYPE_NAME AS "Type"
-            FROM SYS.TABLE_COLUMNS
-            WHERE TABLE_NAME = '{table_name}'
-        """)
+        return self.renderer.dialect.get_columns(table_name)
 
 
 connection_args = OrderedDict(


### PR DESCRIPTION
`HANAHDBCLIDialect` already includes a method for getting columns from a table, this could be a cleaner way.