### PR TITLE
[docs] Add SAP HANA Handler Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ MindsDB works with most of the SQL and NoSQL databases and data Streams for real
 | <a href="https://docs.mindsdb.com/"><img src="https://img.shields.io/badge/PostgreSQL-316192?style=for-the-badge&logo=postgresql&logoColor=white" alt="Connect PostgreSQL"></a> |
 | <a href="https://docs.mindsdb.com/"><img src="https://img.shields.io/badge/QuestDB-d14671?style=for-the-badge&logo=questdb&logoColor=white" alt="Connect QuestDB"></a> |
 | <a href="https://docs.mindsdb.com/"><img src="https://img.shields.io/badge/redis-%23DD0031.svg?&style=for-the-badge&logo=redis&logoColor=white" alt="Connect Redis"></a> |
+| <a href="https://docs.mindsdb.com/"><img src="https://img.shields.io/badge/SAP%20HANA-1661BE?style=for-the-badge&logo=sap&logoColor=white" alt="Connect SAP HANA"></a> |
 | <a href="https://docs.mindsdb.com/"><img src="https://img.shields.io/badge/ScyllaDB-53CADD?style=for-the-badge&logo=scylladbb&logoColor=white" alt="Connect ScyllaDB"></a> |
 | <a href="https://docs.mindsdb.com/"><img src="https://img.shields.io/badge/Singlestore-5f07b4?style=for-the-badge&logo=singlestore&logoColor=white" alt="Connect Singlestore"></a> |
 | <a href="https://docs.mindsdb.com/"><img src="https://img.shields.io/badge/Snowflake-35aedd?style=for-the-badge&logo=snowflake&logoColor=blue" alt="Connect Snowflake"></a> |

--- a/mindsdb/integrations/handlers/hana_handler/README.md
+++ b/mindsdb/integrations/handlers/hana_handler/README.md
@@ -1,0 +1,74 @@
+# SAP HANA Handler
+
+This is the implementation of the SAP HANA handler for MindsDB.
+
+## SAP HANA
+
+SAP HANA (High-performance ANalytic Appliance) is a multi-model database that stores data in its memory instead of keeping it on a disk. The column-oriented in-memory database design used by SAP HANA allows users to run advanced analytics alongside high-speed transactions in a single system. [Read more](https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html).
+
+## Implementation
+
+This handler was implemented using `hdbcli` - the Python driver for SAP HANA.
+
+The required arguments to establish a connection are,
+
+* `host`: the host name or IP address of the SAP HANA instance
+* `port`: the port number of the SAP HANA instance
+* `user`: specifies the user name
+* `password`: specifies the password for the user
+* `schema`: sets the current schema, which is used for identifiers without a schema
+
+## Usage
+
+Assuming you created a schema in SAP HANA called `MINDSDB` and you have a table called `TEST` that was created using
+the following SQL statements:
+
+~~~~sql
+CREATE SCHEMA MINDSDB;
+
+CREATE TABLE MINDSDB.TEST
+(
+    ID          INTEGER NOT NULL,
+    NAME        NVARCHAR(1),
+    DESCRIPTION NVARCHAR(1)
+);
+
+CREATE UNIQUE INDEX MINDSDB.TEST_ID_INDEX
+    ON MINDSDB.TEST (ID);
+
+ALTER TABLE MINDSDB.TEST
+    ADD CONSTRAINT TEST_PK
+        PRIMARY KEY (ID);
+
+INSERT INTO MINDSDB.TEST
+VALUES (1, 'h', 'w');
+~~~~
+
+In order to make use of this handler and connect to the SAP HANA database in MindsDB, the following syntax can be used:
+
+~~~~sql
+CREATE DATABASE sap_hana_trial
+WITH ENGINE = 'hana', 
+PARAMETERS = {
+    "user": "DBADMIN",
+    "password": "password",
+    "host": "<uuid>.hana.trial-us10.hanacloud.ondemand.com",
+    "port": "443",
+    "schema": "MINDSDB",
+    "encrypt": true
+};
+~~~~
+
+**Note**: The above example assumes usage of SAP HANA Cloud, which requires the `encrypt` parameter to be set to `true` and uses port `443`.
+
+Now, you can use this established connection to query your database as follows:
+
+~~~~sql
+SELECT * FROM sap_hana_trial.test
+~~~~
+
+| ID | NAME | DESCRIPTION |
+|----|------|-------------|
+| 1  | h    | w           |
+
+![MindsDB using SAP HANA Integration](https://i.imgur.com/okXNhoc.jpg)

--- a/mindsdb/integrations/handlers/hana_handler/hana_handler.py
+++ b/mindsdb/integrations/handlers/hana_handler/hana_handler.py
@@ -184,7 +184,7 @@ class HanaHandler(DatabaseHandler):
 
     def get_tables(self) -> Response:
         """
-        List all tabese in SAP HANA in the current schema
+        List all tables in SAP HANA in the current schema
         """
 
         return self.native_query(f"""

--- a/mindsdb/integrations/handlers/hana_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/hana_handler/requirements.txt
@@ -1,2 +1,2 @@
-sqlalchemy-hana >= 1.4.0
-hdbcli >= 2.4.140
+sqlalchemy-hana
+hdbcli

--- a/mindsdb/integrations/handlers/hana_handler/tests/test_hana_handler.py
+++ b/mindsdb/integrations/handlers/hana_handler/tests/test_hana_handler.py
@@ -36,6 +36,7 @@ class HanaHandlerTest(unittest.TestCase):
             "user": "DBADMIN",
             "password": os.environ.get('HANA_PASSWORD'),
             "schema": "MINDSDB",
+            "encrypt": True
         }
         cls.handler = HanaHandler('test_hana_handler', cls.kwargs)
 


### PR DESCRIPTION
- Adds SAP HANA handler documentation and features it on the main README
- Fixes the test config and requirement version pins for reproducibility (invalid package versions added earlier inadvertently)