### PR TITLE
Fix timeseries alignment

### DIFF
--- a/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
+++ b/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
@@ -554,7 +554,7 @@ class LightwoodHandler(PredictiveHandler):
         timeseries_settings = predictor_record.learn_args['timeseries_settings']
 
         if timeseries_settings['is_timeseries'] is True:
-            __no_forecast_offset = set([row.get('__mdb_forecast_offset', None) for row in pred_dicts]) == {None}
+            __no_forecast_offset = set([row.get('__mdb_forecast_offset', None) for row in pred_dicts]) == {1}
 
             predict = predictor_record.to_predict[0]
             group_by = timeseries_settings['group_by'] or []


### PR DESCRIPTION
Fixes #3213

## change the logic of __no_forecast_offset

with current implementation, the predict row `__mindsdb_row_id` is not cleared correctly for the 1st row in the 2 cases
- no WHERE condition
- "> LATEST" is used

https://github.com/mindsdb/mindsdb/blob/staging/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py#L622

So the wrong data is joined. 
