### PR TITLE
Fixes MongoAPI for adding predictor

### DIFF
--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -167,7 +167,7 @@ if __name__ == '__main__':
     # @TODO Backwards compatibility for tests, remove later
 
     if args.api is None:
-        api_arr = ['http', 'mysql']
+        api_arr = ['http', 'mysql', 'mongodb']
     else:
         api_arr = args.api.split(',')
 

--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -167,7 +167,7 @@ if __name__ == '__main__':
     # @TODO Backwards compatibility for tests, remove later
 
     if args.api is None:
-        api_arr = ['http', 'mysql', 'mongodb']
+        api_arr = ['http', 'mysql']
     else:
         api_arr = args.api.split(',')
 

--- a/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
+++ b/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Any
 import copy
 from dateutil.parser import parse as parse_datetime
-
+from collections import OrderedDict
 import psutil
 import pandas as pd
 import lightwood
@@ -63,6 +63,7 @@ class NumpyJSONEncoder(json.JSONEncoder):
     x = np.float32(5)
     json.dumps(x, cls=NumpyJSONEncoder)
     """
+
     def default(self, obj):
         if isinstance(obj, np.ndarray):
             return obj.tolist()
@@ -284,12 +285,17 @@ class LightwoodHandler(PredictiveHandler):
 
         lightwood_integration_meta = self.handler_controller.get(name='lightwood')
 
+        if isinstance(statement.query_str, (OrderedDict, dict,)):
+            query_str = str(dict(statement.query_str))
+        else:
+            query_str = statement.query_str
+
         predictor_record = db.Predictor(
             company_id=self.company_id,
             name=model_name,
             integration_id=lightwood_integration_meta['id'],
             data_integration_id=integration_meta['id'],
-            fetch_data_query=statement.query_str,
+            fetch_data_query=query_str,  # This is not string,
             mindsdb_version=mindsdb_version,
             lightwood_version=lightwood_version,
             to_predict=problem_definition.target,

--- a/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
+++ b/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
@@ -295,7 +295,7 @@ class LightwoodHandler(PredictiveHandler):
             name=model_name,
             integration_id=lightwood_integration_meta['id'],
             data_integration_id=integration_meta['id'],
-            fetch_data_query=query_str,  # This is not string,
+            fetch_data_query=query_str,
             mindsdb_version=mindsdb_version,
             lightwood_version=lightwood_version,
             to_predict=problem_definition.target,


### PR DESCRIPTION
Fixes #3297

## Please describe what changes you made, in as much detail as possible
  - As mentioned in the issue, the ` select_data_query` field is of Ordered Dict type.
  - lightwood handler fails to insert *Predictor record* as `fetch_data_query` field expects string instead of dict. Refer here for[DB column data type](https://github.com/mindsdb/mindsdb/blob/2dcf36340fb4791ebfd1417db5f5819744fa828b/mindsdb/interfaces/storage/db.py#L93) and [query that's sent as Ordered dict instead of string](https://github.com/mindsdb/mindsdb/blob/2dcf36340fb4791ebfd1417db5f5819744fa828b/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py#L292)
  - The fix converts the dict datatype to string