### PR TITLE
docker-compose: run migrations in a separate container

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,29 +2,39 @@ version: "3.2"
 
 services:
 
+  migrations:
+    command: bash -c "cd /mindsdb && python ./mindsdb/migrations/migrate.py"
+
+    <<: &globalSettings
+      build:
+        context: ../
+        dockerfile: ./docker/mindsdb.Dockerfile
+      volumes:
+        - type: bind
+          source: ../
+          target: /mindsdb
+      environment:
+        MINDSDB_STORAGE_DIR: "/mindsdb/var"
+
   mindsdb:
-    build:
-      context: ../
-      dockerfile: ./docker/mindsdb.Dockerfile
+    # Copy global settings from migration above
+    <<: *globalSettings
     restart: always
     ports:
       - '47334:47334'
       - '47335:47335'
     command: bash -c "cd /mindsdb && python -m mindsdb"
     environment:
+      MINDSDB_STORAGE_DIR: "/mindsdb/var"
       FLASK_DEBUG: "1"
       FLASK_ENV: "development"
       FLASK_APP: "/mindsdb/mindsdb/__main__.py"
-    volumes:
-      - type: bind
-        source: ../
-        target: /mindsdb
+      SEPARATE_MIGRATIONS: "1"
     healthcheck:
       test:  ["CMD", "curl", "-f", "http://localhost:47334/api/util/ping"]
       interval: 30s
       timeout: 4s
       retries: 100
-
 
   mysql_db:
     image: "mindsdb/mysql-handler-test"

--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -57,8 +57,15 @@ if __name__ == '__main__':
     config = Config()
 
     is_cloud = config.get('cloud', False)
+    # need configure migration behavior by env_variables
+    # leave 'is_cloud' for now, but needs to be removed further
+    run_migration_separately = os.environ.get("SEPARATE_MIGRATIONS", False)
+    if run_migration_separately in (False, "false","False", 0, "0", ""):
+        run_migration_separately = False
+    else:
+        run_migration_separately = True
 
-    if not is_cloud:
+    if not is_cloud and not run_migration_separately:
         print('Applying database migrations:')
         try:
             from mindsdb.migrations import migrate

--- a/mindsdb/migrations/migrate.py
+++ b/mindsdb/migrations/migrate.py
@@ -36,3 +36,7 @@ def migrate_to_head():
             return
 
     upgrade(config=config, revision='head')
+
+
+if __name__ == "__main__":
+    migrate_to_head()


### PR DESCRIPTION
Fixes [50](https://github.com/mindsdb/mindsdb_private/issues/50)

- Migration runs in a separate container
- This behavior managed by specifying/non-specifying SEPARATE_MIGRATIONS env variable
- mindsdb container and migration container use same MINDSDB_STORAGE_DIR (which is mindsdb_repo_root_dir/var by default)