### PR TITLE
Fixed broken links for Docker and Pip in getting-started.

### DIFF
--- a/docs/mindsdb-docs/docs/getting-started.md
+++ b/docs/mindsdb-docs/docs/getting-started.md
@@ -12,11 +12,11 @@ To try out MindsDB right away without bringing in your own data or models, follo
 
     === "Docker"
 
-        To get started with a Docker installation, follow the MindsDB installation instructions using [Docker](/deployment/docker).
+        To get started with a Docker installation, follow the MindsDB installation instructions using [Docker](/setup/self-hosted/docker).
 
     === "pip"
 
-        You can also install MindsDB from source using [pip](setup/self-hosted/pip/source/).
+        You can also install MindsDB from source using [pip](/setup/self-hosted/pip/source/).
 
 1. Open your SQL client and connect to MindsDB.
 


### PR DESCRIPTION
This seems related to #2595 and #2608 although those have been long-since closed.

## Please describe what changes you made, in as much detail as possible
  - While I was setting up a new machine, I noticed that the Docker and Pip links were broken in getting-started, but not in quickstart. Did a quick search to see if there was any issues or PRs related, but couldn't find any, so here's a quick PR to fix those links. :)
  - docs/mindsdb-docs/docs/getting-started.md contained an old link for Docker that appears to no longer exist (/deployment/docker), and the link for Pypi was missing the leading forward slash resulting in a 404 from the docs attempting a relative path instead of absolute.

mindsdb