### PR TITLE
Cleaned up handler tests

### DIFF
--- a/mindsdb/integrations/handlers/cockroach_handler/tests/test_cockroachdb_handler.py
+++ b/mindsdb/integrations/handlers/cockroach_handler/tests/test_cockroachdb_handler.py
@@ -7,11 +7,13 @@ class CockroachHandlerTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.kwargs = {
-            "host": "localhost",
-            "port": "5432",
-            "user": "mindsdb",
-            "password": "mindsdb",
-            "database": "postgres"
+            "connection_data": {
+                "host": "localhost",
+                "port": "5432",
+                "user": "mindsdb",
+                "password": "mindsdb",
+                "database": "postgres"
+            }
         }
         cls.handler = CockroachHandler('test_cockroach_handler', **cls.kwargs)
 

--- a/mindsdb/integrations/handlers/db2_handler/tests/test_db2_handler.py
+++ b/mindsdb/integrations/handlers/db2_handler/tests/test_db2_handler.py
@@ -7,12 +7,14 @@ class DB2HandlerTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.kwargs = {
-            "host": "127.0.0.1",
-            "port": "25000",
-            "user": "db2admin",
-            "password": "1234",
-            "database": "Books",
-            "schemaName": "db2admin"
+            "connection_data": {
+                "host": "127.0.0.1",
+                "port": "25000",
+                "user": "db2admin",
+                "password": "1234",
+                "database": "Books",
+                "schema_name": "db2admin"
+            }
         }
         cls.handler = DB2Handler('test_db2_handler', **cls.kwargs)
 

--- a/mindsdb/integrations/handlers/firebird_handler/tests/test_firebird_handler.py
+++ b/mindsdb/integrations/handlers/firebird_handler/tests/test_firebird_handler.py
@@ -7,10 +7,12 @@ class FirebirdHandlerTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.kwargs = {
-            "host": "localhost",
-            "database": r"C:\Users\minura\Documents\mindsdb\test.fdb",
-            "user": "sysdba",
-            "password": "password"
+            "connection_data": {
+                "host": "localhost",
+                "database": r"C:\Users\minura\Documents\mindsdb\test.fdb",
+                "user": "sysdba",
+                "password": "password"
+            }
         }
         cls.handler = FirebirdHandler('test_firebird_handler', cls.kwargs)
 

--- a/mindsdb/integrations/handlers/informix_handler/tests/test_informix_handler.py
+++ b/mindsdb/integrations/handlers/informix_handler/tests/test_informix_handler.py
@@ -7,14 +7,16 @@ class InformixHandlerTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.kwargs = {
-            "server": "server",
-            "host": "127.0.0.1",
-            "port": 9093,
-            "user": "informix",
-            "password": "in4mix",
-            "database": "demo",
-            "schema_name": "love",
-            "loging_enabled": False
+            "connection_data": {
+                "server": "server",
+                "host": "127.0.0.1",
+                "port": 9093,
+                "user": "informix",
+                "password": "in4mix",
+                "database": "demo",
+                "schema_name": "love",
+                "loging_enabled": False
+            }
         }
         cls.handler = InformixHandler('test_informix_handler', cls.kwargs)
 

--- a/mindsdb/integrations/handlers/matrixone_handler/tests/test_matrixone_handler.py
+++ b/mindsdb/integrations/handlers/matrixone_handler/tests/test_matrixone_handler.py
@@ -8,12 +8,14 @@ class MatrixOneHandlerTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.kwargs = {
-            "host": "localhost",
-            "port": 6001,
-            "user": "dump",
-            "password": "111",
-            "database": "mo_catalog",
-            "ssl": False
+            "connection_data": {
+                "host": "localhost",
+                "port": 6001,
+                "user": "dump",
+                "password": "111",
+                "database": "mo_catalog",
+                "ssl": False
+            }
         }
         cls.handler = MatrixOneHandler('test_mysql_handler', cls.kwargs)
 

--- a/mindsdb/integrations/handlers/mlflow_handler/tests/test_mlflow_handler.py
+++ b/mindsdb/integrations/handlers/mlflow_handler/tests/test_mlflow_handler.py
@@ -1,8 +1,8 @@
 import unittest
 
 from mindsdb.utilities.config import Config
-from mindsdb.integrations.mlflow_handler.mlflow.mlflow_handler import MLflowHandler
-from mindsdb.integrations.mysql_handler.mysql_handler.mysql_handler import MySQLHandler
+from mindsdb.integrations.handlers.mlflow_handler.mlflow_handler.mlflow_handler import MLflowHandler
+from mindsdb.integrations.handlers.mysql_handler.mysql_handler import MySQLHandler
 
 
 class MLflowHandlerTest(unittest.TestCase):

--- a/mindsdb/integrations/handlers/monetdb_handler/tests/test_monetdb_handler.py
+++ b/mindsdb/integrations/handlers/monetdb_handler/tests/test_monetdb_handler.py
@@ -7,11 +7,13 @@ class MonetDBHandlerTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.kwargs = {
-            "host": "127.0.0.1",
-            "port": 50000,
-            "user": "monetdb",
-            "password": "monetdb",
-            "database": "demo",
+            "connection_data": {
+                "host": "127.0.0.1",
+                "port": 50000,
+                "user": "monetdb",
+                "password": "monetdb",
+                "database": "demo",
+            }
             
         }
         cls.handler = MonetDBHandler('test_monet_handler', cls.kwargs)

--- a/mindsdb/integrations/handlers/mssql_handler/tests/test_mssql_handler.py
+++ b/mindsdb/integrations/handlers/mssql_handler/tests/test_mssql_handler.py
@@ -7,11 +7,13 @@ class SqlServerHandlerTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.kwargs = {
-            "host": "localhost",
-            "port": "1433",
-            "user": "sa",
-            "password": "",
-            "database": "master"
+           "connection_data": {
+                "host": "localhost",
+                "port": "1433",
+                "user": "sa",
+                "password": "",
+                "database": "master"
+           }
         }
         cls.handler = SqlServerHandler('test_sqlserver_handler', **cls.kwargs)
 

--- a/mindsdb/integrations/handlers/postgres_handler/postgres_handler.py
+++ b/mindsdb/integrations/handlers/postgres_handler/postgres_handler.py
@@ -26,7 +26,7 @@ class PostgresHandler(DatabaseHandler):
         self.parser = parse_sql
         self.connection_args = kwargs.get('connection_data')
         self.dialect = 'postgresql'
-        self.database = self.connection_args.get('database')
+        self.database = self.connection_args.get['database']
         if 'database' in self.connection_args:
             self.connection_args['database']
         self.renderer = SqlalchemyRender('postgres')

--- a/mindsdb/integrations/handlers/questdb_handler/tests/test_questdb_handler.py
+++ b/mindsdb/integrations/handlers/questdb_handler/tests/test_questdb_handler.py
@@ -7,11 +7,13 @@ class QuestDBHandlerTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.kwargs = {
-            "host": "127.0.0.1",
-            "port": "8812",
-            "user": "admin",
-            "password": "quest",
-            "database": "questdb"
+            "connection_data": {
+                "host": "127.0.0.1",
+                "port": "8812",
+                "user": "admin",
+                "password": "quest",
+                "database": "questdb"
+            }
         }
         cls.handler = QuestDBHandler('test_questdb_handler', **cls.kwargs)
 

--- a/mindsdb/integrations/handlers/singlestore_handler/tests/test_singlestore_handler.py
+++ b/mindsdb/integrations/handlers/singlestore_handler/tests/test_singlestore_handler.py
@@ -1,6 +1,6 @@
 import unittest
 
-from mindsdb.integrations.mysql_handler.mysql_handler import MySQLHandler
+from mindsdb.integrations.handlers.mysql_handler.mysql_handler import MySQLHandler
 from mindsdb.api.mysql.mysql_proxy.libs.constants.response_type import RESPONSE_TYPE
 
 

--- a/mindsdb/integrations/handlers/supabase_handler/tests/test_supabase_handler.py
+++ b/mindsdb/integrations/handlers/supabase_handler/tests/test_supabase_handler.py
@@ -6,12 +6,14 @@ class SupabaseHandlerTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.kwargs = {
-            "host": "localhost",
-            "port": "3306",
-            "user": "root",
-            "password": "root",
-            "database": "test",
-            "ssl": False
+            "connection_data": {
+                "host": "localhost",
+                "port": "3306",
+                "user": "root",
+                "password": "root",
+                "database": "test",
+                "ssl": False
+            }
         }
         cls.handler = SupabaseHandler('test_supabase_handler', **cls.kwargs)
 

--- a/mindsdb/integrations/handlers/trino_handler/tests/test_trino_handler.py
+++ b/mindsdb/integrations/handlers/trino_handler/tests/test_trino_handler.py
@@ -9,14 +9,16 @@ class TrinoHandlerTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.kwargs = {
-            "host": "qa.analytics.quantum.site.gs.com",
-            "port": "8090",
-            "user": "dqsvcuat",
-            "password": "",
-            "catalog": "gsam_dev2imddata_elastic",
-            "schema": "default",
-            "service_name": "HTTP/qa.analytics.quantum.site.gs.com",
-            "config_file_name": "test_trino_config.ini"
+            "connection_data": {
+                "host": "qa.analytics.quantum.site.gs.com",
+                "port": "8090",
+                "user": "dqsvcuat",
+                "password": "",
+                "catalog": "gsam_dev2imddata_elastic",
+                "schema": "default",
+                "service_name": "HTTP/qa.analytics.quantum.site.gs.com",
+                "config_file_name": "test_trino_config.ini"
+            }
         }
         cls.handler = TrinoHandler('test_trino_handler', **cls.kwargs)
 

--- a/mindsdb/integrations/handlers/vertica_handler/tests/test_vertica_handler.py
+++ b/mindsdb/integrations/handlers/vertica_handler/tests/test_vertica_handler.py
@@ -7,12 +7,14 @@ class VerticaHandlerTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.kwargs = {
-            "host":'127.0.0.1',
-            "port":5433,
-            "user":'dbadmin',
-            "password":'',
-            "database":'VMart',
-            "schema_name":'public'
+            "connection_data": {
+                "host":'127.0.0.1',
+                "port":5433,
+                "user":'dbadmin',
+                "password":'',
+                "database":'VMart',
+                "schema_name":'public'
+            }
     
         }
         cls.handler = VerticaHandler('test_vertica_handler', cls.kwargs)

--- a/mindsdb/integrations/handlers/yugabyte_handler/tests/test_yugabyte_handler.py
+++ b/mindsdb/integrations/handlers/yugabyte_handler/tests/test_yugabyte_handler.py
@@ -7,11 +7,13 @@ class YugabyteHandlerTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.kwargs = {
-            "host": "localhost",
-            "port": 5433,
-            "user": "admin",
-            "password": "",
-            "database": "yugabyte"
+            "connection_data": {
+                "host": "localhost",
+                "port": 5433,
+                "user": "admin",
+                "password": "",
+                "database": "yugabyte"
+            }
         }
         cls.handler = YugabyteHandler('test_yugabyte_handler', cls.kwargs)
 


### PR DESCRIPTION
Fixes #

## Please describe what changes you made, in as much detail as possible:
This constitute a clean up of the unit tests written for the database handlers. This involves fixing wrong import paths, and missing dictionary keys (most of the test didn't include the `connection_data` key even though it was written in the handler!).