### PR TITLE
Bug Fix: removed undefined tests

### DIFF
--- a/mindsdb/integrations/handlers/cockroach_handler/tests/test_cockroachdb_handler.py
+++ b/mindsdb/integrations/handlers/cockroach_handler/tests/test_cockroachdb_handler.py
@@ -26,10 +26,6 @@ class CockroachHandlerTest(unittest.TestCase):
         tables = self.handler.get_tables()
         assert tables['type'] is not RESPONSE_TYPE.ERROR
 
-    def test_3_get_views(self):
-        views = self.handler.get_views()
-        assert views['type'] is not RESPONSE_TYPE.ERROR
-
     def test_4_select_query(self):
         query = "SELECT * FROM data.test_mdb WHERE 'id'='1'"
         result = self.handler.query(query)

--- a/mindsdb/integrations/handlers/crate_handler/tests/test_crate_handler.py
+++ b/mindsdb/integrations/handlers/crate_handler/tests/test_crate_handler.py
@@ -17,27 +17,22 @@ class CrateHandlerTest(unittest.TestCase):
     def test_0_connect(self):
          self.handler.connect()
 
-    
-
     def test_1_drop_table(self):
         res = self.handler.query("DROP TABLE IF EXISTS PREM;")
-        assert res.type is  not RESPONSE_TYPE.ERROR 
-
+        assert res.type is not RESPONSE_TYPE.ERROR
 
     def test_2_create_table(self):
         res = self.handler.query("CREATE TABLE IF NOT EXISTS PREM (Premi varchar(50));")
-        assert res.type is not  RESPONSE_TYPE.ERROR 
+        assert res.type is not RESPONSE_TYPE.ERROR
 
     def test_3_insert_table(self):
         res = self.handler.query("INSERT INTO PREM VALUES('Radha <3 Krishna');")
-        assert res.type is not  RESPONSE_TYPE.ERROR 
-    
+        assert res.type is not  RESPONSE_TYPE.ERROR
 
     def test_4_get_tables(self):
         tables = self.handler.get_tables()
         assert tables.type is not  RESPONSE_TYPE.ERROR
 
- 
     def test_5_select_query(self):
         query = "SELECT * FROM PREM;"
         result = self.handler.native_query(query)

--- a/mindsdb/integrations/handlers/d0lt_handler/tests/test_d0lt_handler.py
+++ b/mindsdb/integrations/handlers/d0lt_handler/tests/test_d0lt_handler.py
@@ -20,30 +20,21 @@ class D0ltHandlerTest(unittest.TestCase):
     def test_0_connect(self):
          self.handler.connect()
 
-
-    def test_0_connect(self):
-         self.handler.connect()
-
-    
-
     def test_1_drop_table(self):
         res = self.handler.query("DROP TABLE IF EXISTS PREM;")
-        assert res.type is  not RESPONSE_TYPE.ERROR 
-
+        assert res.type is  not RESPONSE_TYPE.ERROR
 
     def test_2_create_table(self):
         res = self.handler.query("CREATE TABLE IF NOT EXISTS PREM (Premi varchar(50));")
-        assert res.type is not  RESPONSE_TYPE.ERROR 
+        assert res.type is not RESPONSE_TYPE.ERROR
 
     def test_3_insert_table(self):
         res = self.handler.query("INSERT INTO PREM VALUES('Radha <3 Krishna');")
-        assert res.type is not  RESPONSE_TYPE.ERROR 
-    
+        assert res.type is not RESPONSE_TYPE.ERROR
 
     def test_4_get_tables(self):
         tables = self.handler.get_tables()
-        assert tables.type is not  RESPONSE_TYPE.ERROR
-
+        assert tables.type is not RESPONSE_TYPE.ERROR
  
     def test_5_select_query(self):
         query = "SELECT * FROM PREM;"
@@ -51,12 +42,12 @@ class D0ltHandlerTest(unittest.TestCase):
         assert result.type is not  RESPONSE_TYPE.ERROR
     
     def test_6_get_columns(self):
-        
         result = self.handler.get_columns('PREM')
         assert result.type is not  RESPONSE_TYPE.ERROR
 
     def test_7_check_connection(self):
-         self.handler.check_connection()
+        self.handler.check_connection()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mindsdb/integrations/handlers/db2_handler/tests/test_db2_handler.py
+++ b/mindsdb/integrations/handlers/db2_handler/tests/test_db2_handler.py
@@ -17,29 +17,24 @@ class DB2HandlerTest(unittest.TestCase):
         cls.handler = DB2Handler('test_db2_handler', **cls.kwargs)
 
     def test_0_connect(self):
-         self.handler.connect()
-
-    
+        self.handler.connect()
 
     def test_1_drop_table(self):
         res = self.handler.query("DROP TABLE IF EXISTS LOVE")
-        assert res.type is  not RESPONSE_TYPE.ERROR 
-
+        assert res.type is not RESPONSE_TYPE.ERROR
 
     def test_2_create_table(self):
         res = self.handler.query("CREATE TABLE IF NOT EXISTS LOVE (LOVER varchar(20))")
-        assert res.type is not  RESPONSE_TYPE.ERROR 
-    
+        assert res.type is not RESPONSE_TYPE.ERROR
 
     def test_3_get_tables(self):
         tables = self.handler.get_tables()
-        assert tables.type is not  RESPONSE_TYPE.ERROR
-
+        assert tables.type is not RESPONSE_TYPE.ERROR
  
     def test_4_select_query(self):
         query = "SELECT * FROM AUTHORS"
         result = self.handler.native_query(query)
-        assert result.type is   RESPONSE_TYPE.TABLE
+        assert result.type is RESPONSE_TYPE.TABLE
 
     def test_5_check_connection(self):
          self.handler.check_connection()

--- a/mindsdb/integrations/handlers/hive_handler/tests/test_hive_handler.py
+++ b/mindsdb/integrations/handlers/hive_handler/tests/test_hive_handler.py
@@ -28,10 +28,6 @@ class HiveHandlerTest(unittest.TestCase):
         tbls = self.handler.get_tables()
         assert tbls['type'] is not RESPONSE_TYPE.ERROR
 
-    def test_3_get_views(self):
-        views = self.handler.get_views()
-        assert views['type'] is not RESPONSE_TYPE.ERROR
-
     def test_5_drop_table(self):
         res = self.handler.native_query("DROP TABLE IF EXISTS test_hdb")
         assert res['type'] is not RESPONSE_TYPE.ERROR
@@ -48,6 +44,7 @@ class HiveHandlerTest(unittest.TestCase):
         query = "SELECT * FROM test_mdb WHERE foo=238"
         result = self.handler.query(query)
         assert result['type'] is RESPONSE_TYPE.TABLE
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mindsdb/integrations/handlers/informix_handler/tests/test_informix_handler.py
+++ b/mindsdb/integrations/handlers/informix_handler/tests/test_informix_handler.py
@@ -19,14 +19,11 @@ class InformixHandlerTest(unittest.TestCase):
         cls.handler = InformixHandler('test_informix_handler', cls.kwargs)
 
     def test_0_connect(self):
-         self.handler.connect()
-
-    
+        self.handler.connect()
 
     def test_1_drop_table(self):
         res = self.handler.query("DROP TABLE IF EXISTS LOVE;")
-        assert res.type is  not RESPONSE_TYPE.ERROR 
-
+        assert res.type is  not RESPONSE_TYPE.ERROR
 
     def test_2_create_table(self):
         res = self.handler.query("CREATE TABLE IF NOT EXISTS LOVE (LOVER varchar(20));")
@@ -34,20 +31,19 @@ class InformixHandlerTest(unittest.TestCase):
     
     def test_3_insert(self):
         res = self.handler.query("INSERT INTO LOVE VALUES('Hari');")
-        assert res.type is not  RESPONSE_TYPE.ERROR 
+        assert res.type is not RESPONSE_TYPE.ERROR
     
     def test_4_get_tables(self):
         tables = self.handler.get_tables()
-        assert tables.type is   RESPONSE_TYPE.TABLE
-
+        assert tables.type is RESPONSE_TYPE.TABLE
  
     def test_5_select_query(self):
         query = "SELECT * FROM LOVE;"
         result = self.handler.native_query(query)
-        assert result.type is   RESPONSE_TYPE.TABLE
+        assert result.type is RESPONSE_TYPE.TABLE
 
     def test_5_check_connection(self):
-         self.handler.check_connection()
+        self.handler.check_connection()
 
         
 if __name__ == '__main__':

--- a/mindsdb/integrations/handlers/mariadb_handler/tests/test_mariadb_handler.py
+++ b/mindsdb/integrations/handlers/mariadb_handler/tests/test_mariadb_handler.py
@@ -30,10 +30,6 @@ class MariaDBHandlerTest(unittest.TestCase):
         tbls = self.handler.get_tables()
         assert isinstance(tbls, list)
 
-    def test_4_get_views(self):
-        views = self.handler.get_views()
-        assert isinstance(views, list)
-
     def test_5_create_table(self):
         try:
             self.handler.native_query("CREATE TABLE test_mdb (test_col INT)")

--- a/mindsdb/integrations/handlers/matrixone_handler/tests/test_matrixone_handler.py
+++ b/mindsdb/integrations/handlers/matrixone_handler/tests/test_matrixone_handler.py
@@ -19,14 +19,11 @@ class MatrixOneHandlerTest(unittest.TestCase):
 
 
     def test_0_connect(self):
-         self.handler.connect()
-
-    
+        self.handler.connect()
 
     def test_1_drop_table(self):
         res = self.handler.query("DROP TABLE IF EXISTS PREM;")
-        assert res.type is  not RESPONSE_TYPE.ERROR 
-
+        assert res.type is  not RESPONSE_TYPE.ERROR
 
     def test_2_create_table(self):
         res = self.handler.query("CREATE TABLE IF NOT EXISTS PREM (Premi varchar(50));")
@@ -35,25 +32,23 @@ class MatrixOneHandlerTest(unittest.TestCase):
     def test_3_insert_table(self):
         res = self.handler.query("INSERT INTO PREM VALUES('Radha <3 Krishna');")
         assert res.type is not  RESPONSE_TYPE.ERROR 
-    
 
     def test_4_get_tables(self):
         tables = self.handler.get_tables()
         assert tables.type is not  RESPONSE_TYPE.ERROR
 
- 
     def test_5_select_query(self):
         query = "SELECT * FROM PREM;"
         result = self.handler.native_query(query)
         assert result.type is not  RESPONSE_TYPE.ERROR
     
     def test_6_get_columns(self):
-        
         result = self.handler.get_columns('PREM')
         assert result.type is not  RESPONSE_TYPE.ERROR
 
     def test_7_check_connection(self):
-         self.handler.check_connection()
+        self.handler.check_connection()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mindsdb/integrations/handlers/monetdb_handler/tests/test_monetdb_handler.py
+++ b/mindsdb/integrations/handlers/monetdb_handler/tests/test_monetdb_handler.py
@@ -17,14 +17,11 @@ class MonetDBHandlerTest(unittest.TestCase):
         cls.handler = MonetDBHandler('test_monet_handler', cls.kwargs)
 
     def test_0_connect(self):
-         self.handler.connect()
-
-    
+        self.handler.connect()
 
     def test_1_drop_table(self):
         res = self.handler.query("DROP TABLE IF EXISTS PREM;")
         assert res.type is  not RESPONSE_TYPE.ERROR 
-
 
     def test_2_create_table(self):
         res = self.handler.query("CREATE TABLE IF NOT EXISTS PREM (Premi varchar(50));")
@@ -33,20 +30,19 @@ class MonetDBHandlerTest(unittest.TestCase):
     def test_3_insert_table(self):
         res = self.handler.query("INSERT INTO PREM VALUES('Radha <3 Krishna');")
         assert res.type is not  RESPONSE_TYPE.ERROR 
-    
 
     def test_4_get_tables(self):
         tables = self.handler.get_tables()
         assert tables.type is not  RESPONSE_TYPE.ERROR
 
- 
     def test_5_select_query(self):
         query = "SELECT * FROM PREM;"
         result = self.handler.native_query(query)
         assert result.type is RESPONSE_TYPE.TABLE or RESPONSE_TYPE.OK
 
     def test_6_check_connection(self):
-         self.handler.check_connection()
+        self.handler.check_connection()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mindsdb/integrations/handlers/mssql_handler/tests/test_mssql_handler.py
+++ b/mindsdb/integrations/handlers/mssql_handler/tests/test_mssql_handler.py
@@ -18,17 +18,9 @@ class SqlServerHandlerTest(unittest.TestCase):
     def test_0_check_connection(self):
         assert self.handler.check_connection()
 
-    def test_1_describe_table(self):
-        described = self.handler.describe_table("home_rentals")
-        assert described['type'] is not RESPONSE_TYPE.ERROR
-
     def test_2_get_tables(self):
         tables = self.handler.get_tables()
         assert tables['type'] is not RESPONSE_TYPE.ERROR
-
-    def test_3_get_views(self):
-        views = self.handler.get_views()
-        assert views['type'] is not RESPONSE_TYPE.ERROR
 
     def test_4_select_query(self):
         query = "SELECT * FROM test_data.home_rentals"

--- a/mindsdb/integrations/handlers/singlestore_handler/tests/test_singlestore_handler.py
+++ b/mindsdb/integrations/handlers/singlestore_handler/tests/test_singlestore_handler.py
@@ -27,10 +27,6 @@ class MySQLHandlerTest(unittest.TestCase):
     def test_2_get_tables(self):
         tbls = self.handler.get_tables()
         assert tbls['type'] is not RESPONSE_TYPE.ERROR
-
-    def test_3_get_views(self):
-        views = self.handler.get_views()
-        assert views['type'] is not RESPONSE_TYPE.ERROR
     
     def test_5_drop_table(self):
         res = self.handler.native_query("DROP TABLE IF EXISTS test_mdb")
@@ -38,13 +34,9 @@ class MySQLHandlerTest(unittest.TestCase):
 
     def test_4_create_table(self):
         res = self.handler.native_query("CREATE TABLE IF NOT EXISTS test_mdb (test_col INT)")
-        assert res['type'] is not RESPONSE_TYPE.ERROR 
-
-    def test_6_describe_table(self):
-        described = self.handler.describe_table("test_mdb")
-        assert described['type'] is RESPONSE_TYPE.TABLE
+        assert res['type'] is not RESPONSE_TYPE.ERROR
 
     def test_7_select_query(self):
         query = "SELECT * FROM test_mdb WHERE 'id'='a'"
-        result = self.handler.select_query(query)
+        result = self.handler.native_query(query)
         assert result['type'] is RESPONSE_TYPE.TABLE

--- a/mindsdb/integrations/handlers/snowflake_handler/tests/test_snowflake_handler.py
+++ b/mindsdb/integrations/handlers/snowflake_handler/tests/test_snowflake_handler.py
@@ -28,7 +28,7 @@ class SnowflakeHandlerTest(unittest.TestCase):
         assert tbls.type is not RESPONSE_TYPE.ERROR
 
     def test_2_get_columns(self):
-        tbls = self.handler.get_tables()
+        tbls = self.handler.get_columns('home_rentals')
         assert tbls.type is not RESPONSE_TYPE.ERROR
 
     def test_3_select_native(self):

--- a/mindsdb/integrations/handlers/supabase_handler/tests/test_supabase_handler.py
+++ b/mindsdb/integrations/handlers/supabase_handler/tests/test_supabase_handler.py
@@ -29,10 +29,6 @@ class SupabaseHandlerTest(unittest.TestCase):
         tbls = self.handler.get_tables()
         assert isinstance(tbls, list)
 
-    def test_4_get_views(self):
-        views = self.handler.get_views()
-        assert isinstance(views, list)
-
     def test_5_create_table(self):
         try:
             self.handler.native_query("CREATE TABLE test_mdb (test_col INT)")
@@ -40,9 +36,9 @@ class SupabaseHandlerTest(unittest.TestCase):
             pass
 
     def test_6_describe_table(self):
-        described = self.handler.describe_table("dt_test")
+        described = self.handler.get_columns("dt_test")
         assert isinstance(described, list)
 
     def test_7_select_query(self):
         query = "SELECT * FROM dt_test WHERE 'id'='a'"
-        result = self.handler.select_query(query)
+        result = self.handler.native_query(query)

--- a/mindsdb/integrations/handlers/tidb_handler/tests/test_tidb_handler.py
+++ b/mindsdb/integrations/handlers/tidb_handler/tests/test_tidb_handler.py
@@ -30,10 +30,6 @@ class TiDBHandlerTest(unittest.TestCase):
         tbls = self.handler.get_tables()
         assert isinstance(tbls, list)
 
-    def test_4_get_views(self):
-        views = self.handler.get_views()
-        assert isinstance(views, list)
-
     def test_5_create_table(self):
         try:
             self.handler.native_query("CREATE TABLE test_tidb (test_col INT)")
@@ -41,9 +37,9 @@ class TiDBHandlerTest(unittest.TestCase):
             pass
 
     def test_6_describe_table(self):
-        described = self.handler.describe_table("dt_test")
+        described = self.handler.get_columns("dt_test")
         assert isinstance(described, list)
 
     def test_7_select_query(self):
         query = "SELECT * FROM dt_test WHERE 'id'='a'"
-        result = self.handler.select_query(query)
+        result = self.handler.native_query(query)

--- a/mindsdb/integrations/handlers/timescaledb_handler/tests/test_timescaledb_handler.py
+++ b/mindsdb/integrations/handlers/timescaledb_handler/tests/test_timescaledb_handler.py
@@ -16,35 +16,31 @@ class TimeScaleDBHandlerTest(unittest.TestCase):
         cls.handler = TimeScaleDBHandler('test_timescaledb_handler', connection_data=cls.kwargs)
 
     def test_0_connect(self):
-         self.handler.connect()
-
-    
+        self.handler.connect()
 
     def test_1_drop_table(self):
         res = self.handler.query("DROP TABLE IF EXISTS LOVE;")
-        assert res.type is  not RESPONSE_TYPE.ERROR 
-
+        assert res.type is not RESPONSE_TYPE.ERROR
 
     def test_2_create_table(self):
         res = self.handler.query("CREATE TABLE IF NOT EXISTS LOVE (LOVER varchar(20));")
-        assert res.type is not  RESPONSE_TYPE.ERROR 
+        assert res.type is not RESPONSE_TYPE.ERROR
     
     def test_3_insert(self):
         res = self.handler.query("INSERT INTO LOVE VALUES('Hari');")
-        assert res.type is not  RESPONSE_TYPE.ERROR 
+        assert res.type is not RESPONSE_TYPE.ERROR
     
     def test_4_get_tables(self):
         tables = self.handler.get_tables()
-        assert tables.type is   RESPONSE_TYPE.TABLE
+        assert tables.type is RESPONSE_TYPE.TABLE
 
- 
     def test_5_select_query(self):
         query = "SELECT * FROM LOVE;"
         result = self.handler.native_query(query)
-        assert result.type is   RESPONSE_TYPE.TABLE
+        assert result.type is RESPONSE_TYPE.TABLE
 
     def test_5_check_connection(self):
-         self.handler.check_connection()
+        self.handler.check_connection()
 
         
 if __name__ == '__main__':

--- a/mindsdb/integrations/handlers/trino_handler/tests/test_trino_handler.py
+++ b/mindsdb/integrations/handlers/trino_handler/tests/test_trino_handler.py
@@ -35,14 +35,10 @@ class TrinoHandlerTest(unittest.TestCase):
         assert tables
 
     def test_3_describe_table(self):
-        described = self.handler.describe_table("axioma_att_2021-12")
+        described = self.handler.get_columns("axioma_att_2021-12")
         assert described['type'] is not RESPONSE_TYPE.ERROR
 
     # TODO: complete tests implementation
-    # def test_3_get_views(self):
-    #     views = self.handler.get_views()
-    #     assert views['type'] is not RESPONSE_TYPE.ERROR
-    #
     # def test_4_select_query(self):
     #     query = "SELECT * FROM data.test_mdb WHERE 'id'='1'"
     #     result = self.handler.query(query)

--- a/mindsdb/integrations/handlers/yugabyte_handler/tests/test_yugabyte_handler.py
+++ b/mindsdb/integrations/handlers/yugabyte_handler/tests/test_yugabyte_handler.py
@@ -16,28 +16,23 @@ class YugabyteHandlerTest(unittest.TestCase):
         cls.handler = YugabyteHandler('test_yugabyte_handler', cls.kwargs)
 
     def test_0_connect(self):
-         self.handler.connect()
-
-    
+        self.handler.connect()
 
     def test_1_drop_table(self):
         res = self.handler.query("DROP TABLE IF EXISTS PREM;")
-        assert res.type is  not RESPONSE_TYPE.ERROR 
-
+        assert res.type is not RESPONSE_TYPE.ERROR
 
     def test_2_create_table(self):
         res = self.handler.query("CREATE TABLE IF NOT EXISTS PREM (Premi varchar(50));")
-        assert res.type is not  RESPONSE_TYPE.ERROR 
+        assert res.type is not RESPONSE_TYPE.ERROR
 
     def test_3_insert_table(self):
         res = self.handler.query("INSERT INTO PREM VALUES('Radha <3 Krishna');")
-        assert res.type is not  RESPONSE_TYPE.ERROR 
-    
+        assert res.type is not RESPONSE_TYPE.ERROR
 
     def test_4_get_tables(self):
         tables = self.handler.get_tables()
-        assert tables.type is not  RESPONSE_TYPE.ERROR
-
+        assert tables.type is not RESPONSE_TYPE.ERROR
  
     def test_5_select_query(self):
         query = "SELECT * FROM PREM;"
@@ -45,7 +40,7 @@ class YugabyteHandlerTest(unittest.TestCase):
         assert result.type is RESPONSE_TYPE.TABLE or RESPONSE_TYPE.OK
 
     def test_6_check_connection(self):
-         self.handler.check_connection()
+        self.handler.check_connection()
 
         
 if __name__ == '__main__':


### PR DESCRIPTION
I have removed some tests that use undefined functions by going through all of the handlers.

I have just cleaned up the code a little bit as well in some of the test modules.

Further, I have noticed that no tests have been defined for the following handlers,

- byom
- file
- mongodb
- view
- huggingface

Maybe these can be taken up as separate issues?

@ZoranPandovski, a question for you, is it possible to use the `.query()` method within the test modules and then run it using Python locally? I was under the impression that the `native_query()` method needs to be used, unless we are running the code through the MindsDB SQL Editor.