### PR TITLE
Up snowflake version to 1.4.3

### DIFF
--- a/docker/mindsdb.Dockerfile
+++ b/docker/mindsdb.Dockerfile
@@ -17,7 +17,7 @@ RUN python -m pip install --prefer-binary --no-cache-dir --upgrade pip==22.1.2 &
         psycopg[binary]>=1.15.3 \
         pymongo certifi \
         snowflake-connector-python>=2.7.6 \
-        snowflake-sqlalchemy>=1.4.2 \
+        snowflake-sqlalchemy>=1.4.3 \
         clickhouse-driver \
         scylla-driver && \
     pip install --prefer-binary --no-cache-dir \

--- a/docker/release
+++ b/docker/release
@@ -20,7 +20,7 @@ RUN python -m pip install --prefer-binary --no-cache-dir --upgrade pip==22.1.2 &
         psycopg[binary]>=1.15.3 \
         pymongo certifi \
         snowflake-connector-python>=2.7.6 \
-        snowflake-sqlalchemy>=1.4.2 \
+        snowflake-sqlalchemy>=1.4.3 \
         clickhouse-driver \
         scylla-driver && \
     pip install --prefer-binary --no-cache-dir \

--- a/mindsdb/integrations/handlers/snowflake_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/snowflake_handler/requirements.txt
@@ -1,2 +1,2 @@
 snowflake-connector-python>=2.7.12
-snowflake-sqlalchemy>=1.4.2
+snowflake-sqlalchemy>=1.4.3


### PR DESCRIPTION
Fix error:
ImportError: cannot import name '_rfc_1738_quote' from 'sqlalchemy.engine.url'
If snowflake version is 1.4.2 and sqlalchemy version is 1.4.42
