### PR TITLE
Update issue link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ You can find the complete documentation of MindsDB at [docs.mindsdb.com](https:/
 
 ## Support
 
-If you found a bug, please submit an [issue on Github](https://github.com/mindsdb/mindsdb/issues).
+If you found a bug, please submit an [issue on Github](https://github.com/mindsdb/mindsdb/issues/new/choose).
 
 To get community support, you can:
 * Post at MindsDB [Slack community](https://join.slack.com/t/mindsdbcommunity/shared_invite/zt-o8mrmx3l-5ai~5H66s6wlxFfBMVI6wQ).


### PR DESCRIPTION
Fixes # 3848 
Issue Link: https://github.com/mindsdb/mindsdb/issues/3848

## Please describe what changes you made, in as much detail as possible
  -  At readme File, In support Section
![image](https://user-images.githubusercontent.com/34413515/198897869-b92557f6-1284-4075-9839-379ba838fc5f.png)
 highlighted link was redirecting to https://github.com/mindsdb/mindsdb/issues link.
 It should be redirecting to following link: https://github.com/mindsdb/mindsdb/issues/new/choose
So I have updated it.

mindsdb