### PR TITLE
Fix latest without group

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
+++ b/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
@@ -1685,7 +1685,10 @@ class SQLQuery():
         if Latest() in filter_args:
 
             for row in table_data:
-                key = tuple([str(row[i]) for i in group_cols])
+                if group_cols is None:
+                    key = 0  # the same for any value
+                else:
+                    key = tuple([str(row[i]) for i in group_cols])
                 val = row[order_col]
                 if key not in latest_vals or latest_vals[key] < val:
                     latest_vals[key] = val
@@ -1708,7 +1711,10 @@ class SQLQuery():
                 }
                 arg = filter_args[1]
                 if isinstance(arg, Latest):
-                    key = tuple([str(row[i]) for i in group_cols])
+                    if group_cols is None:
+                        key = 0  # the same for any value
+                    else:
+                        key = tuple([str(row[i]) for i in group_cols])
                     if key not in latest_vals:
                         # pass this row
                         continue

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -203,6 +203,118 @@ class Test(BaseExecutorTestMockModel):
         assert ret_df.t.min() == dt.datetime(2020, 1, 2)
         assert ret_df.t.max() == dt.datetime(2020, 1, 3)
 
+    @patch('mindsdb.integrations.handlers.postgres_handler.Handler')
+    def test_ts_predictor_no_group(self, mock_handler):
+        # set integration data
+
+        df = pd.DataFrame([
+            {'a': 1, 't': dt.datetime(2020, 1, 1), 'g': 'x'},
+            {'a': 2, 't': dt.datetime(2020, 1, 2), 'g': 'x'},
+            {'a': 3, 't': dt.datetime(2020, 1, 3), 'g': 'x'},
+        ])
+        self.set_handler(mock_handler, name='pg', tables={'tasks': df})
+
+        # --- use TS predictor ---
+
+        predictor = {
+            'name': 'task_model',
+            'predict': 'a',
+            'problem_definition': {
+                'timeseries_settings': {
+                    'is_timeseries': True,
+                    'window': 2,
+                    'order_by': 't',
+                    'horizon': 3
+                }
+            },
+            'dtypes': {
+                'a': dtype.integer,
+                't': dtype.date,
+                'g': dtype.categorical,
+            },
+            'predicted_value': ''
+        }
+        self.set_predictor(predictor)
+
+        # set predictor output
+        predict_result = [
+            # window
+            {'a': 2, 't': dt.datetime(2020, 1, 2), 'g': 'x', '__mindsdb_row_id': 2},
+            {'a': 3, 't': dt.datetime(2020, 1, 3), 'g': 'x', '__mindsdb_row_id': 3},
+            # horizon
+            {'a': 1, 't': dt.datetime(2020, 1, 4), 'g': 'x', '__mindsdb_row_id': None},
+            {'a': 1, 't': dt.datetime(2020, 1, 5), 'g': 'x', '__mindsdb_row_id': None},
+            {'a': 1, 't': dt.datetime(2020, 1, 6), 'g': 'x', '__mindsdb_row_id': None},
+        ]
+        predict_result = pd.DataFrame(predict_result)
+        self.mock_predict.side_effect = lambda *a, **b: predict_result
+
+        # = latest  ______________________
+        ret = self.command_executor.execute_command(parse_sql(f'''
+                select p.* from pg.tasks t
+                join mindsdb.task_model p
+                where t.t = latest
+            ''', dialect='mindsdb'))
+        assert ret.error_code is None
+
+        ret_df = self.ret_to_df(ret)
+        # one key with max value of a
+        assert ret_df.shape[0] == 1
+        assert ret_df.t[0] == dt.datetime(2020, 1, 3)
+
+        # > latest ______________________
+        ret = self.command_executor.execute_command(parse_sql(f'''
+                select t.t as t0, p.* from pg.tasks t
+                join mindsdb.task_model p
+                where t.t > latest
+            ''', dialect='mindsdb'))
+        assert ret.error_code is None
+
+        ret_df = self.ret_to_df(ret)
+        assert ret_df.shape[0] == 3
+        assert ret_df.t.min() == dt.datetime(2020, 1, 4)
+        # table shouldn't join
+        assert ret_df.t0[0] is None
+
+        # > date ______________________
+        ret = self.command_executor.execute_command(parse_sql(f'''
+                select p.* from pg.tasks t
+                join mindsdb.task_model p
+                where t.t > '2020-01-02'
+            ''', dialect='mindsdb'))
+        assert ret.error_code is None
+
+        ret_df = self.ret_to_df(ret)
+        assert ret_df.shape[0] == 4
+        assert ret_df.t.min() == dt.datetime(2020, 1, 3)
+
+        # between ______________________
+        # set predictor output
+        predict_result = [
+            # window
+            {'a': 1, 't': dt.datetime(2020, 1, 1), 'g': 'x', '__mindsdb_row_id': 1},
+            {'a': 2, 't': dt.datetime(2020, 1, 2), 'g': 'x', '__mindsdb_row_id': 2},
+            {'a': 3, 't': dt.datetime(2020, 1, 3), 'g': 'x', '__mindsdb_row_id': 3},
+            # horizon
+            {'a': 1, 't': dt.datetime(2020, 1, 4), 'g': 'x', '__mindsdb_row_id': None},
+            {'a': 1, 't': dt.datetime(2020, 1, 5), 'g': 'x', '__mindsdb_row_id': None},
+            {'a': 1, 't': dt.datetime(2020, 1, 6), 'g': 'x', '__mindsdb_row_id': None},
+        ]
+        predict_result = pd.DataFrame(predict_result)
+        self.mock_predict.side_effect = lambda *a, **b: predict_result
+
+        ret = self.command_executor.execute_command(parse_sql(f'''
+                select p.* from pg.tasks t
+                join mindsdb.task_model p
+                where t.t between '2020-01-02' and '2020-01-03' 
+            ''', dialect='mindsdb'))
+        assert ret.error_code is None
+
+        ret_df = self.ret_to_df(ret)
+        assert ret_df.shape[0] == 2
+        assert ret_df.t.min() == dt.datetime(2020, 1, 2)
+        assert ret_df.t.max() == dt.datetime(2020, 1, 3)
+
     def test_ts_predictor_file(self):
         # set integration data
 


### PR DESCRIPTION
If TS predictor was created without group_by and prediction is using LATEST it returns error:
`error in apply predictor step: 'NoneType' object is not iterable`