### PR TITLE
Added more bytes to sample read to identify csv dialect

### DIFF
--- a/mindsdb/integrations/handlers/file_handler/file_handler.py
+++ b/mindsdb/integrations/handlers/file_handler/file_handler.py
@@ -274,7 +274,7 @@ class FileHandler(DatabaseHandler):
 
     @staticmethod
     def _get_csv_dialect(buffer) -> csv.Dialect:
-        sample = buffer.read(128 * 1024)
+        sample = buffer.read(256 * 1024)
         buffer.seek(0)
         try:
             accepted_csv_delimiters = [',', '\t', ';']


### PR DESCRIPTION
The file handler was sampling (128*1024) bytes and using that data to identify the csv dialect. 
For the spam dataset that was not enough. changed to (256 * 1024)  and that solved the issue. 

- [X] **Does the PR satisfy the PR guidelines?**
	*(provide a reason in case of NO, see PR guidelines topic)*
	
	PR guidelines still in progress. 
	
- [X] **Need to update public docs?** 
	*(link to the appropriate ticket if documentation have to be changed, but it couldn’t be done in this PR by some reason)*
	
	It doesn't need to update any docs. 
	
- [X] **Need to update existing tests?**
    *(link to the appropriate ticket if tests have to be changed, but it couldn’t be done in this PR by some reason)*
    
    It doesn't 

- [ ] **Need to create new tests?**
	*(link to the appropriate ticket if tests have to be created, but it couldn’t be done in this PR by some reason)*
	
	Potentially we could add the SPAM dataset to a test. 
	
- [X] **Have a well formed description?**

    Yes. 

- [X] **Have well formed related issues, if they exist?**
	*(in case then big feature have been decomposed to several smaller ones)*

   Yes, and its linked to this PR (Fixes #3979)


mindsdb