### PR TITLE
Pass parameters to predictor at prediction stage

### DIFF
--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -68,6 +68,8 @@ jobs:
 
           env PYTHONPATH=./ pytest tests/unit/test_executor.py
 
+          env PYTHONPATH=./ pytest tests/unit/test_predictor_params.py
+        
           env PYTHONPATH=./ pytest tests/unit/test_mongodb_handler.py
 
           env PYTHONPATH=./ pytest tests/unit/test_mongodb_server.py

--- a/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
+++ b/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
@@ -880,7 +880,8 @@ class SQLQuery():
 
                 predictions = project_datanode.predict(
                     model_name=predictor_name,
-                    data=where_data
+                    data=where_data,
+                    params=step.params,
                 )
 
                 data = [{(key, key): value for key, value in row.items()} for row in predictions]
@@ -986,7 +987,8 @@ class SQLQuery():
                     if data is None:
                         data = project_datanode.predict(
                             model_name=predictor_name,
-                            data=where_data
+                            data=where_data,
+                            params=step.params,
                         )
                         if data is not None and isinstance(data, list):
                             predictor_cache.set(key, data)

--- a/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/project_datanode.py
+++ b/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/project_datanode.py
@@ -55,11 +55,11 @@ class ProjectDataNode(DataNode):
     def get_table_columns(self, table_name):
         return self.project.get_columns(table_name)
 
-    def predict(self, model_name: str, data) -> list:
+    def predict(self, model_name: str, data, params=None) -> list:
         project_tables = self.project.get_tables()
         predictor_table_meta = project_tables[model_name]
         handler = self.integration_controller.get_handler(predictor_table_meta['engine_name'])
-        predictions = handler.predict(model_name, data, project_name=self.project.name)
+        predictions = handler.predict(model_name, data, project_name=self.project.name, params=params)
         return predictions
 
     def query(self, query=None, native_query=None, session=None):

--- a/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
+++ b/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
@@ -87,17 +87,18 @@ class LightwoodHandler(BaseMLEngine):
 
     def predict(self, df, args=None):
         pred_format = args['pred_format']
-        predictror_code = args['code']
+        predictor_code = args['code']
         dtype_dict = args['dtype_dict']
         learn_args = args['learn_args']
+        pred_args = args.get('predict_params', {})
         self.model_storage.fileStorage.pull()
 
         predictor = lightwood.predictor_from_state(
             self.model_storage.fileStorage.folder_path / self.model_storage.fileStorage.folder_name,
-            predictror_code
+            predictor_code
         )
 
-        predictions = predictor.predict(df)
+        predictions = predictor.predict(df, args=pred_args)
         predictions = predictions.to_dict(orient='records')
 
         # TODO!!!

--- a/mindsdb/integrations/libs/ml_exec_base.py
+++ b/mindsdb/integrations/libs/ml_exec_base.py
@@ -469,7 +469,7 @@ class BaseMLEngineExec:
 
         args = {
             'pred_format': pred_format,
-            'predict_params': params
+            'predict_params': {} if params is None else params
         }
         # FIXME
         if self.handler_class.__name__ == 'LightwoodHandler':

--- a/mindsdb/integrations/libs/ml_exec_base.py
+++ b/mindsdb/integrations/libs/ml_exec_base.py
@@ -449,7 +449,8 @@ class BaseMLEngineExec:
 
         return Response(RESPONSE_TYPE.OK)
 
-    def predict(self, model_name: str, data: list, pred_format: str = 'dict', project_name: str = None):
+    def predict(self, model_name: str, data: list, pred_format: str = 'dict',
+                project_name: str = None, params: dict = None):
         """ Generates predictions with some model and input data. """
         if isinstance(data, dict):
             data = [data]
@@ -467,7 +468,8 @@ class BaseMLEngineExec:
         ml_handler = self.get_ml_handler(predictor_record.id)
 
         args = {
-            'pred_format': pred_format
+            'pred_format': pred_format,
+            'predict_params': params
         }
         # FIXME
         if self.handler_class.__name__ == 'LightwoodHandler':

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ walrus==0.8.2
 flask-compress >= 1.0.0
 kafka-python >= 2.0.0
 appdirs >= 1.0.0
-mindsdb-sql >= 0.4.4, < 0.5.0
+mindsdb-sql >= 0.4.5, < 0.5.0
 checksumdir >= 1.2.0
 mindsdb-streams == 0.1.1
 duckdb == 0.4.0

--- a/tests/unit/test_predictor_params.py
+++ b/tests/unit/test_predictor_params.py
@@ -1,18 +1,10 @@
-import os.path
 from unittest.mock import patch
-import datetime as dt
-import pytest
-import tempfile
 
 import pandas as pd
-import numpy as np
 from lightwood.api import dtype
 
 from mindsdb_sql import parse_sql
-from mindsdb_sql.render.sqlalchemy_render import SqlalchemyRender
 
-# How to run:
-#  env PYTHONPATH=./ pytest tests/unit/test_executor.py
 
 from .executor_test_base import BaseExecutorTestMockModel
 

--- a/tests/unit/test_predictor_params.py
+++ b/tests/unit/test_predictor_params.py
@@ -1,0 +1,71 @@
+import os.path
+from unittest.mock import patch
+import datetime as dt
+import pytest
+import tempfile
+
+import pandas as pd
+import numpy as np
+from lightwood.api import dtype
+
+from mindsdb_sql import parse_sql
+from mindsdb_sql.render.sqlalchemy_render import SqlalchemyRender
+
+# How to run:
+#  env PYTHONPATH=./ pytest tests/unit/test_executor.py
+
+from .executor_test_base import BaseExecutorTestMockModel
+
+
+class Test(BaseExecutorTestMockModel):
+
+    @patch('mindsdb.integrations.handlers.postgres_handler.Handler')
+    def test_use_predictor_params(self, mock_handler):
+        # set integration data
+
+        df = pd.DataFrame([
+            {'a': 1, 'b': 'one'},
+            {'a': 2, 'b': 'two'},
+            {'a': 1, 'b': 'three'},
+        ])
+        self.set_handler(mock_handler, name='pg', tables={'tasks': df})
+
+        # --- use predictor ---
+        predicted_value = 3.14
+        predictor = {
+            'name': 'task_model',
+            'predict': 'p',
+            'dtypes': {
+                'p': dtype.float,
+                'a': dtype.integer,
+                'b': dtype.categorical
+            },
+            'predicted_value': predicted_value
+        }
+        self.set_predictor(predictor)
+
+        # --- join table ---
+
+        ret = self.command_executor.execute_command(parse_sql('''
+           select m.p, v.a
+           from pg.tasks v
+           join mindsdb.task_model m
+           where v.a = 2
+           using p1='a', p2={'x':1, 'y':2}
+        ''', dialect='mindsdb'))
+        assert ret.error_code is None
+
+        # check predictor input
+        predict_args = self.mock_predict.call_args[0][1]
+        assert predict_args['predict_params'] == {'p1': 'a', 'p2': {'x': 1, 'y': 2}}
+
+        # --- inline prediction ---
+        self.mock_predict.reset_mock()
+
+        ret = self.command_executor.execute_command(parse_sql(f'''
+            select * from mindsdb.task_model where a = 2
+            using p1=1, p2=[1,2] 
+        ''', dialect='mindsdb'))
+
+        predict_args = self.mock_predict.call_args[0][1]
+        assert predict_args['predict_params'] == {'p1': 1, 'p2': [1,2]}


### PR DESCRIPTION
New syntax:

- select * from predictor1 where a=1 using b=2
- select * from table join predictor1 where a=1 using b=2 

Access to params in ML handler:

```
def predict(self, df, args=None):
     print(args['predict_params'])

```
#4016

