### PR TITLE
Enable Google Tag Manager

### DIFF
--- a/docs-v2/mint.json
+++ b/docs-v2/mint.json
@@ -198,5 +198,10 @@
     "linkedin": "https://www.linkedin.com/company/mindsdb",
     "youtube": "https://www.youtube.com/channel/UC5_wBOLCWath6q1iTgPPD5A",
     "medium": "https://medium.com/mindsdb"
+  },
+  "analytics": {
+    "gtm": {
+      "tagId": "GTM-MNN47J3"
+    }
   }
 }


### PR DESCRIPTION
## Please describe what changes you made, in as much detail as possible
  - Adds MindsDB's GTM ID to `mint.json` to enable GTM in Mintlify Docs.
  - Mintlify will automatically add the GTM script with the tag ID on all the pages after this is merged in.

mindsdb