### PR TITLE
Mock multiprocessing to multithreading

### DIFF
--- a/tests/unit/executor_test_base.py
+++ b/tests/unit/executor_test_base.py
@@ -59,6 +59,10 @@ class BaseUnitTest:
         db.init()
         cls.db = db
 
+        from multiprocessing import dummy
+        mp_patcher = mock.patch('torch.multiprocessing.get_context').__enter__()
+        mp_patcher.side_effect = lambda x: dummy
+
     @staticmethod
     def teardown_class(cls):
 


### PR DESCRIPTION
Changed multiproccession to multithreading for unit tests for executor. 
It helps to do mocking in data hanlder that are using in subprocess (for example extracting data for training)
