### PR TITLE
Libomp in macOS docs

### DIFF
--- a/docs/setup/self-hosted/pip/macos.mdx
+++ b/docs/setup/self-hosted/pip/macos.mdx
@@ -47,6 +47,14 @@ The
 error might be caused by some dependencies not working with Python 3.9 version.
 For now, please use Python 3.7.x or Python 3.8.x, as mentioned before.
 
+Some users can get `OSError: dlopen Library not loaded 'libomp.dylib'`. Please make sure you have installed `libomp` and run the export commands.
+
+```
+brew install libomp
+export LDFLAGS="-L/usr/local/opt/libomp/lib"
+export CPPFLAGS="-I/usr/local/opt/libomp/include"
+```
+
 ## Using the Python [`venv`](https://docs.python.org/3/library/venv.html) Module
 
 1. Create a new virtual environment called `mindsdb`:


### PR DESCRIPTION
Add macOS installation docs for `libomp` as a required library for LightGBM

Fixes #https://github.com/mindsdb/mindsdb/issues/3965

