### PR TITLE
Docs api wip warning

### DIFF
--- a/docs/rest/databases/create-databases.mdx
+++ b/docs/rest/databases/create-databases.mdx
@@ -2,3 +2,9 @@
 title: Create Database
 openapi: "POST /databases"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>

--- a/docs/rest/databases/delete-databases.mdx
+++ b/docs/rest/databases/delete-databases.mdx
@@ -2,3 +2,9 @@
 title: Delete Database
 openapi: "DELETE /databases/{databaseName}"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>

--- a/docs/rest/databases/list-database.mdx
+++ b/docs/rest/databases/list-database.mdx
@@ -2,3 +2,9 @@
 title: Get Database
 openapi: "GET /databases/{databaseName}"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>

--- a/docs/rest/databases/list-databases.mdx
+++ b/docs/rest/databases/list-databases.mdx
@@ -2,3 +2,9 @@
 title: Get all Databases
 openapi: "GET /databases"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>

--- a/docs/rest/databases/update-databases.mdx
+++ b/docs/rest/databases/update-databases.mdx
@@ -2,3 +2,9 @@
 title: Update Database
 openapi: "PUT /databases"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>

--- a/docs/rest/models/delete-model.mdx
+++ b/docs/rest/models/delete-model.mdx
@@ -2,3 +2,9 @@
 title: Delete a Model
 openapi: "DELETE /models/{modelName}"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>

--- a/docs/rest/models/describe-model.mdx
+++ b/docs/rest/models/describe-model.mdx
@@ -2,3 +2,9 @@
 title: Describe a Model
 openapi: "GET /models/{modelName}/describe"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>

--- a/docs/rest/models/list-model.mdx
+++ b/docs/rest/models/list-model.mdx
@@ -2,3 +2,9 @@
 title: Get Model
 openapi: "GET /models/{modelName}"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>

--- a/docs/rest/models/list-models.mdx
+++ b/docs/rest/models/list-models.mdx
@@ -2,3 +2,9 @@
 title: Get all Models
 openapi: "GET /models"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>

--- a/docs/rest/models/query-model.mdx
+++ b/docs/rest/models/query-model.mdx
@@ -2,3 +2,9 @@
 title: Query the Model
 openapi: "POST /models/{modelName}"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>

--- a/docs/rest/models/retrain-model.mdx
+++ b/docs/rest/models/retrain-model.mdx
@@ -2,3 +2,9 @@
 title: Retrain Model
 openapi: "POST /models/{modelName}/retrain"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>

--- a/docs/rest/models/train-model.mdx
+++ b/docs/rest/models/train-model.mdx
@@ -2,3 +2,9 @@
 title: Train new Model
 openapi: "POST /models"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>

--- a/docs/rest/tables/create-table.mdx
+++ b/docs/rest/tables/create-table.mdx
@@ -2,3 +2,9 @@
 title: Create Table
 openapi: "POST /tables"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>

--- a/docs/rest/tables/delete-table.mdx
+++ b/docs/rest/tables/delete-table.mdx
@@ -2,3 +2,9 @@
 title: Delete a Table
 openapi: "DELETE /tables/{tableName}"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>

--- a/docs/rest/tables/list-table.mdx
+++ b/docs/rest/tables/list-table.mdx
@@ -2,3 +2,9 @@
 title: Query Table
 openapi: "GET /tables/{tableName}"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>

--- a/docs/rest/views/create-view.mdx
+++ b/docs/rest/views/create-view.mdx
@@ -2,3 +2,9 @@
 title: Create View
 openapi: "POST /views"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>

--- a/docs/rest/views/delete-views.mdx
+++ b/docs/rest/views/delete-views.mdx
@@ -2,3 +2,9 @@
 title: Delete a Views
 openapi: "DELETE /views/{viewName}"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>

--- a/docs/rest/views/list-view.mdx
+++ b/docs/rest/views/list-view.mdx
@@ -2,3 +2,9 @@
 title: Query a Views
 openapi: "GET /views/{viewName}"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>

--- a/docs/rest/views/list-views.mdx
+++ b/docs/rest/views/list-views.mdx
@@ -2,3 +2,9 @@
 title: Get all Views
 openapi: "GET /views"
 ---
+
+<Warning>
+
+The REST API is still under development. Note that the Request Body and Response parameters could be changed.
+
+</Warning>


### PR DESCRIPTION
## Description

This PR adds warning to the REST APIs docs that they are under development.


## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] 📄 Documentation change

### What is the solution?

Added warning box before each `endpoint` page.
