### PR TITLE
fix: __get_retrain_adjust_version robust to Nones

### DIFF
--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -9,7 +9,7 @@ import psutil
 import json
 
 import torch.multiprocessing as mp
-# mp.set_start_method('spawn')
+mp.set_start_method('spawn')
 from packaging import version
 
 from mindsdb.__about__ import __version__ as mindsdb_version

--- a/mindsdb/interfaces/model/model_controller.py
+++ b/mindsdb/interfaces/model/model_controller.py
@@ -369,9 +369,10 @@ class ModelController():
             deleted_at=None,
             active=None,
         )
-        last_version = max([m.version for m in models])
-        if last_version is None:
-            last_version = 1
+        last_version = 1
+        for m in models:
+            if m.version is not None:
+                last_version = max(last_version, m.version)
 
         return last_version + 1
 


### PR DESCRIPTION
## Description

Fix edge case in `adjust()` so that it is robust to `None` values when fetching model versions.

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

Fix edge case in `adjust()` so that it is robust to `None` values when fetching model versions.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, or created issues to update them.
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] I have checked that my code additions will fail neither code linting checks nor unit test.
- [x] I have shared a short loom video or screenshots demonstrating any new functionality.
