### PR TITLE
fix unique constraint

### DIFF
--- a/mindsdb/interfaces/storage/db.py
+++ b/mindsdb/interfaces/storage/db.py
@@ -139,7 +139,7 @@ class Project(Base):
     name = Column(String, nullable=False)
     company_id = Column(Integer)
     __table_args__ = (
-        UniqueConstraint('name', 'company_id', name='unique_integration_name_company_id'),
+        UniqueConstraint('name', 'company_id', name='unique_project_name_company_id'),
     )
 
 

--- a/mindsdb/migrations/versions/2022-10-14_43c52d23845a_projects.py
+++ b/mindsdb/migrations/versions/2022-10-14_43c52d23845a_projects.py
@@ -29,7 +29,7 @@ def upgrade():
         sa.Column('name', sa.String(), nullable=False),
         sa.Column('company_id', sa.Integer(), nullable=True),
         sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('name', 'company_id', name='unique_integration_name_company_id')
+        sa.UniqueConstraint('name', 'company_id', name='unique_project_name_company_id')
     )
 
     conn = op.get_bind()

--- a/mindsdb/migrations/versions/2022-12-26_459218b0844c_fix_unique_constraint.py
+++ b/mindsdb/migrations/versions/2022-12-26_459218b0844c_fix_unique_constraint.py
@@ -1,0 +1,28 @@
+"""fix_unique_constraint
+
+Revision ID: 459218b0844c
+Revises: d429095b570f
+Create Date: 2022-12-26 13:40:57.141241
+
+"""
+from alembic import op
+
+revision = '459218b0844c'
+down_revision = 'd429095b570f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    try:
+        with op.batch_alter_table('project', schema=None) as batch_op:
+            batch_op.drop_constraint('unique_integration_name_company_id', type_='unique')
+            batch_op.create_unique_constraint('unique_project_name_company_id', ['name', 'company_id'])
+    except Exception:
+        pass
+
+
+def downgrade():
+    with op.batch_alter_table('project', schema=None) as batch_op:
+        batch_op.drop_constraint('unique_project_name_company_id', type_='unique')
+        batch_op.create_unique_constraint('unique_integration_name_company_id', ['name', 'company_id'])


### PR DESCRIPTION
## Description

We had doubled db constraints names 'unique_integration_name_company_id': in `project` and `integration` tables. 

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

Constraint renamed in old migration. Added new migration to rename constraint in existing databases (with try/catch for who install mindsdb from scratch)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have checked that my code additions will fail neither code linting checks nor unit test.
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
