### PR TITLE
[ENH] Override dtypes - LW handler

### DIFF
--- a/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/functions.py
+++ b/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/functions.py
@@ -45,6 +45,9 @@ def delete_learn_mark():
 def run_generate(df: DataFrame, predictor_id: int, args: dict = None):
     json_ai_override = args.pop('using', {})
 
+    if 'dtype_dict' in json_ai_override:
+        args['dtype_dict'] = json_ai_override.pop('dtype_dict')
+
     if 'timeseries_settings' in args:
         for tss_key in [f.name for f in dataclasses.fields(lightwood.api.TimeseriesSettings)]:
             k = f'timeseries_settings.{tss_key}'


### PR DESCRIPTION
## Description

Enables support for overriding automatically inferred data types when using the Lightwood handler.

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📄 This change requires a documentation update

### What is the solution?

If the user provides:

```sql
CREATE ...
USING 
dtype_dict = {
   'col1': 'type',
    ...
};
```

The handler will extract this mapping and use it to build a modified problem definition, which will trigger the default encoder belonging to each new `dtype` (note: manually specifying encoders is out of scope for this PR and will be added at a later date).

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] I have checked that my code additions will fail neither code linting checks nor unit test.
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
