### PR TITLE
updated tests/readme formatting as 1.2,1.3,1.4 were on single line

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,15 +1,18 @@
 To run test, execute from project root:
+
 ```
 python3 /tests/integration_tests/flows/test_{name}.py
 ```
+
 Integration tests can be run in two modes, defined by env variable USE_EXTERNAL_DB_SERVER:
+
 1. using local databases. For that:  
-1.1 set env `USE_EXTERNAL_DB_SERVER=0`  
-1.2 define database credentials in `tests/integration_tests/flows/config/config.json`
-1.3 if database does not contain test table, define env `DATASETS_PATH=path/to/test_data`
-1.4 run database and test
+   1.1 set env `USE_EXTERNAL_DB_SERVER=0`  
+   1.2 define database credentials in `tests/integration_tests/flows/config/config.json`  
+   1.3 if database does not contain test table, define env `DATASETS_PATH=path/to/test_data`  
+   1.4 run database and test
 2. using remote databases. For that:  
-2.1 set env `USE_EXTERNAL_DB_SERVER=1`  
-2.2 save database credentials file in home dir: `.mindsdb_credentials.json`  
-2.3 save db machine key in `~/.ssh/db_machine`  
-2.4 run test
+   2.1 set env `USE_EXTERNAL_DB_SERVER=1`  
+   2.2 save database credentials file in home dir: `.mindsdb_credentials.json`  
+   2.3 save db machine key in `~/.ssh/db_machine`  
+   2.4 run test


### PR DESCRIPTION
## Description

Reformatting tests/README.md file. The reason for this was the current version has points 1.2, 1.3, and 1.4 on the single line. 

**Fixes** #4305 

## Type of change

(Please delete options that are not relevant)

- [X ] 📄 This change requires a documentation update

### What is the solution?

Reformatting the md file

## Checklist:

- [ X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ X] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have checked that my code additions will fail neither code linting checks nor unit test.
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
