### PR TITLE
Ignore docstring in ml_exec_base.py with noqa

### DIFF
--- a/mindsdb/integrations/libs/ml_exec_base.py
+++ b/mindsdb/integrations/libs/ml_exec_base.py
@@ -14,7 +14,7 @@ In particular, three big components are included:
 
     - `predict_process` method: handles async dispatch of the `predict` method in an engine.
 
-"""
+""" # noqa
 
 import datetime as dt
 import traceback


### PR DESCRIPTION
## Description

Adding # noqa to docstring at top of ml_exec_base.py

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)

### What is the solution?

Linter will ignore docstring