### PR TITLE
Fix for nan->none conversion

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/integration_datanode.py
+++ b/mindsdb/api/mysql/mysql_proxy/datahub/datanodes/integration_datanode.py
@@ -1,10 +1,11 @@
 import numpy as np
 from numpy import dtype as np_dtype
+import pandas as pd
 from pandas.api import types as pd_types
-
 from sqlalchemy.types import (
     Integer, Float, Text
 )
+
 from mindsdb_sql.parser.ast import Insert, Identifier, CreateTable, TableColumn, DropTables
 
 from mindsdb.api.mysql.mysql_proxy.datahub.datanodes.datanode import DataNode
@@ -133,7 +134,7 @@ class IntegrationDataNode(DataNode):
             return
 
         df = result.data_frame
-        df = df.replace({np.nan: None})
+        df = df.replace(np.NaN, pd.NA).where(df.notnull(), None)
         columns_info = [
             {
                 'name': k,


### PR DESCRIPTION
## Description

Founded strange pandas behavior: if df contains nan, then `df.replace({np.nan: None})` works as expected. But if df contains none values, then `df.replace({np.nan: None})` will replace them to NaN

**Fixes**
https://github.com/mindsdb/mindsdb-frontend/issues/996

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
