### PR TITLE
Microservice mode: save context in REST API

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/controllers/session_controller.py
+++ b/mindsdb/api/mysql/mysql_proxy/controllers/session_controller.py
@@ -73,6 +73,10 @@ class SessionController:
             "packet_sequence_number": self.packet_sequence_number,
         }
 
+    def from_json(self, updated):
+        for key in updated:
+            setattr(self, key, updated[key])
+
 
 class ServerSessionContorller(SessionController):
     """SessionController implementation for case of Executor service.

--- a/mindsdb/api/mysql/mysql_proxy/executor/executor.py
+++ b/mindsdb/api/mysql/mysql_proxy/executor/executor.py
@@ -218,6 +218,8 @@ class Executor:
             "state_track": self.state_track,
             "server_status": self.server_status,
             "is_executed": self.is_executed,
+            "session": self.session.to_json()
+
         }
         return params
 

--- a/mindsdb/api/mysql/mysql_proxy/executor/executor_client.py
+++ b/mindsdb/api/mysql/mysql_proxy/executor/executor_client.py
@@ -33,6 +33,7 @@ class ExecutorClient:
         logger.debug(
             "%s.__init__: executor url - %s", self.__class__.__name__, self.base_url
         )
+
         self.sqlserver = sqlserver
         self.session = session
         self.query = None
@@ -115,7 +116,10 @@ class ExecutorClient:
                     attr,
                     response_json[attr],
                 )
-                setattr(self, attr, response_json[attr])
+                if attr == 'session':
+                    self.session.from_json(response_json[attr])
+                else:
+                    setattr(self, attr, response_json[attr])
 
     def to_mysql_columns(self, columns):
         return columns


### PR DESCRIPTION
## Description

Since there is another logic to save context (current database in particular) in REST API comparing with MySQL API, microservice mode couldn't do it.

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
