### PR TITLE
[fix] raise Error if OpenAI API key has exceeded current quota

### DIFF
--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -8,9 +8,6 @@ import psutil
 import asyncio
 import secrets
 import traceback
-
-import torch.multiprocessing as mp
-mp.set_start_method('spawn')
 from packaging import version
 
 from mindsdb.__about__ import __version__ as mindsdb_version
@@ -29,6 +26,13 @@ from mindsdb.integrations.utilities.install import install_dependencies
 from mindsdb.utilities.fs import create_dirs_recursive
 from mindsdb.utilities.telemetry import telemetry_file_exists, disable_telemetry
 from mindsdb.utilities.context import context as ctx
+
+
+import torch.multiprocessing as mp
+try:
+    mp.set_start_method('spawn')
+except RuntimeError:
+    log.logger.info('Torch multiprocessing context already set, ignoring...')
 
 # is_ray_worker = False
 # if sys.argv[0].endswith('ray/workers/default_worker.py'):

--- a/mindsdb/integrations/handlers/openai_handler/helpers.py
+++ b/mindsdb/integrations/handlers/openai_handler/helpers.py
@@ -27,7 +27,10 @@ def retry_with_exponential_backoff(
         while True:
             try:
                 return func(*args, **kwargs)
-            except errors:
+            except errors as e:
+                if 'You exceeded your current quota' in e.user_message:
+                    raise Exception('API key has exceeded its quota, please try 1) increasing it or 2) using another key.')  # noqa
+
                 num_retries += 1
                 if num_retries > max_retries:
                     raise Exception(

--- a/mindsdb/integrations/handlers/openai_handler/helpers.py
+++ b/mindsdb/integrations/handlers/openai_handler/helpers.py
@@ -28,7 +28,7 @@ def retry_with_exponential_backoff(
             try:
                 return func(*args, **kwargs)
             except errors as e:
-                if 'You exceeded your current quota' in e.user_message:
+                if e.error['type'] == 'insufficient_quota':
                     raise Exception('API key has exceeded its quota, please try 1) increasing it or 2) using another key.')  # noqa
 
                 num_retries += 1


### PR DESCRIPTION
## Description

This PR accounts for when the API key has no token credit left, yielding an informative message when calling an OpenAI model.

Also, added a try-except clause for setting `torch.mp` to `spawn` in the `__main__` process (which is helpful when debugging if this option has already been set).

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

Small change in the exponential backoff decorator to check for `insufficient_quota` in the provided error.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
