### PR TITLE
[ENH] Support for additional OpenAI completion endpoint params

### DIFF
--- a/mindsdb/integrations/handlers/openai_handler/openai_handler.py
+++ b/mindsdb/integrations/handlers/openai_handler/openai_handler.py
@@ -85,9 +85,20 @@ class OpenAIHandler(BaseMLEngine):
         if args.get('context_column', False) and args['context_column'] not in df.columns:
             raise Exception(f"This model expects context in the '{args['context_column']}' column.")
 
+        # api argument validation
         model_name = args.get('model_name', self.default_model)
-        temperature = min(1.0, max(0.0, args.get('temperature', 0.0)))
-        max_tokens = pred_args.get('max_tokens', args.get('max_tokens', self.default_max_tokens))
+        api_args = {
+            'max_tokens': pred_args.get('max_tokens', args.get('max_tokens', self.default_max_tokens)),
+            'temperature': min(1.0, max(0.0, args.get('temperature', 0.0))),
+            'top_p': pred_args.get('top_p', None),
+            'n': pred_args.get('n', None),
+            'stop': pred_args.get('stop', None),
+            'presence_penalty': pred_args.get('presence_penalty', None),
+            'frequency_penalty': pred_args.get('frequency_penalty', None),
+            'best_of': pred_args.get('best_of', None),
+            'logit_bias': pred_args.get('logit_bias', None),
+            'user': pred_args.get('user', None),
+        }
 
         if args.get('prompt_template', False):
             if pred_args.get('prompt_template', False):
@@ -137,7 +148,8 @@ class OpenAIHandler(BaseMLEngine):
         prompts = [j for i, j in enumerate(prompts) if i not in empty_prompt_ids]
 
         api_key = self._get_api_key(args)
-        completion = self._completion(model_name, prompts, max_tokens, temperature, api_key, args)
+        api_args = {k: v for k, v in api_args.items() if v is not None}  # filter out non-specified api args
+        completion = self._completion(model_name, prompts, api_key, api_args, args)
 
         # add null completion for empty prompts
         for i in sorted(empty_prompt_ids):
@@ -146,7 +158,7 @@ class OpenAIHandler(BaseMLEngine):
         pred_df = pd.DataFrame(completion, columns=[args['target']])
         return pred_df
 
-    def _completion(self, model_name, prompts, max_tokens, temperature, api_key, args, parallel=True):
+    def _completion(self, model_name, prompts, api_key, api_args, args, parallel=True):
         """
         Handles completion for an arbitrary amount of rows.
 
@@ -158,14 +170,13 @@ class OpenAIHandler(BaseMLEngine):
         because even with previous checks the tokens-per-minute limit may apply.
         """
         @retry_with_exponential_backoff
-        def _submit_completion(model_name, prompts, max_tokens, temperature, api_key, args):
+        def _submit_completion(model_name, prompts, api_key, api_args, args):
             return openai.Completion.create(
                 model=model_name,
                 prompt=prompts,
-                max_tokens=max_tokens,
-                temperature=temperature,
                 api_key=api_key,
-                organization=args.get('api_organization')
+                organization=args.get('api_organization'),
+                **api_args
             )
 
         def _tidy(comp):
@@ -176,9 +187,8 @@ class OpenAIHandler(BaseMLEngine):
             completion = _submit_completion(
                 model_name,
                 prompts,
-                max_tokens,
-                temperature,
                 api_key,
+                api_args,
                 args
             )
             return _tidy(completion)  
@@ -196,9 +206,8 @@ class OpenAIHandler(BaseMLEngine):
             for i in range(math.ceil(len(prompts) / max_batch_size)):
                 partial = _submit_completion(model_name,
                                              prompts[i * max_batch_size:(i + 1) * max_batch_size],
-                                             max_tokens,
-                                             temperature,
                                              api_key,
+                                             api_args,
                                              args)
                 if not completion:
                     completion = partial
@@ -214,9 +223,8 @@ class OpenAIHandler(BaseMLEngine):
                     future = executor.submit(_submit_completion,
                                              model_name,
                                              prompts[i * max_batch_size:(i + 1) * max_batch_size],
-                                             max_tokens,
-                                             temperature,
                                              api_key,
+                                             api_args,
                                              args)
                     promises.append({"choices": future})
             completion = None


### PR DESCRIPTION
## Description

This PR extends the support for most (but not all) OpenAI text completion parameters.

Already supported params:
- max_tokens
- temperature

Introduced in this PR:
- top_p
- n
- stop
- presence_penalty
- frequency_penalty
- best_of
- logit_bias
- user


For example:

```sql
SELECT input, completion
FROM mindsdb.openai_test
WHERE input = 'Write an essay on your favourite subject'
USING
max_tokens=200,
stop=["debate"];  -- this stops the completion as soon as "debate" is generated
```

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)
- [x] 📄 This change requires a documentation update

### What is the solution?

Refactored some bits of logic in the handler, particularly the _submit_completion function but also the compilation of all api_args has been slightly redesigned for cleaner code.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
