### PR TITLE
Amazon Aurora Integration

### DIFF
--- a/mindsdb/integrations/handlers/aurora_handler/__about__.py
+++ b/mindsdb/integrations/handlers/aurora_handler/__about__.py
@@ -1,0 +1,9 @@
+__title__ = 'MindsDB Amazon Aurora handler'
+__package_name__ = 'mindsdb_aurora_handler'
+__version__ = '0.0.1'
+__description__ = "MindsDB handler for Amazon Aurora"
+__author__ = 'Minura Punchihewa'
+__github__ = 'https://github.com/mindsdb/mindsdb'
+__pypi__ = 'https://pypi.org/project/mindsdb/'
+__license__ = 'GPL-3.0'
+__copyright__ = 'Copyright 2022- mindsdb'

--- a/mindsdb/integrations/handlers/aurora_handler/__init__.py
+++ b/mindsdb/integrations/handlers/aurora_handler/__init__.py
@@ -1,0 +1,23 @@
+from mindsdb.integrations.libs.const import HANDLER_TYPE
+
+from .__about__ import __version__ as version, __description__ as description
+try:
+    from .aurora_handler import (
+        AuroraHandler as Handler,
+        connection_args_example,
+        connection_args
+    )
+    import_error = None
+except Exception as e:
+    Handler = None
+    import_error = e
+
+title = 'Amazon Aurora'
+name = 'aurora'
+type = HANDLER_TYPE.DATA
+icon_path = 'icon.png'
+
+__all__ = [
+    'Handler', 'version', 'name', 'type', 'title', 'description',
+    'connection_args', 'connection_args_example', 'import_error', 'icon_path'
+]

--- a/mindsdb/integrations/handlers/aurora_handler/aurora_handler.py
+++ b/mindsdb/integrations/handlers/aurora_handler/aurora_handler.py
@@ -1,0 +1,116 @@
+from collections import OrderedDict
+
+import pandas as pd
+
+from mindsdb_sql import parse_sql
+from mindsdb_sql.render.sqlalchemy_render import SqlalchemyRender
+from mindsdb_sql.parser.ast.base import ASTNode
+
+from mindsdb.utilities import log
+from mindsdb.integrations.libs.base import DatabaseHandler
+from mindsdb.integrations.libs.response import (
+    HandlerStatusResponse as StatusResponse,
+    HandlerResponse as Response,
+    RESPONSE_TYPE
+)
+from mindsdb.integrations.libs.const import HANDLER_CONNECTION_ARG_TYPE as ARG_TYPE
+
+from mindsdb.integrations.handlers.mysql_handler.mysql_handler import MySQLHandler
+from mindsdb.integrations.handlers.postgres_handler.postgres_handler import PostgresHandler
+
+
+class AuroraHandler(DatabaseHandler):
+    """
+    This handler handles connection and execution of the Firebird statements.
+    """
+
+    name = 'aurora'
+
+    def __init__(self, name: str, connection_data: Optional[dict], **kwargs):
+        """
+        Initialize the handler.
+        Args:
+            name (str): name of particular handler instance
+            connection_data (dict): parameters for connecting to the database
+            **kwargs: arbitrary keyword arguments.
+        """
+        super().__init__(name)
+        self.parser = parse_sql
+        self.dialect = 'aurora'
+        self.connection_data = connection_data
+        self.kwargs = kwargs
+
+        self.connection = None
+        self.is_connected = False
+
+    def __del__(self):
+        if self.is_connected is True:
+            self.disconnect()
+
+    def connect(self) -> StatusResponse:
+        """
+        Set up the connection required by the handler.
+        Returns:
+            HandlerStatusResponse
+        """
+
+        pass
+
+    def disconnect(self):
+        """
+        Close any existing connections.
+        """
+
+        pass
+
+    def check_connection(self) -> StatusResponse:
+        """
+        Check connection to the handler.
+        Returns:
+            HandlerStatusResponse
+        """
+
+        pass
+
+    def native_query(self, query: str) -> StatusResponse:
+        """
+        Receive raw query and act upon it somehow.
+        Args:
+            query (str): query in native format
+        Returns:
+            HandlerResponse
+        """
+
+        pass
+
+    def query(self, query: ASTNode) -> StatusResponse:
+        """
+        Receive query as AST (abstract syntax tree) and act upon it somehow.
+        Args:
+            query (ASTNode): sql query represented as AST. May be any kind
+                of query: SELECT, INTSERT, DELETE, etc
+        Returns:
+            HandlerResponse
+        """
+
+        pass
+
+    def get_tables(self) -> StatusResponse:
+        """
+        Return list of entities that will be accessible as tables.
+        Returns:
+            HandlerResponse
+        """
+
+        pass
+
+    def get_columns(self, table_name: str) -> StatusResponse:
+        """
+        Returns a list of entity columns.
+        Args:
+            table_name (str): name of one of tables returned by self.get_tables()
+        Returns:
+            HandlerResponse
+        """
+
+        pass

--- a/mindsdb/integrations/handlers/aurora_handler/aurora_handler.py
+++ b/mindsdb/integrations/handlers/aurora_handler/aurora_handler.py
@@ -74,14 +74,14 @@ class AuroraHandler(DatabaseHandler):
             HandlerStatusResponse
         """
 
-        pass
+        return self.db.connect()
 
     def disconnect(self):
         """
         Close any existing connections.
         """
 
-        pass
+        return self.db.disconnect()
 
     def check_connection(self) -> StatusResponse:
         """
@@ -90,7 +90,7 @@ class AuroraHandler(DatabaseHandler):
             HandlerStatusResponse
         """
 
-        pass
+        return self.db.check_connection()
 
     def native_query(self, query: str) -> StatusResponse:
         """
@@ -101,7 +101,7 @@ class AuroraHandler(DatabaseHandler):
             HandlerResponse
         """
 
-        pass
+        return self.db.native_query(query)
 
     def query(self, query: ASTNode) -> StatusResponse:
         """
@@ -113,7 +113,7 @@ class AuroraHandler(DatabaseHandler):
             HandlerResponse
         """
 
-        pass
+        return self.db.query(query)
 
     def get_tables(self) -> StatusResponse:
         """
@@ -122,7 +122,7 @@ class AuroraHandler(DatabaseHandler):
             HandlerResponse
         """
 
-        pass
+        return self.db.get_tables()
 
     def get_columns(self, table_name: str) -> StatusResponse:
         """
@@ -133,4 +133,4 @@ class AuroraHandler(DatabaseHandler):
             HandlerResponse
         """
 
-        pass
+        return self.db.get_columns(table_name)

--- a/mindsdb/integrations/handlers/aurora_handler/aurora_handler.py
+++ b/mindsdb/integrations/handlers/aurora_handler/aurora_handler.py
@@ -134,3 +134,35 @@ class AuroraHandler(DatabaseHandler):
         """
 
         return self.db.get_columns(table_name)
+
+
+connection_args = OrderedDict(
+    user={
+        'type': ARG_TYPE.STR,
+        'description': 'The user name used to authenticate with the Amazon Aurora DB cluster.'
+    },
+    password={
+        'type': ARG_TYPE.STR,
+        'description': 'The password to authenticate the user with the Amazon Aurora DB cluster.'
+    },
+    database={
+        'type': ARG_TYPE.STR,
+        'description': 'The database name to use when connecting with the Amazon Aurora DB cluster.'
+    },
+    host={
+        'type': ARG_TYPE.STR,
+        'description': 'The host name or IP address of the Amazon Aurora DB cluster. NOTE: use \'127.0.0.1\' instead of \'localhost\' to connect to local server.'
+    },
+    port={
+        'type': ARG_TYPE.INT,
+        'description': 'The TCP/IP port of the Amazon Aurora DB cluster. Must be an integer.'
+    }
+)
+
+connection_args_example = OrderedDict(
+    host='127.0.0.1',
+    port=3306,
+    user='root',
+    password='password',
+    database='database'
+)

--- a/mindsdb/integrations/handlers/aurora_handler/aurora_handler.py
+++ b/mindsdb/integrations/handlers/aurora_handler/aurora_handler.py
@@ -137,6 +137,14 @@ class AuroraHandler(DatabaseHandler):
 
 
 connection_args = OrderedDict(
+    aws_access_key_id={
+        'type': ARG_TYPE.STR,
+        'description': 'The access key for the AWS account.'
+    },
+    aws_secret_access_key={
+        'type': ARG_TYPE.STR,
+        'description': 'The secret key for the AWS account.'
+    },
     user={
         'type': ARG_TYPE.STR,
         'description': 'The user name used to authenticate with the Amazon Aurora DB cluster.'
@@ -160,6 +168,8 @@ connection_args = OrderedDict(
 )
 
 connection_args_example = OrderedDict(
+    aws_access_key_id='PCAQ2LJDOSWLNSQKOCPW',
+    aws_secret_access_key='U/VjewPlNopsDmmwItl34r2neyC6WhZpUiip57i',
     host='127.0.0.1',
     port=3306,
     user='root',

--- a/mindsdb/integrations/handlers/aurora_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/aurora_handler/requirements.txt
@@ -1,0 +1,4 @@
+psycopg[binary] >= 1.15.3
+docker >= 5.0.3
+mysql-connector-python
+boto3

--- a/mindsdb/integrations/handlers/aurora_handler/tests/test_aurora_handler.py
+++ b/mindsdb/integrations/handlers/aurora_handler/tests/test_aurora_handler.py
@@ -1,0 +1,38 @@
+import unittest
+from mindsdb.integrations.handlers.aurora_handler.aurora_handler import AuroraHandler
+from mindsdb.api.mysql.mysql_proxy.libs.constants.response_type import RESPONSE_TYPE
+
+
+class AuroraHandlerTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.kwargs = {
+            "connection_data": {
+                "host": "",
+                "port": 0,
+                "user": "",
+                "password": "",
+                "database": ""
+            }
+        }
+        cls.handler = AuroraHandler('test_aurora_handler', cls.kwargs)
+
+    def test_0_check_connection(self):
+        assert self.handler.check_connection()
+
+    def test_1_native_query_select(self):
+        query = ""
+        result = self.handler.native_query(query)
+        assert result.type is RESPONSE_TYPE.TABLE
+
+    def test_2_get_tables(self):
+        tables = self.handler.get_tables()
+        assert tables.type is not RESPONSE_TYPE.ERROR
+
+    def test_3_get_columns(self):
+        columns = self.handler.get_columns('')
+        assert columns.type is not RESPONSE_TYPE.ERROR
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I have implemented the new integration for Amazon Aurora. I have not been able to perform any testing as I don't really have access to an AWS account.

Amazon Aurora comes in two flavors: a MySQL compatible version and a PostgreSQL compatible version. This integration makes use of the relevant handlers that have already been implemented for these RDBMSs.

It uses `boto3` to identify which database engine that the database cluster is running and then instantiates the relevant handler. For this purpose, users will be required to pass in their AWS access key and secret access key. However, this can be simplified by getting the users to pass in the name of the database engine as a parameter. 
@ZoranPandovski What are your thoughts on this?

I am somewhat confident that this integration will work, however, it would be beneficial to conduct some testing.