### PR TITLE
[fix] override problem definition in lightwood handler

### DIFF
--- a/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/functions.py
+++ b/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/functions.py
@@ -48,6 +48,9 @@ def run_generate(df: DataFrame, predictor_id: int, args: dict = None):
     if 'dtype_dict' in json_ai_override:
         args['dtype_dict'] = json_ai_override.pop('dtype_dict')
 
+    if 'problem_definition' in json_ai_override:
+        args = {**args, **json_ai_override['problem_definition']}
+
     if 'timeseries_settings' in args:
         for tss_key in [f.name for f in dataclasses.fields(lightwood.api.TimeseriesSettings)]:
             k = f'timeseries_settings.{tss_key}'


### PR DESCRIPTION
## Description

Enables problem definition overriding for lightwood handler.

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

Can now do something like:

```sql
CREATE MODEL 
  mindsdb.home_rentals_model
FROM example_db
  (SELECT * FROM demo_data.home_rentals)
PREDICT rental_price
USING
problem_definition={'use_default_analysis': False};
```

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
