### PR TITLE
add-community-tutorial-link

### DIFF
--- a/docs/connect/connect-mariadb-skysql.mdx
+++ b/docs/connect/connect-mariadb-skysql.mdx
@@ -156,3 +156,12 @@ remaining pages from the **SQL API** section, as they explain a common SQL
 syntax with examples.
 
 Have fun!
+
+<Tip>
+**From Our Community**
+
+Check out the tutorial created by our community:
+
+- [Let's connect Mindsdb with Mariadb shell Locally and Predict the Mobile Price](https://atharva08.hashnode.dev/lets-connect-mindsdb-with-mariadb-shell-locally-and-predict-the-mobile-price-range)
+  by [Atharva Shirdhankar](https://github.com/StarTrooper08)
+</Tip>


### PR DESCRIPTION
## Description

Please include a summary of the change and the issue it solves. 

**Fixes** #(4475)

## Type of change

- [ ] 📄 This change requires a documentation update

### What is the solution?

Add community tutorial links to the Using MindsDB via SQL API -> Connect to MindsDB -> Other SQL Clients -> MariaDB SkySQL page

