### PR TITLE
add tutorial links #4481

### DIFF
--- a/docs/connect/sql-alchemy.mdx
+++ b/docs/connect/sql-alchemy.mdx
@@ -122,3 +122,17 @@ remaining pages from the **SQL API** section, as they explain a common SQL
 syntax with examples.
 
 Have fun!
+<Tip>
+**From Our Community**
+
+Check out the articles and video guides created by our community:
+
+- Article on [Predict Diamond prices with SQL Alchemy](https://dev.to/tesprogram/predict-diamond-prices-with-sql-alchemy-and-mindsdb-b4e)
+  by [Teslim Odumuyiwa](https://github.com/Tes-program)
+
+- Article on [Predicting Home Rental Prices with MindsDB in Python](https://curiousprogrammer.hashnode.dev/predicting-home-rental-prices-with-mindsdb-in-python)
+  by [Temidayo](https://hashnode.com/@Temicoder)
+
+- Video guide on [How to connect to MindsDB with SQL Alchemy(Python)](https://www.youtube.com/watch?v=pYR83QTyOQA)
+  by [Nishant Sapkota](https://github.com/thenishantsapkota)
+</Tip>


### PR DESCRIPTION
## Description

Adds community tutorial links to the Using MindsDB via SQL API -> Connect to MindsDB -> Other SQL Clients -> SQL Alchemy page.

**Fixes** #(4481)

## Type of change
Add community tutorial links to the Using MindsDB via SQL API -> Connect to MindsDB -> Other SQL Clients -> SQL Alchemy page.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
