### PR TITLE
[Docs] Add community tutorial link to Mongo API regression page (#4564)

### DIFF
--- a/docs/using-mongo-api/regression.mdx
+++ b/docs/using-mongo-api/regression.mdx
@@ -13,3 +13,5 @@ Here are our community tutorials that use MongoDB in regression predictions:
   by [Nupoor Shetye](https://github.com/Nupoor10)
 - [Predicting gold prices with MindsDB and MongoDB](https://dev.to/yagueto/predicting-gold-prices-with-mindsdb-and-mongodb-4k22)
   by [yagueto](https://github.com/yagueto)
+- [Tutorial to Predict the Energy Usage using MindsDB and MongoDB](https://dev.to/dohrisalim/tutorial-to-predict-the-energy-usage-using-mindsdb-and-mongodb-g60)
+  by [Salim Dohri](https://github.com/dohrisalim)


### PR DESCRIPTION
## Description

This PR adds a community tutorial link to the Mongo API regression page.

**Fixes** #(issue) #4564

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

To implement this feature, I added the community tutorial link to the appropriate location in the Mongo API regression page (regression.mdx).

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.

I have read the CLA Document and I hereby sign the CLA.
