### PR TITLE
Add missing renderer instance variable

### DIFF
--- a/mindsdb/integrations/handlers/duckdb_handler/duckdb_handler.py
+++ b/mindsdb/integrations/handlers/duckdb_handler/duckdb_handler.py
@@ -5,6 +5,7 @@ import pandas as pd
 from duckdb import DuckDBPyConnection
 from mindsdb_sql import parse_sql
 from mindsdb_sql.parser.ast.base import ASTNode
+from mindsdb_sql.render.sqlalchemy_render import SqlalchemyRender
 
 from mindsdb.integrations.libs.base import DatabaseHandler
 from mindsdb.integrations.libs.const import (
@@ -28,6 +29,7 @@ class DuckDBHandler(DatabaseHandler):
         self.parser = parse_sql
         self.dialect = 'postgresql'
         self.connection_data = kwargs.get('connection_data')
+        self.renderer = SqlalchemyRender('postgres')
 
         self.connection = None
         self.is_connected = False


### PR DESCRIPTION
## Description

Added missing renderer instance variable in the DuckDB handler.

**Fixes** #4609

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### What is the solution?

- `SqlalchemyRender('postgres')` added as the renderer.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
