### PR TITLE
Fixed typos recomendation -> recommendation

### DIFF
--- a/docs/sql/tutorials/crop-prediction.mdx
+++ b/docs/sql/tutorials/crop-prediction.mdx
@@ -1,8 +1,9 @@
 ---
-title: Crop Recomendation
+title: Crop Recommendation
 ---
 
-_Dataset: [Crop recomendation Data](https://www.kaggle.com/atharvaingle/crop-recommendation-dataset)_
+_Dataset: [Crop recommendation 
+Data](https://www.kaggle.com/atharvaingle/crop-recommendation-dataset)_
 
 _Communtiy Author: [pixpack](https://github.com/pixpack)_
 


### PR DESCRIPTION
## Description

I have changed two instances of the word "recomendation" to "recommendation" in the Crop Recommendation tutorial.

**Fixes** #4631

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
