### PR TITLE
fix a typo in docs about connrction using DBeaver

### DIFF
--- a/docs/connect/dbeaver.mdx
+++ b/docs/connect/dbeaver.mdx
@@ -75,7 +75,7 @@ On success, you should see the message, as below.
 
 ## Let's Run Some Queries
 
-To finally make sure that our MinsdDB database connection works, let's run some
+To finally make sure that our MindsDB database connection works, let's run some
 queries.
 
 ```sql


### PR DESCRIPTION
## Description

fix a typo in docs about connection using DBeaver.
links to the doc: [https://docs.mindsdb.com/connect/dbeaver](https://docs.mindsdb.com/connect/dbeaver
)
**Fixes** #4591

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

 in `docs/connect/dbeaver.mdx`, under the "Let’s Run Some Queries" section, change the misspelling **MinsdDB** to **MindsDB**.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
