### PR TITLE
fix filter for starting model training

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/executor/executor_commands.py
+++ b/mindsdb/api/mysql/mysql_proxy/executor/executor_commands.py
@@ -644,16 +644,17 @@ class ExecuteCommands:
         is_cloud = self.session.config.get('cloud', False)
         if is_cloud and ctx.user_class == 0:
             models = get_model_records(active=None)
-            longest_training = None
-            for p in models:
+            shortest_training = None
+            for model in models:
                 if (
-                        p.status in (PREDICTOR_STATUS.GENERATING, PREDICTOR_STATUS.TRAINING)
-                        and p.training_start_at is not None and p.training_stop_at is None
+                        model.status in (PREDICTOR_STATUS.GENERATING, PREDICTOR_STATUS.TRAINING)
+                        and model.training_start_at is not None and model.training_stop_at is None
                 ):
-                    training_time = datetime.datetime.now() - p.training_start_at
-                    if longest_training is None or training_time > longest_training:
-                        longest_training = training_time
-            if longest_training is not None and longest_training > datetime.timedelta(hours=1):
+                    training_time = datetime.datetime.now() - model.training_start_at
+                    if shortest_training is None or training_time < shortest_training:
+                        shortest_training = training_time
+
+            if shortest_training is not None and shortest_training < datetime.timedelta(hours=1):
                 raise SqlApiException(
                     f"Can't start {phase_name} process while predictor is in status 'training' or 'generating'"
                 )

--- a/mindsdb/api/mysql/mysql_proxy/executor/executor_commands.py
+++ b/mindsdb/api/mysql/mysql_proxy/executor/executor_commands.py
@@ -640,7 +640,9 @@ class ExecuteCommands:
         return model_record
 
     def _sync_predictor_check(self, phase_name):
-        """ Checks if there is already a predictor retraining or adjusting """
+        """ Checks if there is already a predictor retraining or adjusting
+            Do not allow to run retrain if there is another model in training process in less that 1h
+        """
         is_cloud = self.session.config.get('cloud', False)
         if is_cloud and ctx.user_class == 0:
             models = get_model_records(active=None)


### PR DESCRIPTION
## Description

At the start of model training we need to check if user already has model in 'training' status. We need to prevent user from starting training too frequently 

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
