### PR TITLE
Add schema as a param to Postgres connection

### DIFF
--- a/mindsdb/integrations/handlers/postgres_handler/postgres_handler.py
+++ b/mindsdb/integrations/handlers/postgres_handler/postgres_handler.py
@@ -43,15 +43,18 @@ class PostgresHandler(DatabaseHandler):
         if self.is_connected is True:
             return self.connection
 
-        # TODO: Check psycopg_pool
-        if self.connection_args.get('dbname') is None:
-            self.connection_args['dbname'] = self.database
-        args = self.connection_args.copy()
+        config = {
+            'host': self.connection_args.get('host'),
+            'port': self.connection_args.get('port'),
+            'user': self.connection_args.get('user'),
+            'password': self.connection_args.get('password'),
+            'dbname': self.connection_args.get('database')
+        }
 
-        for key in ['type', 'publish', 'test', 'date_last_update', 'integrations_name', 'database_name', 'id', 'database']:
-            if key in args:
-                del args[key]
-        connection = psycopg.connect(**args, connect_timeout=10)
+        if self.connection_args.get('schema'):
+            config['options'] = f'-c search_path={self.connection_args.get("schema")},public'
+
+        connection = psycopg.connect(**config, connect_timeout=10)
 
         self.is_connected = True
         self.connection = connection


### PR DESCRIPTION
## Description

This PR adds schema as an optional parameter to the psql connection. If the `schema` is provided, it will be used as a default alongside `public`. If not, only the public is used by default.

**Fixes** #4659

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
