### PR TITLE
Updated Readme with the unsupported PostrgreSQL features

### DIFF
--- a/mindsdb/integrations/handlers/cloud_spanner_handler/README.md
+++ b/mindsdb/integrations/handlers/cloud_spanner_handler/README.md
@@ -35,3 +35,16 @@ Now, you can use this established connection to query your database as follows:
 ```sql
 SELECT * FROM cloud_spanner_datasource.my_table;
 ```
+
+> **NOTE** : Cloud Spanner supports PostgreSQL syntax and also Google's GoogleSQL dialect. But, not all PostgresSQL dialect features are supported. Find the list of such features below.
+> - Change streams
+> - GoogleSQL `JSON` type (PostgreSQL-dialect databases support the PostgreSQL JSONB type.)
+> - `SELECT DISTINCT` (`DISTINCT` is supported in aggregate functions.)
+> - `FULL JOIN` with `USING`
+> - Query optimizer versioning
+> - Optimizer statistics package versioning
+> - `ORDER BY`, `LIMIT`, and `OFFSET` in `UNION`,`EXCEPT`, or `DISTINCT` statements
+> - The following columns in `SPANNER_SYS` statistics tables:
+>      - Transaction statistics: `TOTAL_LATENCY_DISTRIBUTION` and `OPERATIONS_BY_TABLE`
+>      - Query statistics: `LATENCY_DISTRIBUTION`
+>      - Lock Statistics: `SAMPLE_LOCK_REQUESTS`


### PR DESCRIPTION
## Description

This PR updates the Readme page of the Cloud Spanner Handler.

**Fixes** #4724 

## Type of change

- [x] 📄 This change requires a documentation update

### What is the solution?

This will add a new `NOTE` section at the end of the Readme page of Cloud Spanner Handler containing a list of all the unsupported PostgreSQL features.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
- [x] Simple Documentation Update. The above checklist options are not applicable.
