### PR TITLE
[Docs] doc page for community tutorial links

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -142,7 +142,8 @@
                 {
                   "group": "Regression",
                   "pages": [
-                    "sql/tutorials/home-rentals"
+                    "sql/tutorials/home-rentals",
+                    "sql/tutorials/regression-community"
                   ]
                 }
               ]

--- a/docs/sql/tutorials/regression-community.mdx
+++ b/docs/sql/tutorials/regression-community.mdx
@@ -1,0 +1,90 @@
+---
+title: Tutorials by Our Community
+sidebarTitle: Tutorials by Our Community
+---
+
+Check out the articles and video guides created by our community:
+
+- Article on [Predict Tesla Stock Prices using MindsDB](https://dev.to/rutamhere/predict-tesla-stock-prices-using-mindsdb-40k5)
+by [Rutam Prita Mishra](https://community.ops.io/rutamhere)
+
+- Article on [Predicting Logistics Quality using MindsDB](https://dev.to/armanchand/predicting-logistics-quality-using-mindsdb-2n9d)
+by [Arman Chand](https://dev.to/armanchand)
+
+- Article on [Predict Wine Quality using MindsDB](https://dev.to/rutamhere/predict-wine-quality-using-mindsdb-1521)
+by [Rutam Prita Mishra](https://community.ops.io/rutamhere)
+
+- Article on [Predicting Life Expectancy using MindsDB Cloud](https://dev.to/armanchand/predicting-life-expectancy-using-mindsdb-cloud-3643)
+by [Arman Chand](https://dev.to/armanchand)
+
+- Article on [Predict Purchasing Power per Country using MindsDB](https://dev.to/rutamhere/predict-purchasing-power-per-country-using-mindsdb-1oh7)
+by [Rutam Prita Mishra](https://community.ops.io/rutamhere)
+
+- Article on [Predicting Data Science Job Salaries using MindsDB Cloud](https://community.ops.io/rutamhere/predicting-data-science-job-salaries-using-mindsdb-cloud-1lgn)
+by [Rutam Prita Mishra](https://community.ops.io/rutamhere)
+
+- Article on [Predicting Used Car Prices using MindsDB](https://tealfeed.com/predicting-used-car-prices-using-mindsdb-idzuc)
+by [Rutam Prita Mishra](https://community.ops.io/rutamhere)
+
+- Article on [Predicting Supermarket Future Sales Using Machine Learning with MindsDB](https://dev.to/ephraimx/predicting-future-sales-using-machine-learning-with-mindsdb-3p70)
+by [Ephraimx](https://dev.to/ephraimx)
+
+- Article on [Predict insurance cost using MindsDB](https://medium.com/@kinkusuma/predict-insurance-cost-using-mindsdb-54b6a331fea8)
+by [Kinie K Kusuma](https://medium.com/@kinkusuma)
+
+- Article on [Forecast bitcoin price using MindsDB](https://medium.com/@kinkusuma/forecast-bitcoin-price-using-mindsdb-75f9f0500e86)
+by [Kinie K Kusuma](https://medium.com/@kinkusuma)
+
+- Article on [Predicting car prices using MindsDB](https://medium.com/@pipboyguy/predicting-car-prices-using-mindsdb-c7dd51919b83)
+by [Marcel Coetzee](https://medium.com/@pipboyguy)
+
+- Article on [Predict Gold Prices Using MindsDB](https://medium.com/@alissatroianonyc/predict-gold-prices-using-mindsdb-9da57d24ddab)
+by [Alissa Troiano](https://github.com/alissatroiano)
+
+- Article on [MindsDB: Predicting Supply Chain Demand with Machine Learning using SQL](https://www.devforce.one/18303637/mindsdb-predicting-supply-chain-demand-with-machine-learning-using-sql#/)
+by [Chandre Van Der Westhuizen](https://github.com/chandrevdw31)
+
+- Article on [Predicting Mobile Phone Price using MindsDB Cloud](https://dev.to/armanchand/predicting-mobile-phone-price-using-mindsdb-cloud-23d5)
+by [Arman Chand](https://dev.to/armanchand)
+
+- Article on [Predicting Turbine Yield Energy using MindsDB](https://medium.com/@dhaneshvijay10/want-to-do-ml-without-knowing-ml-5f4934942019)
+by [DhaneshRagu](https://medium.com/@dhaneshvijay10)
+
+- Article on [Predicting Store Sales Data using MindsDB](https://dev.to/kevinheng/predict-store-sales-data-with-mindsdb-using-machine-learning-and-sql-2af8)
+by [Kevin Heng](https://github.com/HengKevin)
+
+- Article on [Using MindsDB to Predict Future Retail Sales](https://medium.com/@alissatroianonyc/using-mindsdb-to-predict-future-retail-sales-a300f63a086b)
+by [Alissa Troiano](https://github.com/alissatroiano)
+
+- Article on [Predicting the Rating of Cars using Mindsdb](https://atharva08.hashnode.dev/predicting-the-rating-of-cars-using-mindsdb)
+by [Atharva Shirdhankar](https://github.com/StarTrooper08)
+
+- Article on [Gold price prediction using MindsDB](https://dev.to/purgecodee/predicting-gold-price-with-mindsdb-205n)
+by [Pritish Sinha](https://github.com/Pritish-Sinha)
+
+- Article on [Predicting Environment Impact of Food Production caused by C02 Emission](https://dev.to/tesprogram/predicting-environment-impact-of-food-production-caused-by-c02-emission-51e3)
+by [Teslim Odumuyiwa](https://github.com/Tes-program)
+
+- Article on [Using MindsDB to Predict Amazon Rainforest Degradation](https://medium.com/@alissatroianonyc/nusing-mindsdb-to-predict-amazon-rainforest-degradation-1ccb8e993e48)
+by [Alissa Troiano](https://github.com/alissatroiano)
+
+- Article on [Using MindsDB to Predict Microsoft Stock Prices ](https://dev.to/viveknshah/using-mindsdb-to-predict-microsoft-stock-prices-3l79)
+by [Vivek Shah](https://github.com/viveknshah)
+
+- Article on [Predicting Home Rental Prices with MindsDB in Java](https://curiousprogrammer.hashnode.dev/machine-learning-with-mindsdb-in-java)
+by [Temidayo](https://hashnode.com/@Temicoder)
+
+- Video guide on [Exploring Learning Hub on MindsDB by predicting house rental prices and forecasting house sales](https://youtu.be/Qmk_v0iginw)
+by [@akhilcoder](https://twitter.com/akhilcoder)
+
+- Video guide on [CREATE Predictor with USING statement using Cement Manufacturing Dataset Civil Engineering](https://www.youtube.com/watch?v=aLP7KLolUSs&t=2s)
+by [Teslim Odumuyiwa](https://github.com/Tes-program)
+
+- Video guide on [Predict house prices with MindsDB](https://www.youtube.com/watch?v=p2j696YgFN4)
+by [HellFire](https://github.com/Artemis6969)
+
+- Video guide on [Regression Tutorial - Home Rentals](https://youtu.be/qf4HQ4EzaUU) by
+[Teslim Odumuyiwa](https://github.com/Tes-program)
+
+- Video guide on [Predicting car prices with MindsDB](https://www.youtube.com/watch?v=pYSlYBjukNA)
+by [Syed Zubeen](https://github.com/syedzubeen)


### PR DESCRIPTION
## Description

Created a doc page to contain the community tutorial links (Tutorials -> Regression -> Tutorials by Our Community)

**Fixes** #4729

## Type of change

(Please delete options that are not relevant)

- [x] 📄 This change requires a documentation update

### What is the solution?

This feature was implemented by following instructions outlined in https://github.com/mindsdb/mindsdb/issues/4729

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
