### PR TITLE
Fix parsing error on amazon redshift docs page

### DIFF
--- a/docs/data-integrations/amazon-redshift.mdx
+++ b/docs/data-integrations/amazon-redshift.mdx
@@ -23,8 +23,7 @@ The required arguments to establish a connection are,
 
 ## Usage
 Before attempting to connect to a Redshift cluster using MindsDB, ensure that it accepts incoming connections. The following can be used as a guideline to accomplish this,
-<br>
-https://aws.amazon.com/premiumsupport/knowledge-center/cannot-connect-redshift-cluster/
+  https://aws.amazon.com/premiumsupport/knowledge-center/cannot-connect-redshift-cluster
 
 In order to make use of this handler and connect to a Redshift cluster in MindsDB, the following syntax can be used,
 ```sql


### PR DESCRIPTION
## Description

Fixes parsing error present on the Amazon Redshift documentation page.

**Fixes** #4761 

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


### What is the solution?

Removed the `<br>` tag that was causing the parsing issue.

