### PR TITLE
Simplify file name detection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,5 @@ pydateinfer==0.3.0
 pyarrow >= 9.0.0, < 10.0.0
 dataprep_ml
 grpcio-tools
+python-magic >= 0.4.27
+openpyxl >= 3.1.1


### PR DESCRIPTION
## Description

This PR resolves #4747 by adding the missing dependency installed in the old version by mindsdb_datasources. Also, the 
type guessing for xlsx, xsl files was not working as expected, and sometimes the file type was guessed as CSV so the data wasn't displayed correctly

**Fixes** #4747, #4912

>NOTE: We should simplify the guessing type and re use the py magic for all file types.

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

Install missing openpyxl library and use pythohn-magic for file guessing type.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
