### PR TITLE
Updated pip install docs (MacOS) by adding a command to start MindsD

### DIFF
--- a/docs/setup/self-hosted/pip/macos.mdx
+++ b/docs/setup/self-hosted/pip/macos.mdx
@@ -105,6 +105,13 @@ export CPPFLAGS="-I/usr/local/opt/libomp/include"
    ...
    ```
 
+5. Start MindsDB:
+
+    ```bash
+    python -m mindsdb
+    ```
+
+
 ## Using Anaconda
 
 Here, you need either [Anaconda](https://www.anaconda.com/products/individual)


### PR DESCRIPTION
## Description

**Solved the issue #4838 to Update the pip install docs (MacOS) by adding a command to start MindsDB**

## Type of change

- [x] 📄 This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have updated the documentation or created issues to update them.
