### PR TITLE
Fixed Dependencies for the d0lt Handler

### DIFF
--- a/mindsdb/integrations/handlers/d0lt_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/d0lt_handler/requirements.txt
@@ -1,1 +1,1 @@
-mysql-connector-python
+pymysql


### PR DESCRIPTION
The `d0lt` handler has been implemented by inheriting from the the `matrixone` handler. The only dependency for the `matrixone` handler is the `pymysql` package,
![image](https://user-images.githubusercontent.com/49385643/224528667-69f1d3a0-eb24-4932-94b5-f2cda8e57d2b.png)

As the `d0lt` implementation is inheriting from this handler, the only dependency for it should also be `pymysql`, however, the previous dependency listed for it was `mysql-connector-python`.

This has been fixed by adding the correct dependency and the logs stating that the handler cannot be used (https://github.com/mindsdb/mindsdb/issues/4548) are no longer visible,
![image](https://user-images.githubusercontent.com/49385643/224528843-c39a8198-46d7-42c1-86ff-5942c3882f19.png)
