### PR TITLE
Fixed Dependencies in MySQL and Postgres Handlers

### DIFF
--- a/mindsdb/integrations/handlers/aurora_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/aurora_handler/requirements.txt
@@ -1,4 +1,3 @@
 psycopg[binary] >= 1.15.3
-docker >= 5.0.3
 mysql-connector-python
 boto3

--- a/mindsdb/integrations/handlers/aurora_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/aurora_handler/requirements.txt
@@ -1,3 +1,3 @@
-psycopg[binary] >= 1.15.3
+psycopg[binary]
 mysql-connector-python
 boto3

--- a/mindsdb/integrations/handlers/cloud_sql_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/cloud_sql_handler/requirements.txt
@@ -1,4 +1,3 @@
 psycopg[binary] >= 1.15.3
-docker >= 5.0.3
 mysql-connector-python
 pymssql >= 2.1.4

--- a/mindsdb/integrations/handlers/cloud_sql_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/cloud_sql_handler/requirements.txt
@@ -1,3 +1,3 @@
-psycopg[binary] >= 1.15.3
+psycopg[binary]
 mysql-connector-python
 pymssql >= 2.1.4

--- a/mindsdb/integrations/handlers/cockroach_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/cockroach_handler/requirements.txt
@@ -1,1 +1,1 @@
-psycopg[binary] >= 1.15.3
+psycopg[binary]

--- a/mindsdb/integrations/handlers/mysql_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/mysql_handler/requirements.txt
@@ -1,2 +1,1 @@
-docker >= 5.0.3
 mysql-connector-python

--- a/mindsdb/integrations/handlers/opengauss_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/opengauss_handler/requirements.txt
@@ -1,1 +1,1 @@
-psycopg[binary] >= 1.15.3
+psycopg[binary]

--- a/mindsdb/integrations/handlers/orioledb_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/orioledb_handler/requirements.txt
@@ -1,1 +1,1 @@
-psycopg[binary] >= 1.15.3
+psycopg[binary]

--- a/mindsdb/integrations/handlers/postgres_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/postgres_handler/requirements.txt
@@ -1,1 +1,1 @@
-psycopg[binary] >= 1.15.3
+psycopg[binary]

--- a/mindsdb/integrations/handlers/questdb_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/questdb_handler/requirements.txt
@@ -1,1 +1,1 @@
-psycopg[binary] >= 1.15.3
+psycopg[binary]

--- a/mindsdb/integrations/handlers/supabase_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/supabase_handler/requirements.txt
@@ -1,1 +1,1 @@
-psycopg[binary] >= 1.15.3
+psycopg[binary]

--- a/mindsdb/integrations/handlers/timescaledb_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/timescaledb_handler/requirements.txt
@@ -1,1 +1,1 @@
-psycopg[binary] >= 1.15.3
+psycopg[binary]


### PR DESCRIPTION
The following dependency requirements have been resolved below,

- The `docker` dependency has been removed from the MySQL as it has not been used anywhere. The same requirement has been removed from two other handlers that use this handler: Amazon Aurora and Google Cloud SQL
- The `psycopg[binary]` dependency in the Postgres handler and all other handlers that inherit from it has been updated as the version specified does not seem to exist as mentioned here: https://github.com/mindsdb/mindsdb/issues/4555. I have tested out the Postgres handler with the new version of the dependency by spinning up a Docker container and it seems to be working fine.