### PR TITLE
Fixed Dependencies for the trino Handler

### DIFF
--- a/mindsdb/integrations/handlers/trino_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/trino_handler/requirements.txt
@@ -1,2 +1,3 @@
 trino~=0.313.0
 requests-kerberos==0.12.0
+pyhive


### PR DESCRIPTION
The `pyhive` package which is used in the implementation of the `trino` handler was not included in the `requirements.txt` file. As a result, the trino handler was unusable. This has been fixed.