### PR TITLE
[Docs] Updated title of the MySQL Question Answering tutorial

### DIFF
--- a/docs/nlp/question-answering-inside-mysql-with-openai.mdx
+++ b/docs/nlp/question-answering-inside-mysql-with-openai.mdx
@@ -1,6 +1,6 @@
 ---
-title: Question Answering on MySQL with MindsDB and OpenAI
-sidebarTitle: MySQL Question Answering
+title: Question Answering with MindsDB and OpenAI using SQL
+sidebarTitle: Question Answering using SQL
 ---
 
 ## Introduction


### PR DESCRIPTION
## Description

Changed the values of `title` and `sidebarTitle` to read as follows:

`title: Question Answering with MindsDB and OpenAI using SQL 
sidebarTitle: Question Answering using SQL
`

**Fixes** #5006

## Checklist:

- [x] I have updated the documentation
