### PR TITLE
fix: Table formatting in feature-eng.mdx (#4130)

### DIFF
--- a/docs/sql/feature-eng.mdx
+++ b/docs/sql/feature-eng.mdx
@@ -80,17 +80,54 @@ Let's prepare and verify the data. Here, we create the views and query them to e
 
     Where:
 
-    | Name           | Description                                                 |
-    |----------------|-------------------------------------------------------------|
-    | `model`        | Model of the car.                                           |
-    | `year`         | Year of production.                                         |
-    | `price`        | Price of the car.                                           |
-    | `transmission` | Transmission (`Manual`, or `Automatic`, or `Semi-Auto`).    |
-    | `mileage`      | Mileage of the car.                                         |
-    | `fueltype`     | Fuel type of the car.                                       |
-    | `tax`          | Tax.                                                        |
-    | `mpg`          | Miles per gallon.                                           |
-    | `enginesize`   | Engine size of the car.                                     |
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>model</code></td>
+          <td>Model of the car.</td>
+        </tr>
+        <tr>
+          <td><code>year</code></td>
+          <td>Year of production.</td>
+        </tr>
+        <tr>
+          <td><code>price</code></td>
+          <td>Price of the car.</td>
+        </tr>
+        <tr>
+          <td><code>transmission</code></td>
+          <td>Transmission (<code>Manual</code>, or <code>Automatic</code>, or <code>Semi-Auto</code>).</td>
+        </tr>
+        <tr>
+          <td><code>mileage</code></td>
+          <td>Mileage of the car.</td>
+        </tr>
+        <tr>
+          <td><code>fueltype</code></td>
+          <td>Fuel type of the car.</td>
+        </tr>
+        <tr>
+          <td><code>tax</code></td>
+          <td>Tax.</td>
+        </tr>
+        <tr>
+          <td><code>mpg</code></td>
+          <td>Miles per gallon.</td>
+        </tr>
+        <tr>
+          <td><code>enginesize</code></td>
+          <td>Engine size of the car.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <br />
 
   </Tab>
   <Tab title="Using the Base Table + 2 More Columns">


### PR DESCRIPTION
## Description

- Fix table formatting in feature-eng.mdx tabs by adding table structure instead of using markdown table

**Fixes** #(4130)

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📄 This change requires a documentation update

### What is the solution?

The table tags are rendered directly instead of converting the markdown table.

<img width="836" alt="image" src="https://user-images.githubusercontent.com/17215044/227759723-fed7dfb8-b3cd-419d-838e-4910e6f9433e.png">

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
