### PR TITLE
Openai missing required keys test

### DIFF
--- a/tests/handler_tests/test_openai_handler.py
+++ b/tests/handler_tests/test_openai_handler.py
@@ -3,7 +3,7 @@ import pytest
 
 from mindsdb.api.mysql.mysql_proxy.libs.constants.response_type import RESPONSE_TYPE
 from integration_tests.flows.http_test_helpers import HTTPHelperMixin
-from integration_tests.flows.conftest import *
+from integration_tests.flows.conftest import *  # noqa: F403,F401
 
 # used by (required for) mindsdb_app fixture in conftest
 API_LIST = [
@@ -24,4 +24,3 @@ class TestOpenAIHandler(HTTPHelperMixin):
             api_key = '{OPEN_AI_API_KEY}';
         """
         self.sql_via_http(query, RESPONSE_TYPE.ERROR)
-


### PR DESCRIPTION
## Description

An integration test for testing missing USING clause keys validation in the OpenAI handler.

**Fixes** #5111

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### What is the solution?

Added integration test in `test/handlers/test_openai_handler.py` using fixtures from other integration tests.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, or created issues to update them.
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] I have shared a short loom video or screenshots demonstrating any new functionality.
