### PR TITLE
Add singlestore.mdx file to docs navigation

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -337,7 +337,8 @@
             "data-integrations/oceanbase",
             "data-integrations/mariadb",
             "data-integrations/amazon-s3",
-            "data-integrations/oracle"
+            "data-integrations/oracle",
+            "data-integrations/singlestore"
           ]
         },
         {


### PR DESCRIPTION
## Description

Add the singlestore.mdx file to docs navigation.

This allows navigation to that page inside the documentation.

**Fixes** #5315 

## Type of change

(Please delete options that are not relevant)

- [ ] 📄 This change requires a documentation update

### What is the solution?

The "data-integrations/singlestore" page was included in the `docs/mint.json` file. 

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
