### PR TITLE
solved 5385-parsing error in the docs

### DIFF
--- a/docs/data-integrations/DynamoDB.mdx
+++ b/docs/data-integrations/DynamoDB.mdx
@@ -7,7 +7,7 @@ This is the implementation of the DynamoDB handler for MindsDB.
 
 ## DynamoDB
 Amazon DynamoDB is a fully managed, serverless, key-value NoSQL database designed to run high-performance applications at any scale. DynamoDB offers built-in security, continuous backups, automated multi-Region replication, in-memory caching, and data export tools.
-<br>
+<br/>
 https://aws.amazon.com/dynamodb/
 
 ## Implementation


### PR DESCRIPTION
## Description

The DynamoDB.mdx file had a small error that caused a parsing error. The issue consisted of a `<br>` not being closed correctly. 

**Fixes** #5385 

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)

### What is the solution?

The `<br>` was  changed to `<br/>` which now allows the page to be rendered correctly.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
