### PR TITLE
remove html tags

### DIFF
--- a/docs/data-integrations/PostgreSQL.mdx
+++ b/docs/data-integrations/PostgreSQL.mdx
@@ -2,13 +2,13 @@
 title: PostgreSQL
 sidebarTitle: PostgreSQL
 ---
-<br>
+
 
 This is the implementation of the PostgreSQL handler for MindsDB.
 
 ## PostgreSQL
 PostgreSQL is a powerful, open source object-relational database system that uses and extends the SQL language combined with many features that safely store and scale the most complicated data workloads.
-<br>
+
 https://www.postgresql.org
 
 ## Syntax


### PR DESCRIPTION
Currently, the page https://docs.mindsdb.com/data-integrations/PostgreSQL fails to render

I assume the reason are the HTML tags in the markdown page

## Description

Please include a summary of the change and the issue it solves. 

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
