### PR TITLE
Added a step in Windows installation guide

### DIFF
--- a/docs/setup/self-hosted/pip/windows.mdx
+++ b/docs/setup/self-hosted/pip/windows.mdx
@@ -31,6 +31,12 @@ Or you could try to install MindsDB with
 [Anaconda](https://www.anaconda.com/products/individual) and run the
 installation from the **Anaconda prompt**.
 
+In addition, for Windows systems with default languages other than English, your system 
+might not have UTF-8 as the default encoding standard, which will cause encoding errors 
+when installing dependencies. To solve this issue, go to 
+`Control Panel` > `Clock and Region` > `Region` > `Administrative tab` > 
+`Change system locale button` and enable `Beta: Use Unicode UTF-8 for worldwide language support`.
+
 ### Installing torch or torchvision
 
 If the installation fails when installing **torch** or **torchvision**, try to


### PR DESCRIPTION
This step resolves the encoding error on Windows systems with default encoding standards other than UTF-8.

## Description

Added a step in the Windows installation guide to solve a Windows system's common encoding issue.

**Fixes** #5478 

## Type of change

(Please delete options that are not relevant)

- [x] 📄 This change requires a documentation update

### What is the solution?

Added a step for users to enable the beta feature of windows, which allows the system to use the UTF-8 encoding standard.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, or created issues to update them.
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] I have shared a short loom video or screenshots demonstrating any new functionality.
