### PR TITLE
docs: added instructions to start mongodb api

### DIFF
--- a/docs/setup/self-hosted/pip/linux.mdx
+++ b/docs/setup/self-hosted/pip/linux.mdx
@@ -106,6 +106,12 @@ installed. It is to avoid the `No module named mindsdb` error.
    ```bash
    python -m mindsdb
    ```
+   
+By default, MindsDB will always start the `http` and `mysqul` APIs. If you want to use Mongo API, you will need to provide that as a parameter to `--api`. You can do it as following:
+
+   ```bash
+   python -m mindsdb --api=http,mongodb,mysql
+   ```
 
 ## Using Anaconda
 

--- a/docs/setup/self-hosted/pip/macos.mdx
+++ b/docs/setup/self-hosted/pip/macos.mdx
@@ -109,6 +109,11 @@ export CPPFLAGS="-I/usr/local/opt/libomp/include"
     python -m mindsdb
     ```
 
+By default, MindsDB will always start the `http` and `mysqul` APIs. If you want to use Mongo API, you will need to provide that as a parameter to `--api`. You can do it as following:
+
+   ```bash
+   python -m mindsdb --api=http,mongodb,mysql
+   ```
 
 ## Using Anaconda
 

--- a/docs/setup/self-hosted/pip/source.mdx
+++ b/docs/setup/self-hosted/pip/source.mdx
@@ -86,6 +86,12 @@ error, please report it on our
    python -m mindsdb
    ```
 
+By default, MindsDB will always start the `http` and `mysqul` APIs. If you want to use Mongo API, you will need to provide that as a parameter to `--api`. You can do it as following:
+
+   ```bash
+   python -m mindsdb --api=http,mongodb,mysql
+   ```
+
 6. Now, you can access the following:
 
 <CodeGroup>

--- a/docs/setup/self-hosted/pip/windows.mdx
+++ b/docs/setup/self-hosted/pip/windows.mdx
@@ -99,6 +99,12 @@ install them manually by following the instructions on their
    python -m mindsdb
    ```
 
+By default, MindsDB will always start the `http` and `mysqul` APIs. If you want to use Mongo API, you will need to provide that as a parameter to `--api`. You can do it as following:
+
+   ```bash
+   python -m mindsdb --api=http,mongodb,mysql
+   ```
+
 ## Using Anaconda
 
 Here, you need either [Anaconda](https://www.anaconda.com/products/individual)


### PR DESCRIPTION
## Description

Added instructions of how to run `mongodb` API in the docs in setup via `pip`

Fixes #5544

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)