### PR TITLE
In the updated setup.py file, the dependency_links argument is remove…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,18 +32,15 @@ def install_deps():
     """
     default = open('requirements.txt', 'r').readlines()
     new_pkgs = []
-    links = []
     for resource in default:
         if 'git+https' in resource:
             pkg = resource.split('#')[-1]
-            links.append(resource.strip() + '-9876543210')
-            new_pkgs.append(pkg.replace('egg=', '').rstrip())
+            new_pkgs.append(resource.strip() + '-9876543210')
         else:
             new_pkgs.append(resource.strip())
-    return new_pkgs, links
+    return new_pkgs
 
-
-pkgs, new_links = install_deps()
+pkgs = install_deps()
 
 setup(
     name=about['__title__'],
@@ -58,7 +55,6 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(),
     install_requires=pkgs,
-    dependency_links=new_links,
     include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
…d because it is deprecated and not recommended by the latest versions of pip.

Instead of using dependency_links, the URLs of the required packages from private repositories are specified directly in the install_requires list using the git+https syntax.

Therefore, in the install_deps() function, the links list is not needed anymore because it was used to generate the dependency_links argument. The function now only needs to return the new_pkgs list containing the names of the required packages.

## Description

Please include a summary of the change and the issue it solves. 

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, or created issues to update them.
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
