### PR TITLE
Hierarchical forecast v2 - integration with Neuralforecast handler

### DIFF
--- a/mindsdb/integrations/handlers/neuralforecast_handler/README.md
+++ b/mindsdb/integrations/handlers/neuralforecast_handler/README.md
@@ -33,6 +33,10 @@ Users can specify `train_time` as a USING arg (see example in PR). `train_time` 
 
 Users can define `exogenous_vars` as a USING arg. These are complementary variables in the table that may improve forecast accuracy. Pass this as a list of strings e.g. `USING exogenous_vars=['var_1', 'var_2']`
 
+Users can optionally define a hierarchy to the data, with the "hierarchy" arg.
+The model will reconcile forecasts according to the hierarchy, which may improve their accuracy.
+This is further explained in https://github.com/mindsdb/mindsdb/pull/5605
+
 # Does this integration offer model explainability or insights via the DESCRIBE syntax?
 Yes - see https://github.com/mindsdb/mindsdb/pull/5445 for an example of how to call the DESCRIBE method.
 

--- a/mindsdb/integrations/handlers/neuralforecast_handler/neuralforecast_handler.py
+++ b/mindsdb/integrations/handlers/neuralforecast_handler/neuralforecast_handler.py
@@ -99,7 +99,6 @@ class NeuralForecastHandler(BaseMLEngine):
         """
         # Load model arguments
         model_args = self.model_storage.json_get("model_args")
-        training_df = dill.loads(self.model_storage.file_get("training_df"))
 
         prediction_df = transform_to_nixtla_df(df, model_args)
         groups_to_keep = prediction_df["unique_id"].unique()
@@ -107,6 +106,7 @@ class NeuralForecastHandler(BaseMLEngine):
         neural = NeuralForecast.load(model_args["model_folder"])
         forecast_df = neural.predict()
         if model_args["hierarchy"]:
+            training_df = dill.loads(self.model_storage.file_get("training_df"))
             hier_df = dill.loads(self.model_storage.file_get("hier_df"))
             hier_dict = dill.loads(self.model_storage.file_get("hier_dict"))
             reconciled_df = reconcile_forecasts(training_df, forecast_df, hier_df, hier_dict)

--- a/mindsdb/integrations/handlers/neuralforecast_handler/neuralforecast_handler.py
+++ b/mindsdb/integrations/handlers/neuralforecast_handler/neuralforecast_handler.py
@@ -1,4 +1,5 @@
 from sklearn.metrics import r2_score
+import dill
 import pandas as pd
 import tempfile
 from mindsdb.integrations.libs.base import BaseMLEngine
@@ -6,7 +7,9 @@ from mindsdb.integrations.utilities.time_series_utils import (
     transform_to_nixtla_df,
     get_results_from_nixtla_df,
     infer_frequency,
-    get_model_accuracy_dict
+    get_model_accuracy_dict,
+    get_hierarchy_from_df,
+    reconcile_forecasts
 )
 from neuralforecast import NeuralForecast
 from neuralforecast.models import NHITS
@@ -65,11 +68,20 @@ class NeuralForecastHandler(BaseMLEngine):
         model_args["exog_vars"] = using_args["exogenous_vars"] if "exogenous_vars" in using_args else []
         model_args["model_folder"] = tempfile.mkdtemp()
 
+        # Deal with hierarchy
+        model_args["hierarchy"] = using_args["hierarchy"] if "hierarchy" in using_args else False
+        if model_args["hierarchy"]:
+            training_df, hier_df, hier_dict = get_hierarchy_from_df(df, model_args)
+            self.model_storage.file_set("hier_dict", dill.dumps(hier_dict))
+            self.model_storage.file_set("hier_df", dill.dumps(hier_df))
+            self.model_storage.file_set("training_df", dill.dumps(training_df))
+        else:
+            training_df = transform_to_nixtla_df(df, model_args, model_args["exog_vars"])
+
         # Train model
         model = choose_model(num_trials, time_settings["horizon"], time_settings["window"])
-        nixtla_df = transform_to_nixtla_df(df, model_args, model_args["exog_vars"])
         neural = NeuralForecast(models=[model], freq=model_args["frequency"])
-        results_df = neural.cross_validation(nixtla_df)
+        results_df = neural.cross_validation(training_df)
         # Get model accuracy
         model_args["accuracies"] = get_model_accuracy_dict(results_df, r2_score)
 
@@ -87,20 +99,27 @@ class NeuralForecastHandler(BaseMLEngine):
         """
         # Load model arguments
         model_args = self.model_storage.json_get("model_args")
+        training_df = dill.loads(self.model_storage.file_get("training_df"))
 
         prediction_df = transform_to_nixtla_df(df, model_args)
         groups_to_keep = prediction_df["unique_id"].unique()
 
         neural = NeuralForecast.load(model_args["model_folder"])
-        forecast_df = neural.predict(prediction_df)
-        forecast_df = forecast_df[forecast_df.index.isin(groups_to_keep)]
-        return get_results_from_nixtla_df(forecast_df, model_args)
+        forecast_df = neural.predict()
+        if model_args["hierarchy"]:
+            hier_df = dill.loads(self.model_storage.file_get("hier_df"))
+            hier_dict = dill.loads(self.model_storage.file_get("hier_dict"))
+            reconciled_df = reconcile_forecasts(training_df, forecast_df, hier_df, hier_dict)
+            results_df = reconciled_df[reconciled_df.index.isin(groups_to_keep)]
+        else:
+            results_df = forecast_df[forecast_df.index.isin(groups_to_keep)]
+        return get_results_from_nixtla_df(results_df, model_args)
 
     def describe(self, attribute=None):
         model_args = self.model_storage.json_get("model_args")
 
         if attribute == "model":
-            return pd.DataFrame({k: [model_args[k]] for k in ["model_name", "frequency"]})
+            return pd.DataFrame({k: [model_args[k]] for k in ["model_name", "frequency", "hierarchy"]})
 
         if attribute == "features":
             return pd.DataFrame(

--- a/mindsdb/integrations/utilities/time_series_utils.py
+++ b/mindsdb/integrations/utilities/time_series_utils.py
@@ -111,10 +111,13 @@ def get_hierarchy_from_df(df, model_args):
     in tests/unit/ml_handlers/test_time_series_utils.py for an example.
     """
     spec = spec_hierarchy_from_list(model_args["hierarchy"])
+
     nixtla_df = df.rename({model_args["order_by"]: "ds", model_args["target"]: "y"}, axis=1)
+    nixtla_df["ds"] = pd.to_datetime(nixtla_df["ds"])
     for col in model_args["group_by"]:
         nixtla_df[col] = nixtla_df[col].astype(str)  # grouping columns need to be string format
     nixtla_df.insert(0, "Total", "total")
+
     nixtla_df, hier_df, hier_dict = aggregate(nixtla_df, spec)  # returns (nixtla_df, hierarchy_df, hierarchy_dict)
     return nixtla_df, hier_df, hier_dict
 

--- a/tests/unit/ml_handlers/test_neuralforecast.py
+++ b/tests/unit/ml_handlers/test_neuralforecast.py
@@ -140,3 +140,42 @@ class TestNeuralForecast(BaseExecutorTest):
 
         describe_features = self.run_sql("describe proj.model_exog_var.features")
         assert describe_features["exog_vars"][0] == ["exog_var_1"]
+
+    @patch("mindsdb.integrations.handlers.postgres_handler.Handler")
+    def test_hierarchical(self, mock_handler):
+        # create project
+        self.run_sql("create database proj")
+        df = pd.read_csv("tests/unit/ml_handlers/data/house_sales.csv")  # comes mindsdb docs forecast example
+        self.set_handler(mock_handler, name="pg", tables={"df": df})
+
+        self.run_sql(
+            """
+           create model proj.model_1_group
+           from pg (select * from df)
+           predict ma
+           order by saledate
+           group by type, bedrooms
+           horizon 4
+           window 8
+           using
+             engine='neuralforecast',
+             hierarchy=['type', 'bedrooms'],
+             train_time=0.01
+        """
+        )
+        self.wait_predictor("proj", "model_1_group")
+
+        # run predict
+        mindsdb_result_hier = self.run_sql(
+            """
+           SELECT p.*
+           FROM pg.df as t
+           JOIN proj.model_1_group as p
+           where t.type='house'
+        """
+        )
+        print(mindsdb_result_hier)
+        assert len(list(round(mindsdb_result_hier["ma"])))
+
+        describe_result = self.run_sql("describe proj.model_1_group.model")
+        assert describe_result["hierarchy"][0] == ["type", "bedrooms"]

--- a/tests/unit/ml_handlers/test_neuralforecast.py
+++ b/tests/unit/ml_handlers/test_neuralforecast.py
@@ -174,7 +174,6 @@ class TestNeuralForecast(BaseExecutorTest):
            where t.type='house'
         """
         )
-        print(mindsdb_result_hier)
         assert len(list(round(mindsdb_result_hier["ma"])))
 
         describe_result = self.run_sql("describe proj.model_1_group.model")


### PR DESCRIPTION
## Description

Implement hierarchical reconciliation for Nixtla's Neuralforecast handler.

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)


### What is the solution?

We added hierarchical reconciliation using a similar method to the Statsforecast handler.

Also added a new unit test and updated the describe method.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, or created issues to update them.
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] I have shared a short loom video or screenshots demonstrating any new functionality.

### Model creation
```
CREATE MODEL 
  mindsdb.nf_hier
FROM example_db
  (SELECT * FROM demo_data.house_sales)
PREDICT ma
ORDER BY saledate
GROUP BY type, bedrooms
-- as the target is quarterly, we will look back two years to forecast the next one
WINDOW 8
HORIZON 4
USING engine='neuralforecast', train_time=0.01, hierarchy=['type', 'bedrooms']
;
```
![image](https://user-images.githubusercontent.com/29843907/231491697-cb6e92d8-5cd7-499b-b43b-664eeae2571e.png)

### Prediction
```
 SELECT m.saledate as date, m.ma as forecast
  FROM mindsdb.nf_hier as m 
  JOIN example_db.demo_data.house_sales as t
  WHERE t.saledate > LATEST and t.type='house' and t.bedrooms=4
  LIMIT 4;
```
![image](https://user-images.githubusercontent.com/29843907/231491808-11aafc15-9bb2-42c1-b32c-d25cb0bee525.png)

### Describe
```DESCRIBE mindsdb.nf_hier.model;```
![image](https://user-images.githubusercontent.com/29843907/231491906-620376b0-f5c8-4978-aef1-1af730e97286.png)

