### PR TITLE
Removed wrong implementation section

### DIFF
--- a/docs/data-integrations/planet-scale.mdx
+++ b/docs/data-integrations/planet-scale.mdx
@@ -10,10 +10,6 @@ This is the implementation of the PlanetScale data integration for MindsDB.
 ##Implementation
 This handler is implemented using the planetscaledb library. Please install it before using this handler:
 
-```bash
-pip install planetscaledb
-```
-
 The required arguments to establish a connection are,
 * `host`: the host name or IP address 
 * `port`: the TCP/IP port number


### PR DESCRIPTION
## Description
pip install for `planetscaledb` does not exist's. Removed the block of code

**Fixes** #5603 


