### PR TITLE
Use Binance US endpoint instead of Binance Global endpoint

### DIFF
--- a/mindsdb/integrations/handlers/binance_handler/binance_handler.py
+++ b/mindsdb/integrations/handlers/binance_handler/binance_handler.py
@@ -12,6 +12,8 @@ from mindsdb.integrations.libs.response import (
 from mindsdb.utilities import log
 from mindsdb_sql import parse_sql
 
+_BASE_BINANCE_US_URL = 'https://api.binance.us'
+
 
 class BinanceHandler(APIHandler):
     """A class for handling connections and interactions with the Binance API.
@@ -55,9 +57,9 @@ class BinanceHandler(APIHandler):
             return self.client
 
         if self.api_key and self.api_secret:
-            self.client = Spot(key=self.api_key, secret=self.api_secret)
+            self.client = Spot(key=self.api_key, secret=self.api_secret, base_url=_BASE_BINANCE_US_URL)
         else:
-            self.client = Spot()
+            self.client = Spot(base_url=_BASE_BINANCE_US_URL)
 
         self.is_connected = True
         return self.client


### PR DESCRIPTION
## Description

The global Binance API endpoint has a list of restricted countries, and includes the United States. Therefore, all API requests from the US are rejected. [See their terms here](https://www.binance.com/en/terms)

We need to use the Binance US API endpoint, where only certain states (Hawaii, New York, Texas and Vermont) are blocked.

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

