### PR TITLE
[Docs] Update feedback buttons configuration

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -11,6 +11,10 @@
     "light": "#55D799",
     "dark": "#117866"
   },
+  "feedback": {
+    "suggestEdit": true,
+    "raiseIssue": true
+  },
   "openapi": "https://raw.githubusercontent.com/mindsdb/mindsdb/openapi-specs/mindsdb/api/http/openapi.yml",
   "api": {
     "baseUrl": [


### PR DESCRIPTION
## Description

Mintlify recently changed its configuration schema for feedback buttons. The new configuration hides it by default but enables it using

```json
"feedback": {
   "suggestEdit": true,
   "raiseIssue": true
}
```

![CleanShot 2023-04-15 at 13 19 19@2x](https://user-images.githubusercontent.com/44352119/232251571-3aabc6d1-6bdb-4da3-901f-942d801029ad.png)

## Type of change

- [x] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📄 This change requires a documentation update

### What is the solution?

Updates the documentation configuration to use the proper schema
