### PR TITLE
Added <> from the oceandocs title and site-title

### DIFF
--- a/docs/data-integrations/oceanbase.mdx
+++ b/docs/data-integrations/oceanbase.mdx
@@ -1,6 +1,6 @@
 ---
-title: <OceanBase>
-sidebarTitle: <OceanBase>
+title: OceanBase
+sidebarTitle: OceanBase
 ---
 
 # OceanBase Handler


### PR DESCRIPTION
## Description

This PR updates the documentation by removing the < and > operators from the title and sidebar title for improved readability and consistency.

**Fixes** #(5632)

## Type of change

- [x] 📄 This change requires a documentation update

### What is the solution?

The solution involved removing the < and > operators from the title and sidebar title in the documentation files. This was achieved by updating the relevant Markdown files to use plain text instead of these operators.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
