### PR TITLE
Init lexer parsers on start

### DIFF
--- a/mindsdb/api/http/start.py
+++ b/mindsdb/api/http/start.py
@@ -8,6 +8,7 @@ from mindsdb.api.http.initialize import initialize_app
 from mindsdb.interfaces.storage import db
 from mindsdb.utilities import log
 from mindsdb.utilities.config import Config
+from mindsdb.utilities.functions import init_lexer_parsers
 
 
 def start(verbose, no_studio, with_nlp):
@@ -16,6 +17,8 @@ def start(verbose, no_studio, with_nlp):
     server = os.environ.get('MINDSDB_DEFAULT_SERVER', 'waitress')
     db.init()
     log.initialize_log(config, 'http', wrap_print=True if server.lower() != 'gunicorn' else False)
+
+    init_lexer_parsers()
 
     app = initialize_app(config, no_studio, with_nlp)
 

--- a/mindsdb/api/mongo/start.py
+++ b/mindsdb/api/mongo/start.py
@@ -1,12 +1,15 @@
 from mindsdb.utilities.config import Config
 from mindsdb.api.mongo.server import run_server
-from mindsdb.utilities.log import initialize_log
 from mindsdb.interfaces.storage import db
+from mindsdb.utilities.log import initialize_log
+from mindsdb.utilities.functions import init_lexer_parsers
 
 
 def start(verbose=False):
     config = Config()
     db.init()
+    init_lexer_parsers()
+
     initialize_log(config, 'mongodb', wrap_print=True)
 
     run_server(config)

--- a/mindsdb/api/mysql/start.py
+++ b/mindsdb/api/mysql/start.py
@@ -1,11 +1,13 @@
 from mindsdb.api.mysql.mysql_proxy.mysql_proxy import MysqlProxy
-from mindsdb.utilities.config import Config
 import mindsdb.interfaces.storage.db as db
+from mindsdb.utilities.config import Config
 from mindsdb.utilities import log
+from mindsdb.utilities.functions import init_lexer_parsers
 
 
 def start(verbose=False):
     db.init()
+    init_lexer_parsers()
 
     config = Config()
 

--- a/mindsdb/utilities/functions.py
+++ b/mindsdb/utilities/functions.py
@@ -101,4 +101,3 @@ def get_versions_where_predictors_become_obsolete():
 def init_lexer_parsers():
     get_lexer_parser('mindsdb')
     get_lexer_parser('mysql')
-    get_lexer_parser('sqlite')

--- a/mindsdb/utilities/functions.py
+++ b/mindsdb/utilities/functions.py
@@ -3,6 +3,7 @@ import datetime
 from functools import wraps
 
 import requests
+from mindsdb_sql import get_lexer_parser
 
 from mindsdb.utilities.fs import create_process_mark, delete_process_mark
 
@@ -95,3 +96,9 @@ def get_versions_where_predictors_become_obsolete():
 
     versions_for_updating_predictors = [x for x in versions_for_updating_predictors if len(x) > 0]
     return True, versions_for_updating_predictors
+
+
+def init_lexer_parsers():
+    get_lexer_parser('mindsdb')
+    get_lexer_parser('mysql')
+    get_lexer_parser('sqlite')


### PR DESCRIPTION
## Description

Add loading of parsers at start of api. Therefore parser won't be loading on first query. That saves about 3s for first query processing.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

Added loading of parsers to start of api

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
