### PR TITLE
StatsForecast - minor frequency patch

### DIFF
--- a/mindsdb/integrations/handlers/statsforecast_handler/statsforecast_handler.py
+++ b/mindsdb/integrations/handlers/statsforecast_handler/statsforecast_handler.py
@@ -34,6 +34,7 @@ def get_season_length(frequency):
     season_dict = {  # https://pandas.pydata.org/docs/user_guide/timeseries.html#timeseries-offset-aliases
         "H": 24,
         "M": 12,
+        "MS": 12,
         "Q": 4,
         "SM": 24,
         "BM": 12,


### PR DESCRIPTION
## Description

Pandas sometimes calls monthly frequency "MS" (month start). 

This was omitted in the first implementation, so it assumed season length of 1 rather than 12 for MS data.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### What is the solution?

Added row for the new frequency.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
