### PR TITLE
Fix: only 1 part in create database command

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/executor/executor_commands.py
+++ b/mindsdb/api/mysql/mysql_proxy/executor/executor_commands.py
@@ -5,7 +5,7 @@ from functools import reduce
 
 import pandas as pd
 from mindsdb_sql.parser.dialects.mindsdb import (
-    CreateDatasource,
+    CreateDatabase,
     RetrainPredictor,
     CreatePredictor,
     FinetunePredictor,
@@ -145,7 +145,7 @@ class ExecuteCommands:
             sql = self.executor.sql
             sql_lower = self.executor.sql_lower
 
-        if type(statement) == CreateDatasource:
+        if type(statement) == CreateDatabase:
             return self.answer_create_database(statement)
         elif type(statement) == CreateMLEngine:
             return self.answer_create_ml_engine(statement)
@@ -871,7 +871,10 @@ class ExecuteCommands:
             statement (ASTNode): data for creating database/project
         """
 
-        database_name = statement.name
+        if len(statement.name.parts) != 1:
+            raise Exception("Database name should contain only 1 part.")
+
+        database_name = statement.name.parts[0]
         engine = statement.engine
         if engine is None:
             engine = "mindsdb"

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ walrus==0.8.2
 flask-compress >= 1.0.0
 kafka-python >= 2.0.0
 appdirs >= 1.0.0
-git+https://github.com/mindsdb/mindsdb_sql.git@staging
 checksumdir >= 1.2.0
 mindsdb-streams == 0.1.1
 duckdb == 0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ walrus==0.8.2
 flask-compress >= 1.0.0
 kafka-python >= 2.0.0
 appdirs >= 1.0.0
-mindsdb-sql >= 0.6.0, < 0.7.0
+git+ssh://git@github.com/mindsdb/mindsdb_sql.git@staging
 checksumdir >= 1.2.0
 mindsdb-streams == 0.1.1
 duckdb == 0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ walrus==0.8.2
 flask-compress >= 1.0.0
 kafka-python >= 2.0.0
 appdirs >= 1.0.0
-mindsdb-sql >= 0.5.2, < 0.6.0
+mindsdb-sql >= 0.6.0, < 0.7.0
 checksumdir >= 1.2.0
 mindsdb-streams == 0.1.1
 duckdb == 0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ walrus==0.8.2
 flask-compress >= 1.0.0
 kafka-python >= 2.0.0
 appdirs >= 1.0.0
-mindsdb-sql >= 0.5.1, < 0.6.0
+mindsdb-sql >= 0.5.2, < 0.6.0
 checksumdir >= 1.2.0
 mindsdb-streams == 0.1.1
 duckdb == 0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ walrus==0.8.2
 flask-compress >= 1.0.0
 kafka-python >= 2.0.0
 appdirs >= 1.0.0
-git+ssh://git@github.com/mindsdb/mindsdb_sql.git@staging
+git+https://github.com/mindsdb/mindsdb_sql.git@staging
 checksumdir >= 1.2.0
 mindsdb-streams == 0.1.1
 duckdb == 0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ walrus==0.8.2
 flask-compress >= 1.0.0
 kafka-python >= 2.0.0
 appdirs >= 1.0.0
+mindsdb-sql >= 0.6.1, < 0.7.0
 checksumdir >= 1.2.0
 mindsdb-streams == 0.1.1
 duckdb == 0.4.0


### PR DESCRIPTION
Changes:
- is not possible to use:
```
 create database aa.bb
```
- if you need to create database with '.' in name need to use '`' symbol:
```
 create database `aa.bb`

-- for drop:
 drop database `aa.bb`
```


Fix #5616

## Description

Please include a summary of the change and the issue it solves. 

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
