### PR TITLE
Adding an optional Postgres connection parameter sslmode

### DIFF
--- a/mindsdb/integrations/handlers/postgres_handler/postgres_handler.py
+++ b/mindsdb/integrations/handlers/postgres_handler/postgres_handler.py
@@ -38,7 +38,7 @@ class PostgresHandler(DatabaseHandler):
 
     def connect(self):
         """
-        Handles the connection to a PostgreSQL database insance.
+        Handles the connection to a PostgreSQL database instance.
         """
         if self.is_connected is True:
             return self.connection
@@ -50,6 +50,9 @@ class PostgresHandler(DatabaseHandler):
             'password': self.connection_args.get('password'),
             'dbname': self.connection_args.get('database')
         }
+
+        if self.connection_args.get('sslmode'):
+            config['sslmode'] = self.connection_args.get('sslmode')
 
         if self.connection_args.get('schema'):
             config['options'] = f'-c search_path={self.connection_args.get("schema")},public'
@@ -137,7 +140,7 @@ class PostgresHandler(DatabaseHandler):
 
     def get_tables(self) -> Response:
         """
-        List all tabels in PostgreSQL without the system tables information_schema and pg_catalog
+        List all tables in PostgreSQL without the system tables information_schema and pg_catalog
         """
         query = """
             SELECT


### PR DESCRIPTION
## Description
Adding an optional Postgres connection parameter sslmode to toggle disable/enable encryption. 
Fixing misspellings.

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Issue

Local Postgres instances are often configured without encryption (e.g. official Postgres docker instances).
Mindsdb only supports encrypted connections to Postgres because of psycopg default.
As a result of psycopg default, Mindsdb fails to connect to a local docker Postgres instance.


### What is the solution?

Add an optional sslmode connection parameter that can be set to 'disable' for unencrypted Postgres connections.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.