### PR TITLE
fix typos in openai nlp documentation

### DIFF
--- a/docs/nlp/nlp-mindsdb-openai.mdx
+++ b/docs/nlp/nlp-mindsdb-openai.mdx
@@ -27,9 +27,9 @@ CREATE MODEL project_name.predictor_name        -- AI TABLE TO STORE THE MODEL
 PREDICT target_column                           -- NAME OF THE COLUMN TO STORE PREDICTED VALUES
 USING
   engine = 'openai',                            -- USING THE OPENAI ENGINE
-  prompt_template = 'promt/task
+  prompt_template = 'prompt/task
                     {{input_column}}',          -- PROMPT TEMPLATE WITH PLACEHOLDERS FOR INPUT COLUMNS
-  model_name = 'model_name',                    -- OPTIONAL, DEFAULT IS THE text-davinci-002 MODEL
+  model_name = 'model_name',                    -- OPTIONAL, DEFAULT IS THE gpt-3.5-turbo MODEL
   api_key = 'YOUR_OPENAI_API_KEY';              -- OPTIONAL, IF NOT PASSED MINDSDB FETCHES THE
                                                 -- `OPENAI_API_KEY` ENVIRONMENT VARIABLE VALUE
 ```


### PR DESCRIPTION
## Description

This PR just fixes a typo in the page https://docs.mindsdb.com/nlp/nlp-mindsdb-openai, `promt -> prompt` and also changes the name of default openai model which is `gpt-3.5-turbo`.

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📄 This change requires a documentation update

### What is the solution?

just updated the docs

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
