### PR TITLE
MindsDB Text to SQL

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/executor/executor.py
+++ b/mindsdb/api/mysql/mysql_proxy/executor/executor.py
@@ -200,7 +200,7 @@ class Executor:
                 try:
                     from mindsdb_text_to_sql import GPTTextToSQL
 
-                    text_to_sql = GPTTextToSQL(os.getenv('OPENAI_API_KEY'))
+                    text_to_sql = GPTTextToSQL(self._get_openai_api_key())
                     query = text_to_sql.convert_text_to_sql(sql)
                     logger.info("%s.parse: converted query - %s", self.__class__.__name__, query)
                     self.query = parse_sql(query, dialect="mindsdb")

--- a/mindsdb/api/mysql/mysql_proxy/executor/executor.py
+++ b/mindsdb/api/mysql/mysql_proxy/executor/executor.py
@@ -182,26 +182,43 @@ class Executor:
 
     @profiler.profile()
     def parse(self, sql):
+        print('parse')
         logger.info("%s.parse: sql - %s", self.__class__.__name__, sql)
         self.sql = sql
         sql_lower = sql.lower()
         self.sql_lower = sql_lower.replace("`", "")
 
-        try:
-            self.query = parse_sql(sql, dialect="mindsdb")
-        except Exception as mdb_error:
-            try:
-                self.query = parse_sql(sql, dialect="mysql")
-            except Exception:
-                # not all statements are parsed by parse_sql
-                logger.warning(f"SQL statement is not parsed by mindsdb_sql: {sql}")
+        from mindsdb_text_to_sql import TextToSQL
 
-                raise SqlApiException(
-                    f"SQL statement cannot be parsed by mindsdb_sql - {sql}: {mdb_error}"
-                ) from mdb_error
+        text_to_sql = TextToSQL('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')
+        query = text_to_sql.convert_text_to_sql(sql)
+        self.query = parse_sql(query, dialect="mindsdb")
+        print(self.query)
 
-                # == a place for workarounds ==
-                # or run sql in integration without parsing
+        # try:
+        #     self.query = parse_sql(sql, dialect="mindsdb")
+        # except Exception as mdb_error:
+        #     try:
+        #         self.query = parse_sql(sql, dialect="mysql")
+        #     except Exception:
+        #         try:
+        #             from mindsdb_text_to_sql import TextToSQL
+        #
+        #             text_to_sql = TextToSQL('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')
+        #             query = text_to_sql.convert_text_to_sql(sql)
+        #             print(query)
+        #             self.query = query
+        #
+        #         except Exception:
+        #             # not all statements are parsed by parse_sql
+        #             logger.warning(f"SQL statement is not parsed by mindsdb_sql: {sql}")
+        #
+        #             raise SqlApiException(
+        #                 f"SQL statement cannot be parsed by mindsdb_sql - {sql}: {mdb_error}"
+        #             ) from mdb_error
+
+                    # == a place for workarounds ==
+                    # or run sql in integration without parsing
 
     @profiler.profile()
     def do_execute(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ dataprep_ml
 grpcio-tools
 python-magic >= 0.4.27
 openpyxl >= 3.1.1
+mindsdb-text-to-sql


### PR DESCRIPTION
Hey @ZoranPandovski,
As discussed this is my PR for the new feature I have working on (as part of the hackathon) to allow users to interact with MindsDB by using natural language.

Essentially, this has been implemented using the new package I have developed called `mindsdb-text-to-sql`,
https://github.com/MinuraPunchihewa/mindsdb-text-to-sql

The release that I have created so far makes use of the OpenAI API to accomplish the conversion of text to SQL. However, I am also working on a LangChain implementation that creates an index out of publicly available documentation on MindsDB. The source code for this feature can be found here,
https://github.com/MinuraPunchihewa/mindsdb-text-to-sql/tree/feature/langchain_index

In general, I believe that the LangChain implementation is better because it can make use of the documentation available. I have implemented so that it actually scrapes URLs provided (through a configuration file) to find the other required links, for example, the links to all of the supported data integrations. As a result, the index will keep updating each time new documentation becomes available.

The downside to this implementation is the fact that the Python packages required by the `UnstructuredURLLoader` of LangChain to parse these documents is quite heavy. The size of the Python environment environment that I used to develop this feature is 5.2 GB.

If I am to talk about the actual implementation that I have created here, the flow is generally as follows,
- As before, the `executor` will first try to parse the query provided using `mindsdb` and `mysql` dialects first. If this fails, the `mindsdb-text-to-sql` package will attempt to convert this query to SQL (this assumes that if the query cannot be parsed using the first couple of methods, it is natural language)
- Next, the SQL obtained as a result of this conversion will be passed into the `parse_sql` method and executed

So, the only change made here has been to the `executor`, but the conversion logic is part of the `mindsdb-text-to-sql` package.

If I am to talk about the execution of the package (OpenAI implementation), it is as follows,
- A bunch of examples of common commands that are run on MindsDB (CREATE DATABASE, CREATE MODEL etc.) are included in a configuration file (config/examples.json) are mapped against corresponding natural language prompts
- Each time a command is sent to the API for conversion, these examples are used to 'prime' the model, i.e. they are sent across as part of the prompt that the API can refer

Given below is an entire ML workload that I have run using this, from creating a data source to making predictions using a model,
```
Create a connection called gsheets_datasource to the Google Sheet with spreadsheet_id '1sk9Pa5Bd3a75zQZJngggRvqwhbPpfsrR3gbINdpCAx8' and sheet_name 'twitter_data'

Get the top 10 records of the twitter_data table of the gsheets_datasource

Create an engine called openai_engine with the api_key 'sk-...'

Create a model called mindsdb.oi_sentiment_classifier using the openai_engine engine to predict sentiment using the prompt_template 'predict the sentiment of the text:{{review}} exactly as either positive or negative or neutral'

Check the status of the mindsdb.oi_sentiment_classifier model

Predict the sentiment of the review 'This was the worst movie ever!' using the model mindsdb.oi_sentiment_classifier

Predict the sentiments of the twitter_data table of the gsheets_datasource using the mindsdb.oi_sentiment_classifier model
```
Please note that some of the commands run here are somewhat similar to the examples included, however, I believe this will work with commands that are different as well.

I would love to hear your thoughts, especially on the following,
- What do you believe the next steps should be?
- Should I continue with the LangChain implementation despite the issues with the size of the packages?
- If the LangChain implementation is the way to move forward, will what I have done here suffice as a MVP?

FYI: @paxcema.