### PR TITLE
fix neuralforecast dependency

### DIFF
--- a/docker/release
+++ b/docker/release
@@ -76,7 +76,9 @@ RUN python -m pip install --prefer-binary --no-cache-dir --upgrade pip==22.1.2 &
         teradatasql teradatasqlalchemy || true \
     pip install --prefer-binary --no-cache-dir \
         sqlalchemy-sqlany sqlanydb || true \
-    pip install --prefer-binary --no-cache-dir openai==0.27.0 || true
+    pip install --prefer-binary --no-cache-dir openai==0.27.0 || true \
+    pip install --prefer-binary --no-cache-dir \
+        'neuralforecast>=1.4.0, <1.5.0' 'hierarchicalforecast<1.0' 'hyperopt<1.0' || true
 
 ARG VERSION=
 RUN pip install --no-cache-dir mindsdb${VERSION:+"==$VERSION"}

--- a/mindsdb/integrations/handlers/neuralforecast_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/neuralforecast_handler/requirements.txt
@@ -1,3 +1,3 @@
-neuralforecast>=1.4.0, <2.0
+neuralforecast>=1.4.0, <1.5.0
 hierarchicalforecast<1.0
 hyperopt<1.0


### PR DESCRIPTION
## Description

Last version of `neuralforecast` use pytorch==2.0, which cause dependency conflict with Lightwood. For now version of `neuralforecast` bounded with `<1.5.0`.

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
