### PR TITLE
Updated Docker Self-host Tutorial docker.mdx

### DIFF
--- a/docs/setup/self-hosted/docker.mdx
+++ b/docs/setup/self-hosted/docker.mdx
@@ -4,14 +4,14 @@ sidebarTitle: Docker
 ---
 
 <iframe
-  className="w-full h-96"
-  width="628"
-  height="286"
-  src="https://www.youtube.com/embed/Bmuavy0MelQ"
-  title="Deploy MindsDB using Docker"
-  frameborder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
+    className="w-full h-96"
+    width="628"
+    height="286"
+    src="https://www.youtube.com/embed/Bmuavy0MelQ"
+    title="Deploy MindsDB using Docker"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
 ></iframe>
 
 ## Install Docker
@@ -46,7 +46,19 @@ Run the command below to start MindsDB in Docker.
 docker run -p 47334:47334 -p 47335:47335 mindsdb/mindsdb
 ```
 
+If you wish to simply spin up the container without the logs, run the following command:
+
+```bash
+docker run -d -p 47334:47334 -p 47335:47335 mindsdb/mindsdb
+```
+
+What's the difference?
+
+-   On running the previous command, docker will print out all the mindsdb logs in your shell.
+-   Using Docker's `detach` flag, the CLI will simply return the container ID, such that you can use the same shell again for different things.
+
 If you would like to persist your models & configurations in the host machine, run the following commands:
+
 ```bash
 mkdir mdb_data
 docker run -p 47334:47334 -p 47335:47335 -v $(pwd)/mdb_data:/root/mdb_storage mindsdb/mindsdb
@@ -54,12 +66,12 @@ docker run -p 47334:47334 -p 47335:47335 -v $(pwd)/mdb_data:/root/mdb_storage mi
 
 Let's analyze this command part by part:
 
-- `docker run` is a native Docker command used to start a container
-- `-p 47334:47334` publishes port 47334 to access MindsDB GUI and HTTP
-  API
-- `-p 47335:47335` publishes port 47335 to access MindsDB MySQL API
-- `-v $(pwd)/mdb_data:/root/mdb_storage` maps the newly created folder mdb_data on the host machine to the /root/mdb_storage inside the container.
-- `mindsdb/mindsdb` is the container we want to start
+-   `docker run` is a native Docker command used to start a container
+-   `-p 47334:47334` publishes port 47334 to access MindsDB GUI and HTTP
+    API
+-   `-p 47335:47335` publishes port 47335 to access MindsDB MySQL API
+-   `-v $(pwd)/mdb_data:/root/mdb_storage` maps the newly created folder mdb_data on the host machine to the /root/mdb_storage inside the container.
+-   `mindsdb/mindsdb` is the container we want to start
 
 ## Default Configuration
 
@@ -68,38 +80,38 @@ as below.
 
 ```json
 {
-  "config_version": "1.4",
-  "storage_dir": "/root/mdb_storage",
-  "log": {
-    "level": {
-      "console": "ERROR",
-      "file": "WARNING",
-      "db": "WARNING"
-    }
-  },
-  "debug": false,
-  "integrations": {},
-    "auth":{
+    "config_version": "1.4",
+    "storage_dir": "/root/mdb_storage",
+    "log": {
+        "level": {
+            "console": "ERROR",
+            "file": "WARNING",
+            "db": "WARNING"
+        }
+    },
+    "debug": false,
+    "integrations": {},
+    "auth": {
         "username": "mindsdb",
         "password": "123"
     },
-  "api": {
-      "http": {
-          "host": "127.0.0.1",
-          "port": "47334"
-      },
-      "mysql": {
-          "host": "127.0.0.1",
-          "port": "47335",
-          "database": "mindsdb",
-          "ssl": true
-      },
-      "mongodb": {
-          "host": "127.0.0.1",
-          "port": "47336",
-          "database": "mindsdb"
-      }
-  }
+    "api": {
+        "http": {
+            "host": "127.0.0.1",
+            "port": "47334"
+        },
+        "mysql": {
+            "host": "127.0.0.1",
+            "port": "47335",
+            "database": "mindsdb",
+            "ssl": true
+        },
+        "mongodb": {
+            "host": "127.0.0.1",
+            "port": "47336",
+            "database": "mindsdb"
+        }
+    }
 }
 ```
 
@@ -111,10 +123,13 @@ To override the default configuration, you can provide values via the
 ```bash
 docker run -e MDB_CONFIG_CONTENT='{"api":{"http": {"host": "0.0.0.0","port": "8080"}}}' mindsdb/mindsdb
 ```
+
 <Warning>
-Note that changing only one API value will not override the default values for other API keys. For e.g if you want to change the values for `mysql api` include the 
-values for `http api` too since it will not be started. This should be resolved soon, 
-check the progress [here](https://github.com/mindsdb/mindsdb/issues/4058).
+    Note that changing only one API value will not override the default values
+    for other API keys. For e.g if you want to change the values for `mysql api`
+    include the values for `http api` too since it will not be started. This
+    should be resolved soon, check the progress
+    [here](https://github.com/mindsdb/mindsdb/issues/4058).
 </Warning>
 
 ## Known Issues
@@ -130,6 +145,6 @@ docker run -e MKL_SERVICE_FORCE_INTEL=1 -p 47334:47334 -p 47335:47335 mindsdb/mi
 ```
 
 <Tip>
-**What's next?** We recommend you follow one of our tutorials or learn more about the
-[MindsDB Database](/sql/table-structure/).
+    **What's next?** We recommend you follow one of our tutorials or learn more
+    about the [MindsDB Database](/sql/table-structure/).
 </Tip>


### PR DESCRIPTION
## Description

I've simply made one addition to the Docker self-hosting tutorial to mention Docker's `detach` flag. I noticed it when I self-hosted it on AWS and I thought it might be a handy addition.

My writing may not be as documentation-friendly, so I'm open to any language-related changes if required :)

## Type of change

- [x] 📄 Documentation Update

## Checklist:

- [x] I have updated the documentation.
