### PR TITLE
ML ENGINES in mongo

### DIFF
--- a/mindsdb/api/mongo/README.md
+++ b/mindsdb/api/mongo/README.md
@@ -312,6 +312,32 @@ db.sales_model.stats({'scale':'ensemble'})
 db.predictors.deleteOne({'name': "sales_model"})
 ```
 
+## ML Engines
+
+**Create**
+
+`CREATE ml_engine ...` alternative in mongo:
+
+```
+db.ml_engines.insertOne({'name': "openai_2", "handler": "openai", "params": {"api_key": "qqq"}})
+```
+
+**List**
+
+`SHOW ml_engines` alternative in mongo:
+
+```
+db.ml_engines.find()
+```
+
+**Delete**
+
+`DROP ml_engine ...` alternative in mongo:
+
+```
+db.ml_engines.deleteOne({"name": "openai_2"})
+```
+
 ## Jobs
 
 **Create**

--- a/mindsdb/api/mongo/responders/delete.py
+++ b/mindsdb/api/mongo/responders/delete.py
@@ -1,7 +1,7 @@
 from mindsdb.api.mongo.classes import Responder
 import mindsdb.api.mongo.functions as helpers
 from mindsdb_sql.parser.ast import Delete, Identifier, BinaryOperation, Constant
-from mindsdb_sql.parser.dialects.mindsdb import DropPredictor, DropJob
+from mindsdb_sql.parser.dialects.mindsdb import DropPredictor, DropJob, DropMLEngine
 from mindsdb.interfaces.jobs.jobs_controller import JobsController
 
 from mindsdb.api.mongo.classes.query_sql import run_sql_command
@@ -32,8 +32,9 @@ class Responce(Responder):
 
         project_name = request_env['database']
 
-        if table not in ('models_versions', 'models', 'jobs'):
-            raise Exception("Only REMOVE from 'models' or 'jobs' collection is supported at this time")
+        allowed_tables = ('models_versions', 'models', 'jobs', 'ml_engines')
+        if table not in allowed_tables:
+            raise Exception(f"Only removing from this collections is supported: {', '.join(allowed_tables)}")
 
         if len(query['deletes']) != 1:
             raise Exception("Should be only one argument in REMOVE operation")
@@ -98,6 +99,10 @@ class Responce(Responder):
 
         elif table == 'jobs':
             ast_query = DropJob(Identifier(parts=[project_name, obj_name]))
+            run_sql_command(request_env, ast_query)
+
+        elif table == 'ml_engines':
+            ast_query = DropMLEngine(Identifier(parts=[obj_name]))
             run_sql_command(request_env, ast_query)
 
         return {

--- a/mindsdb/api/mongo/responders/find.py
+++ b/mindsdb/api/mongo/responders/find.py
@@ -1,6 +1,6 @@
 from bson.int64 import Int64
 
-from mindsdb_sql.parser.ast import Join, Select, Identifier, Describe
+from mindsdb_sql.parser.ast import Join, Select, Identifier, Describe, Show
 import mindsdb.api.mongo.functions as helpers
 from mindsdb.api.mongo.classes import Responder
 from mindsdb.api.mongo.utilities.mongodb_ast import MongoToAst
@@ -86,7 +86,7 @@ class Responce(Responder):
             }
 
         # system queries
-        if query['find'] == 'system.version':
+        elif query['find'] == 'system.version':
             # For studio3t
             data = [{
                 "_id": "featureCompatibilityVersion",
@@ -102,7 +102,11 @@ class Responce(Responder):
                 'ok': 1
             }
 
-        ast_query = find_to_ast(query, database)
+        elif query['find'] == 'ml_engines':
+            ast_query = Show('ml_engines')
+
+        else:
+            ast_query = find_to_ast(query, database)
 
         # add _id for objects
         table_name = None

--- a/mindsdb/api/mongo/responders/insert.py
+++ b/mindsdb/api/mongo/responders/insert.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
-from mindsdb_sql.parser.dialects.mindsdb import CreatePredictor, CreateJob, RetrainPredictor, FinetunePredictor
+from mindsdb_sql.parser.dialects.mindsdb import CreatePredictor, CreateJob, RetrainPredictor, FinetunePredictor,\
+    CreateMLEngine
 from mindsdb_sql.parser.ast import Identifier, OrderBy, Insert, TableColumn, Constant
 
 import mindsdb.api.mongo.functions as helpers
@@ -210,6 +211,17 @@ class Responce(Responder):
             )
             run_sql_command(request_env, ast_query)
 
+    def _insert_ml_enine(self, query, request_env, mindsdb_env):
+        for doc in query['documents']:
+
+            ast_query = CreateMLEngine(
+                name=Identifier(doc['name']),
+                handler=doc['handler'],
+                params=doc['params']
+            )
+
+            run_sql_command(request_env, ast_query)
+
     def _result(self, query, request_env, mindsdb_env):
         table = query['insert']
 
@@ -221,6 +233,9 @@ class Responce(Responder):
 
         elif table == 'jobs':
             self._insert_job(query, request_env, mindsdb_env)
+
+        elif table == 'ml_engines':
+            self._insert_ml_enine(query, request_env, mindsdb_env)
 
         else:
             # regular insert

--- a/tests/unit/test_mongodb_server.py
+++ b/tests/unit/test_mongodb_server.py
@@ -225,6 +225,36 @@ class TestMongoDBServer(BaseUnitTest):
         expected_sql = "DELETE FROM myproj.models_versions WHERE name = 'house_sales_model5' and version=112"
         assert parse_sql(expected_sql, 'mindsdb').to_string() == ast.to_string()
 
+    # ml engines
+
+    def t_create_ml_engine(self, client_con, mock_executor):
+
+        client_con.myproj.ml_engines.insert_one({'name': "openai2", "handler": "openai", "params": {"api_key": "qqq"}})
+
+        ast = mock_executor.call_args[0][0]
+
+        expected_sql = "CREATE ML_ENGINE openai2 FROM openai USING api_key= 'qqq'"
+        assert parse_sql(expected_sql, 'mindsdb').to_string() == ast.to_string()
+
+    def t_list_ml_engines(self, client_con, mock_executor):
+
+        res = client_con.myproj.ml_engines.find({})
+        res = list(res)
+
+        ast = mock_executor.call_args[0][0]
+
+        expected_sql = "SHOW ML_ENGINES"
+        assert parse_sql(expected_sql, 'mindsdb').to_string() == ast.to_string()
+
+    def t_drop_ml_engine(self, client_con, mock_executor):
+
+        client_con.myproj.ml_engines.delete_one({'name': 'openai2'})
+
+        ast = mock_executor.call_args[0][0]
+
+        expected_sql = "DROP ML_ENGINE openai2"
+        assert parse_sql(expected_sql, 'mindsdb').to_string() == ast.to_string()
+
     def t_delete_model_version_by_id(self, client_con, mock_executor):
         # TODO
         #   delete model and version by _id


### PR DESCRIPTION

## Adding support of ML Engines in mongodb server


**Create**

`CREATE ml_engine ...` alternative in mongo:

```
db.ml_engines.insertOne({'name': "openai_2", "handler": "openai", "params": {"api_key": "qqq"}})
```

**List**

`SHOW ml_engines` alternative in mongo:

```
db.ml_engines.find()
```

**Delete**

`DROP ml_engine ...` alternative in mongo:

```
db.ml_engines.deleteOne({"name": "openai_2"})
```

resolves #5778

## Description

Please include a summary of the change and the issue it solves. 

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [x] ⚡ New feature (non-breaking change which adds functionality)


### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, or created issues to update them.
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
