### PR TITLE
Fix the monetdb handler

### DIFF
--- a/mindsdb/integrations/handlers/monetdb_handler/monetdb_handler.py
+++ b/mindsdb/integrations/handlers/monetdb_handler/monetdb_handler.py
@@ -130,7 +130,7 @@ class MonetDBHandler(DatabaseHandler):
         try:
             cur.execute(query)
                    
-            if cur._rows>0 :
+            if len(cur._rows)>0 :
                 result = cur.fetchall() 
                 response = Response(
                     RESPONSE_TYPE.TABLE,


### PR DESCRIPTION
- Change the monetdb_handler.py file
- Closes #5979

## Description

- Monetdb handler is comparing the list of result rows with a number which gives an error.


**Fixes** #5979 

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### What is the solution?

- To resolve this, I changed the comparison to the length of result rows with numbers.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
