### PR TITLE
Use args for BYOM

### DIFF
--- a/mindsdb/integrations/handlers/byom_handler/README.md
+++ b/mindsdb/integrations/handlers/byom_handler/README.md
@@ -24,3 +24,31 @@ Uploaded files
    - remove virtual environment if it was created
    - remove ml engine
 
+Using:
+
+1. Add args argument to train and predict methods:
+```
+class CustomPredictor():
+    def train(self, df, target_col, args=None):
+       ...
+       
+    def predict(self, df, args=None):
+       ...
+```
+
+2. Passing args to model training
+``` 
+create predictor pred 
+from files (select * from byom)
+predict Time
+using engine='uploaded_model',
+  param1=1, param2='2'
+```
+
+3. Passing args at predict
+```
+select * from files.byom t 
+join pred3 p
+using param1=1, param2='2'
+```
+

--- a/mindsdb/integrations/handlers/byom_handler/byom_handler.py
+++ b/mindsdb/integrations/handlers/byom_handler/byom_handler.py
@@ -40,7 +40,7 @@ class BYOMHandler(BaseMLEngine):
 
         model_proxy = self._get_model_proxy()
 
-        model_state = model_proxy.train(df, target)
+        model_state = model_proxy.train(df, target, args)
 
         self.model_storage.file_set('model', model_state)
 
@@ -63,12 +63,13 @@ class BYOMHandler(BaseMLEngine):
         self.model_storage.columns_set(columns)
 
     def predict(self, df, args=None):
+        pred_args = args.get('predict_params', {})
 
         model_proxy = self._get_model_proxy()
 
         model_state = self.model_storage.file_get('model')
 
-        pred_df = model_proxy.predict(df, model_state)
+        pred_df = model_proxy.predict(df, model_state, pred_args)
 
         return pred_df
 
@@ -195,24 +196,26 @@ class ModelWrapper:
         }
         return self._run_command(params)
 
-    def train(self, df, target):
+    def train(self, df, target, args):
         params = {
             'method': 'train',
             'df': pd_encode(df),
             'code': self.code,
-            'to_predict': target
+            'to_predict': target,
+            'args': args,
         }
 
         model_state = self._run_command(params)
         return model_state
 
-    def predict(self, df, model_state):
+    def predict(self, df, model_state, args):
 
         params = {
             'method': 'predict',
             'code': self.code,
             'df': pd_encode(df),
             'model_state': model_state,
+            'args': args,
         }
         pred_df = self._run_command(params)
         return pd_decode(pred_df)

--- a/mindsdb/integrations/handlers/byom_handler/proc_wrapper.py
+++ b/mindsdb/integrations/handlers/byom_handler/proc_wrapper.py
@@ -109,8 +109,13 @@ def main():
     if method == 'train':
         df = pd_decode(params['df'])
         to_predict = params['to_predict']
+        args = params['args']
         model = model_class()
-        model.train(df, to_predict)
+
+        call_args = [df, to_predict]
+        if args:
+            call_args.append(args)
+        model.train(*call_args)
 
         # return model
         data = model.__dict__
@@ -121,11 +126,15 @@ def main():
     elif method == 'predict':
         model_state = params['model_state']
         df = pd_decode(params['df'])
+        args = params['args']
 
         model = model_class()
         model.__dict__ = decode(model_state)
 
-        res = model.predict(df)
+        call_args = [df]
+        if args:
+            call_args.append(args)
+        res = model.predict(*call_args)
         return_output(pd_encode(res))
 
     raise NotImplementedError(method)


### PR DESCRIPTION
Using:

1. Add args argument to train and predict methods:
```
class CustomPredictor():
    def train(self, df, target_col, args=None):
       ...
       
    def predict(self, df, args=None):
       ...
```

2. Passing args to model training
``` 
create predictor pred 
from files (select * from byom)
predict Time
using engine='uploaded_model',
  param1=1, param2='2'
```

3. Passing args at predict
```
select * from files.byom t 
join pred3 p
using param1=1, param2='2'
```

fixes #5747

## Description

Please include a summary of the change and the issue it solves. 

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
