### PR TITLE
add: neuralforecast file to navigation

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -421,7 +421,8 @@
                 {
                   "group": "Nixtla",
                   "pages": [
-                    "nixtla/statsforecast"
+                    "nixtla/statsforecast",
+                    "nixtla/neuralforecast"
                   ]
                 }
               ]

--- a/docs/nixtla/neuralforecast.mdx
+++ b/docs/nixtla/neuralforecast.mdx
@@ -1,0 +1,8 @@
+---
+title: NeuralForecast
+sidebarTitle: NeuralForecast
+---
+
+<Note>
+This page is a work in progress.
+</Note>


### PR DESCRIPTION
## What does this PR do?

As mentioned in the issue #5991, created and added the neuralforecast file to navigation.
`in the directory docs/nixtla/` 

```
---
title: NeuralForecast
sidebarTitle: NeuralForecast
---

<Note>
This page is a work in progress.
</Note>
```

`in docs/mint.json`

```
 "group": "Time Series",
              "pages": [
                {
                  "group": "Nixtla",
                  "pages": [
                    "nixtla/statsforecast",
		    "nixtla/neuralforecast"
                  ]
```