### PR TITLE
Removed '"ml-engines/automl/xgboost"' in mint.json

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -397,7 +397,6 @@
               "pages": [
                 "ml-engines/automl/lightwood",
                 "ml-engines/automl/ludwig",
-                "ml-engines/automl/xgboost",
                 "ml-engines/automl/autosklearn"
               ]
             },


### PR DESCRIPTION
## Description

The issue was regarding the removal of the xgboost file from navigation. I made changes in the 
mint.json file where I removed the line '"ml-engines/automl/xgboost"' with the coma after.

**Fixes** #5986 

## Type of change

- [x] 📄 This change requires a documentation update

### What is the solution?

Going to the mint.json and removing '"ml-engines/automl/xgboost"' with the coma after, as instructed by @martyna-mindsdb 

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ x] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
