### PR TITLE
Update mindsdb.yml

### DIFF
--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -48,14 +48,6 @@ jobs:
       env:
         ACCESS_KEY:  ${{ secrets.GH_ACCESS_KEY }}
         mindsdb_github_masterkey: ${{secrets.mindsdb_github_masterkey}}
-    - name: Install dependencies Windows
-      run: |
-        if [ "$RUNNER_OS" == "Windows" ]; then
-          pip install torch==1.7.0+cpu torchvision==0.8.1+cpu -f https://download.pytorch.org/whl/torch_stable.html;
-        fi
-      shell: bash
-      env:
-        CHECK_FOR_UPDATES: False
     - name: Install staging mdb libraries if it's not mindsdb/stable
       if: ${{ github.ref != 'refs/heads/stable' }}
       run: |


### PR DESCRIPTION
## Description

Currently, all PRs fail because of this step. This PR removes the installation of Pytorch on Windows. This is not required in our CI tests since Lightwood is now optional, and this can be tested in Lightwood repo.

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

Remove not required test for installing pytorch on Windows.

