### PR TITLE
Drop 3.7 python support

### DIFF
--- a/.github/workflows/matrix_includes.json
+++ b/.github/workflows/matrix_includes.json
@@ -1,7 +1,7 @@
 [
     {
       "runs_on": "ubuntu-latest",
-      "python-version": 3.7,
+      "python-version": 3.9,
       "runOn": "always"
     },
     {

--- a/setup.py
+++ b/setup.py
@@ -64,5 +64,5 @@ setup(
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.7"
+    python_requires=">=3.8"
 )


### PR DESCRIPTION
## Description

Now we are having errors in CI because:

- Lightwood 23.5.1.0 requires torch >=2.0.0
- torch 2.0.0 doesn't support python 3.7

Changes in this PR:
- removing python 3.7 support by mindsdb package
- removing python 3.7 in CI workflow
- adding python 3.9 in CI workflow


## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
