### PR TITLE
Replace `threading.get_ident` to `threading.get_native_id`

### DIFF
--- a/mindsdb/interfaces/database/integrations.py
+++ b/mindsdb/interfaces/database/integrations.py
@@ -70,10 +70,9 @@ class HandlersCache:
             Args:
                 handler (DatabaseHandler)
         """
-        # print(f'!!!! set {handler.name} {ctx.company_id} {threading.get_ident()}')
         with self._lock:
             try:
-                key = (handler.name, ctx.company_id, threading.get_ident())
+                key = (handler.name, ctx.company_id, threading.get_native_id())
                 handler.connect()
                 self.handlers[key] = {
                     'handler': handler,
@@ -93,7 +92,7 @@ class HandlersCache:
                 DatabaseHandler
         """
         with self._lock:
-            key = (name, ctx.company_id, threading.get_ident())
+            key = (name, ctx.company_id, threading.get_native_id())
             if (
                 key not in self.handlers
                 or self.handlers[key]['expired_at'] < time()
@@ -109,7 +108,7 @@ class HandlersCache:
                 name (str): handler name
         """
         with self._lock:
-            key = (name, ctx.company_id, threading.get_ident())
+            key = (name, ctx.company_id, threading.get_native_id())
             if key in self.handlers:
                 try:
                     self.handlers[key].disconnect()

--- a/mindsdb/utilities/fs.py
+++ b/mindsdb/utilities/fs.py
@@ -51,7 +51,7 @@ def _get_process_mark_id(unified: bool = False) -> str:
         Returns:
             mark of process+thread
     '''
-    mark = f'{os.getpid()}-{threading.get_ident()}'
+    mark = f'{os.getpid()}-{threading.get_native_id()}'
     if unified is True:
         return mark
     return f"{mark}-{str(time.time()).replace('.', '')}"


### PR DESCRIPTION
## Description

Because of we do not support python 3.7 anymore, we can replace  `threading.get_ident` with `threading.get_native_id`. That will make debugging easier.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
