### PR TITLE
[Docs] Update Python versions in the /contribute/install doc page

### DIFF
--- a/docs/contribute/install.mdx
+++ b/docs/contribute/install.mdx
@@ -22,7 +22,7 @@ from source.
 Here, we recall the steps of MindsDB installation from source. You can either
 follow the steps below or visit the provided link.
 
-Before proceeding, make sure you have `Git` and `Python 3.7.x` or `Python 3.8.x`
+Before proceeding, make sure you have `Git` and `Python 3.8.x` or `Python 3.9.x`
 installed.
 
 1. Fork the MindsDB repository from


### PR DESCRIPTION
## Description
Update Python versions from  `3.8.x` to` 3.9.x` on the /contribute/install doc page.

issue: [6141](https://github.com/mindsdb/mindsdb/issues/6141)