### PR TITLE
docs: update python version in docs/setup/self-hosted/pip/linux.mdx

### DIFF
--- a/docs/setup/self-hosted/pip/linux.mdx
+++ b/docs/setup/self-hosted/pip/linux.mdx
@@ -21,10 +21,10 @@ installation. Please have a look at them below.
 
 ### Pip and Python Versions
 
-We suggest using **Python 3.7.x, 3.8.x, or 3.9.x versions** for now.
+We suggest using **Python 3.8.x, or 3.9.x versions** for now.
 
 To successfully install MindsDB, use **Python 64-bit version**. Also, make sure
-that **Python >= 3.7** and **pip >= 20.3**. You can check the pip and python
+that **Python >= 3.8** and **pip >= 20.3**. You can check the pip and python
 versions by running the `pip --version` and
 `python --version` commands.
 


### PR DESCRIPTION
## Description
This PR updates the python version in `docs/setup/self-hosted/pip/linux.mdx` (A guide for setting mindsdb on Linux locally) to min python `3.8.0`.

For more details regarding the issue, you can visit the following link: `Github Issue` https://github.com/mindsdb/mindsdb/issues/6138