### PR TITLE
Fetch OpenAI API key during handler creation

### DIFF
--- a/mindsdb/integrations/handlers/openai_handler/openai_handler.py
+++ b/mindsdb/integrations/handlers/openai_handler/openai_handler.py
@@ -64,7 +64,8 @@ class OpenAIHandler(BaseMLEngine):
         args = args['using']
 
         args['target'] = target
-        available_models = [m.openai_id for m in openai.Model.list().data]
+        api_key = self._get_openai_api_key(args)
+        available_models = [m.openai_id for m in openai.Model.list(api_key=api_key).data]
         if not args.get('model_name'):
             args['model_name'] = self.default_model
         elif args['model_name'] not in available_models:


### PR DESCRIPTION
## Description

The `openai.Model.list` method used during creation of an OpenAI handler requires an API key for authentication, and we were not providing one. This PR adds the api_key as an argument to fix any API key authentication issues.

## Type of change


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
