### PR TITLE
Port Value Update jupysql.mdx

### DIFF
--- a/docs/connect/jupysql.mdx
+++ b/docs/connect/jupysql.mdx
@@ -111,7 +111,7 @@ Please follow the instructions below to connect into your MindsDB via Jupysql an
         *Make sure* to update the user and password in the connection string.
         user - your Mindsdb Cloud email address is your username
         ```python
-        %sql mysql+pymysql://<mindsdb_user>:<mindsdb_pass>@<dedicated instace ip>:<port>/mindsdb
+        %sql mysql+pymysql://<mindsdb_user>:<mindsdb_pass>@<dedicated instace ip>:3306/mindsdb
         ```
 
         Testing connection by listing the existing tables (pure SQL):


### PR DESCRIPTION
## Description

Corrected the port value in the jupysql.mdx file.

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [ ] 📄 This change requires a documentation update

### What is the solution?

Replaced %sql mysql+pymysql://<mindsdb_user>:<mindsdb_pass>@<dedicated instace ip>:<port>/mindsdb with %sql mysql+pymysql://<mindsdb_user>:<mindsdb_pass>@<dedicated instace ip>:3306/mindsdb on line 114

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
