### PR TITLE
Port Value Update mysql-client.mdx

### DIFF
--- a/docs/connect/mysql-client.mdx
+++ b/docs/connect/mysql-client.mdx
@@ -33,7 +33,7 @@ installation or a MindsDB Cloud instance.
     ```
 
     ```bash MindsDB Pro
-    mysql -h <dedicated instace ip> --port <port> -u [mindsdb_cloud_username] -p [mindsdb_cloud_password]
+    mysql -h <dedicated instace ip> --port 3306 -u [mindsdb_cloud_username] -p [mindsdb_cloud_password]
     ```
 
 </CodeGroup>


### PR DESCRIPTION
## Description

Corrected the port value in the mysql-client.mdx file.

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [ ] 📄 This change requires a documentation update

### What is the solution?

Replaced %mysql -h <dedicated instace ip> --port <port> -u [mindsdb_cloud_username] -p [mindsdb_cloud_password] with %mysql -h <dedicated instace ip> --port 3306 -u [mindsdb_cloud_username] -p [mindsdb_cloud_password] on line 36

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
