### PR TITLE
[Docs] Correct port value in metabase #6186 -> Fixed

### DIFF
--- a/docs/connect/metabase.mdx
+++ b/docs/connect/metabase.mdx
@@ -75,7 +75,7 @@ Follow the steps below to connect your MindsDB to Metabase.
       Database type: `MySQL`
       Display name: `MindsDB`
       Host: `<dedicated instace ip>`
-      Port: <port>
+      Port: 3306
       Database name: `mindsdb`
       Username: `<your MindsDB Cloud username>`
       Password: `<your MindsDB Cloud password>`


### PR DESCRIPTION
I have read the CLA Document and I hereby sign the CLA

## Description

 Correct port value in metabase
 
 
**Fixes** #6186 

![image](https://github.com/mindsdb/mindsdb/assets/92156721/a45ce0a5-b33b-4738-8f71-7ec7b27864ae)
