### PR TITLE
Issue fixed Correct port value in mongo-shell #6190

### DIFF
--- a/docs/connect/mongo-shell.mdx
+++ b/docs/connect/mongo-shell.mdx
@@ -74,7 +74,7 @@ Let's look at the connection strings for both MindsDB Cloud and local installati
     mongodb://mindsdb_cloud_username:mindsdb_cloud_password@<dedicated instace ip>:<port>/?authMechanism=DEFAULT
     ```
 
-    It is similar to connecting MindsDB Cloud. Please replace the `mindsdb_cloud_username` placeholder with your MindsDB Cloud account email. Also, replace the `mindsdb_cloud_password` placeholder with your MindsDB Cloud password. The host value is the IP address of your dedicated instance and the port value is custom. We use the default authentication mechanism.
+    It is similar to connecting MindsDB Cloud. Please replace the `mindsdb_cloud_username` placeholder with your MindsDB Cloud account email. Also, replace the `mindsdb_cloud_password` placeholder with your MindsDB Cloud password. The host value is the IP address of your dedicated instance and the port value is 3306. We use the default authentication mechanism.
 
   </Tab>
 </Tabs>


### PR DESCRIPTION
changed 
It is similar to connecting MindsDB Cloud. Please replace the `mindsdb_cloud_username` placeholder with your MindsDB Cloud account email. Also, replace the `mindsdb_cloud_password` placeholder with your MindsDB Cloud password. The host value is the IP address of your dedicated instance and the port value is custom. We use the default authentication mechanism.

TO:
   It is similar to connecting MindsDB Cloud. Please replace the `mindsdb_cloud_username` placeholder with your MindsDB Cloud account email. Also, replace the `mindsdb_cloud_password` placeholder with your MindsDB Cloud password. The host value is the IP address of your dedicated instance and the port value is 3306. We use the default authentication mechanism.

