### PR TITLE
Fix Frappe API Handler to be Able to Fetch All Document Fields

### DIFF
--- a/mindsdb/integrations/handlers/frappe_handler/frappe_handler.py
+++ b/mindsdb/integrations/handlers/frappe_handler/frappe_handler.py
@@ -96,14 +96,11 @@ class FrappeHandler(APIHandler):
 
     def _get_documents(self, params: Dict = None) -> pd.DataFrame:
         client = self.connect()
-        limit = None
-        filters = None
         doctype = params['doctype']
-        if 'limit' in params:
-            limit = params['limit']
-        if 'filters' in params:
-            filters = params['filters']
-        documents = client.get_documents(doctype, limit=limit, filters=filters)
+        limit = params.get('limit', None)
+        filters = params.get('filters', None)
+        fields = params.get('fields', None)
+        documents = client.get_documents(doctype, limit=limit, fields=fields, filters=filters)
         return pd.DataFrame.from_records([self._document_to_dataframe_row(doctype, d) for d in documents])
 
     def _create_document(self, params: Dict = None) -> pd.DataFrame:

--- a/mindsdb/integrations/handlers/frappe_handler/frappe_tables.py
+++ b/mindsdb/integrations/handlers/frappe_handler/frappe_tables.py
@@ -35,6 +35,8 @@ class FrappeDocumentsTable(APITable):
 
         if query.limit:
             params['limit'] = query.limit.value
+        if filters:
+            params['filters'] = filters
 
         if 'name' in params:
             document_data = self.handler.call_frappe_api(


### PR DESCRIPTION
## Description

The [REST API docs](https://frappeframework.com/docs/v14/user/en/api/rest) are misleading, since `GET` requests to `https` URLs actually **don't** work with `fields`, `filters`, and other parameters. You actually need to use `http`, but only requests *with* a trailing slash will actually redirect properly. For example, `https://example-frappe.com/api/resource/Expense%20Claim?fields=["*"]` won't redirect properly, but `https://example-frappe.com/api/resource/Expense%20Claim/?fields=["*"]` will.

Also, after some digging, I found that the [Python requests library doesn't preserve the Authorization header](https://github.com/request/request/pull/1184/commits/210b326fd8625f358e06c59dc11e74468b1de515) for these redirects (different protocol means different host). So we also need to manually handle redirections inside the handler.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)