### PR TITLE
[Docs] Fix link to table structure information from install.mdx

### DIFF
--- a/docs/contribute/install.mdx
+++ b/docs/contribute/install.mdx
@@ -83,7 +83,7 @@ Now that you are all set, we recommend you check out our **Tutorials** and
 regression, classification, and time series predictions with MindsDB.
 
 To learn more about MindsDB itself, follow the guide on
-[MindsDB database structure](/sql/table-structure/). Also, don't miss out on the
+[MindsDB database structure](../sql/table-structure.mdx). Also, don't miss out on the
 remaining pages from the **SQL API** section, as they explain a common SQL
 syntax with examples.
 


### PR DESCRIPTION
## Description

Fix a wrong link from docs/contribute/install.mdx file to table structure information 

**Fixes** (N/A)

## Type of change

### What is the solution?

(Describe at a high level how the feature was implemented)
Set a properly relative link to docs/sql/table-structure.mdx file.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
