### PR TITLE
removed not tested apps from docs navigation

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -125,10 +125,6 @@
         {
           "group": "Applications",
           "pages": [
-            "app-integrations/confluence",
-            "app-integrations/google-calendar",
-            "app-integrations/plaid",
-            "app-integrations/reddit",
             "app-integrations/twitter"
           ]
         },


### PR DESCRIPTION
## Description

these apps (reddit, plaid, google calendar, confluence) were released on April 28th, and on that day I created doc pages to link them in the changelog blog post.
since these are not tested (and reddit does not work in cloud), I remove them from docs navigation for now.

**Fixes** #-

## Type of change

(Please delete options that are not relevant)

- [ ] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [ ] I have updated the documentation, or created issues to update them.
