### PR TITLE
Correct port value in mongo-shell documentation

### DIFF
--- a/docs/connect/mongo-shell.mdx
+++ b/docs/connect/mongo-shell.mdx
@@ -74,7 +74,7 @@ Let's look at the connection strings for both MindsDB Cloud and local installati
     mongodb://mindsdb_cloud_username:mindsdb_cloud_password@<dedicated instance ip>:3306/?authMechanism=DEFAULT
     ```
 
-    It is similar to connecting MindsDB Cloud. Please replace the `mindsdb_cloud_username` placeholder with your MindsDB Cloud account email. Also, replace the `mindsdb_cloud_password` placeholder with your MindsDB Cloud password. The host value is the IP address of your dedicated instance and the port value is custom. We use the default authentication mechanism.
+    It is similar to connecting MindsDB Cloud. Please replace the `mindsdb_cloud_username` placeholder with your MindsDB Cloud account email. Also, replace the `mindsdb_cloud_password` placeholder with your MindsDB Cloud password. The host value is the IP address of your dedicated instance and the port value is 3306. We use the default authentication mechanism.
 
   </Tab>
 </Tabs>


### PR DESCRIPTION
## Description

Updated the Docs to set the proper port number for mongo-shell.

**Fixes** #6297 

## Type of change

- [ ] 📄 This change requires a documentation update

### What is the solution?

Changed to port value to 3306 in mongo-shell documentation

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
