### PR TITLE
Upgrade python version to 3.8 for all docker base images

### DIFF
--- a/docker/db_handler.Dockerfile
+++ b/docker/db_handler.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM python:3.7
+FROM python:3.8
 
 RUN apt-get update && apt-get upgrade -y
 RUN pip3 install --upgrade pip && pip3 install psycopg2-binary

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,6 +17,7 @@ services:
         MINDSDB_STORAGE_DIR: "/mindsdb/var"
 
   mindsdb:
+    platform: linux/amd64
     # Copy global settings from migration above
     <<: *globalSettings
     restart: always

--- a/docker/executor.Dockerfile
+++ b/docker/executor.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM python:3.7
+FROM python:3.8
 
 RUN apt-get update && apt-get upgrade -y
 RUN pip3 install --upgrade pip && pip3 install psycopg2-binary

--- a/docker/handler_discovery.Dockerfile
+++ b/docker/handler_discovery.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM python:3.7
+FROM python:3.8
 
 RUN apt-get update && apt-get upgrade -y
 RUN pip3 install --upgrade pip

--- a/docker/mindsdb.Dockerfile
+++ b/docker/mindsdb.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.8
 
 
 RUN apt update && apt-get upgrade -y && apt install -y build-essential

--- a/docker/ml_handler.Dockerfile
+++ b/docker/ml_handler.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM python:3.7
+FROM python:3.8
 
 RUN apt-get update && apt-get upgrade -y
 RUN pip3 install --upgrade pip && pip3 install psycopg2-binary

--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -73,21 +73,21 @@ if __name__ == '__main__':
     args = args_parse()
 
     # ---- CHECK SYSTEM ----
-    if not (sys.version_info[0] >= 3 and sys.version_info[1] >= 6):
+    if not (sys.version_info[0] >= 3 and sys.version_info[1] >= 7):
         print("""
-     MindsDB server requires Python >= 3.7 to run
+     MindsDB server requires Python >= 3.8 to run
 
-     Once you have Python 3.7 installed you can tun mindsdb as follows:
+     Once you have Python 3.8 installed you can run mindsdb as follows:
 
      1. create and activate venv:
-     python3.7 -m venv venv
+     python -m venv venv
      source venv/bin/activate
 
      2. install MindsDB:
      pip3 install mindsdb
 
      3. Run MindsDB
-     python3.7 -m mindsdb
+     python -m mindsdb
 
      More instructions in https://docs.mindsdb.com
          """)


### PR DESCRIPTION
## Description

python library `lightwood` starting on version `23.5.1.0` is no longer compatible with `python 3.7`, so it's needed to upgrade to `3.8` for all base docker images

**Fixes** #6335

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

- upgrade base docker image from `python:3.7` to `python:3.8`
- update mindsdb CLI to require python >= 3.8

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
