### PR TITLE
Add target column to output even if dtype_dict is empty

### DIFF
--- a/mindsdb/interfaces/database/projects.py
+++ b/mindsdb/interfaces/database/projects.py
@@ -242,8 +242,14 @@ class Project:
             name=table_name
         ).first()
         columns = []
-        if predictor_record is not None and isinstance(predictor_record.dtype_dict, dict):
-            columns = list(predictor_record.dtype_dict.keys())
+        if predictor_record is not None:
+            if isinstance(predictor_record.dtype_dict, dict):
+                columns = list(predictor_record.dtype_dict.keys())
+            elif predictor_record.to_predict is not None:
+                # no dtype_dict, use target
+                columns = predictor_record.to_predict
+                if not isinstance(columns, list):
+                    columns = [columns]
 
         return columns
 


### PR DESCRIPTION
## Description

Change: 
Add model columns to output even if we joining empty dataframe with model

This change is fixing this query:

```
 SELECT
  sentiment as text
FROM (
    SELECT * FROM ( SELECT * FROM mysql_demo_db.amazon_reviews limit 0)
   JOIN sentiment_classifier_gpt3
   LIMIT 1
);
```

At the moment it is working with error if  limit 0 and without error if  limit 1



## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
