### PR TITLE
Fix: first job run with using twitter api

### DIFF
--- a/mindsdb/interfaces/jobs/jobs_controller.py
+++ b/mindsdb/interfaces/jobs/jobs_controller.py
@@ -348,7 +348,8 @@ class JobsExecutor:
                         # start date of the job
                         value = record.created_at
                     else:
-                        value = history_prev.start_at
+                        # fix for twitter: created_at filter must be minimum of 10 seconds prior to the current time
+                        value = history_prev.start_at - dt.timedelta(seconds=60)
                     value = value.strftime("%Y-%m-%d %H:%M:%S")
                     sql = sql.replace('{{PREVIOUS_START_DATETIME}}', value)
 

--- a/tests/unit/test_project_structure.py
+++ b/tests/unit/test_project_structure.py
@@ -581,7 +581,7 @@ class TestJobs(BaseExecutorDummyML):
         # job wasn't executed
         ret = self.run_sql('select * from jobs_history', database='proj2')
         assert len(ret) == 1
-        prev_run = ret.RUN_START[0]
+        prev_run = ret.RUN_START[0] - dt.timedelta(seconds=60)
 
         # shift 'next run' and run once again
         job = self.db.Jobs.query.filter(self.db.Jobs.name == 'j2').first()


### PR DESCRIPTION
## Description

First PREVIOUS_START_DATETIME value now is 1 minute before first job run.
It shouldn't raise error if query is using filter "t.created_at > "{{PREVIOUS_START_DATETIME}}" because twitter API required this  filter minimum of 10 seconds prior to the current time


## Description


**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
