### PR TITLE
Fixed issue #6454

### DIFF
--- a/docs/sql/tutorials/eeg-forecasting.mdx
+++ b/docs/sql/tutorials/eeg-forecasting.mdx
@@ -113,7 +113,7 @@ linear regression).
 ## Training a Predictor
 
 Let's create and train the machine learning model. For that, we use the
-[`CREATE MODEL`](/sql/create/predictor) statement and specify the
+[`CREATE MODEL`](/sql/create/model) statement and specify the
 input columns used to train `FROM` (features) and what we want to
 `PREDICT` (labels).
 


### PR DESCRIPTION
changed /sql/create/predictor to /sql/create/model in docs\sql\tutorials\eeg-forecasting.mdx

**Fixes** #6454 

## Type of change

📄 This change requires a documentation update

### What is the solution?

Replaced  /sql/create/predictor to /sql/create/model in a link in docs\sql\tutorials\eeg-forecasting.mdx

## Checklist:

My code follows the style guidelines(PEP 8) of MindsDB.
I have commented my code, particularly in hard-to-understand areas.
I have updated the documentation, or created issues to update them.
