### PR TITLE
fixed broken link in docs/custom-model/openai.mdx

### DIFF
--- a/docs/custom-model/openai.mdx
+++ b/docs/custom-model/openai.mdx
@@ -7,7 +7,7 @@ MindsDB lets you create models that utilize features provided by OpenAI GPT-3.
 
 ## How to Bring the OpenAI Model to MindsDB
 
-We use the [`CREATE MODEL`](/sql/create/predictor) statement to bring the OpenAI models to MindsDB.
+We use the [`CREATE MODEL`](/sql/create/model) statement to bring the OpenAI models to MindsDB.
 
 MindsDB provides an OpenAI engine by default. But if you want to use your own OpenAI engine, please create it using the command below and passing your OpenAI API key:
 


### PR DESCRIPTION
## Description

changed /sql/create/predictor to /sql/create/model in docs/custom-model/openai.mdx

**Fixes** [issue](https://github.com/mindsdb/mindsdb/issues/6356)

## Type of change

- 📄 This change requires a documentation update

### What is the solution?

Replaced /sql/create/predictor to /sql/create/model in docs/custom-model/openai.mdx and fixed the broken link

## Checklist:

- My code follows the style guidelines(PEP 8) of MindsDB.
- I have commented my code, particularly in hard-to-understand areas.
- I have updated the documentation, or created issues to update them.
