### PR TITLE
Add more instruction on how to run the documentation locally

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 # MindsDB Documentation    <a href="https://docs.mindsdb.com?utm_medium=community&utm_source=github&utm_campaign=mindsdb%20repo"><img src="https://img.shields.io/website?url=https%3A%2F%2Fwww.mindsdb.com%2F" alt="MindsDB Docs"></a>	
 
 ## Running the docs locally
+Run the following commands in your local repo, and make sure you are located at 'docs' folder.
 
 First install `mintlify`:
 


### PR DESCRIPTION
I would like to give contributors more instruction on how to run the documentation locally to save their time by avoiding unnecessary detours

## Description

I would like to give contributors more instruction on how to run the documentation locally to save their time by avoiding unnecessary detours

## Type of change

(Please delete options that are not relevant)

- [x] ⚡ New feature (non-breaking change which adds functionality)

### What is the solution?

I tried to run the documentation locally myself, but I did not pay attention and ran the commands on the root mindsdb folder, therefore got an error message. So I added a reminder that contributors should run it at the docs folder. In this way, the contributors can save their time by avoiding unnecessary detours. 

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
