### PR TITLE
Update dbeaver.mdx

### DIFF
--- a/docs/connect/dbeaver.mdx
+++ b/docs/connect/dbeaver.mdx
@@ -39,7 +39,7 @@ There are three options, as below.
     
     ```
     Hostname: `127.0.0.1`
-    Port: `47334`
+    Port: `47335`
     Username: `mindsdb`
     Password: <leave it empty>
     Database: <leave it empty>


### PR DESCRIPTION

## Description

The incorrect Port number is mentioned in the docs. 

## Type of change

- [x] 📄 This change requires a documentation update

### What is the solution?

Docker is asked to run on port 47335 in the docs but 47334 mentioned

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, or created issues to update them.
