### PR TITLE
Add google handlers dependencies

### DIFF
--- a/docker/release
+++ b/docker/release
@@ -80,6 +80,7 @@ RUN python -m pip install --prefer-binary --no-cache-dir --upgrade pip==23.1.2 &
     pip install --prefer-binary --no-cache-dir slack_sdk || true \
     pip install --no-cache-dir 'neuralforecast>=1.4.0, <1.5.0' 'hierarchicalforecast<1.0' 'hyperopt<1.0' || true && \
     pip install --prefer-binary --no-cache-dir 'statsforecast>=1.4.0, <2.0' || true && \
+    pip install --no-cache-dir google-api-python-client google-auth-httplib2 google-auth-oauthlib || true && \
     pip install --prefer-binary --no-cache-dir hugging_py_face || true 
 
 ARG VERSION=


### PR DESCRIPTION
## Description

This PR adds missing dependencies for using Gmail and Google calendar handlers:

```
google-api-python-client
google-auth-httplib2
google-auth-oauthlib
```

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

