### PR TITLE
[fix] skip target check in data for genAI handlers

### DIFF
--- a/mindsdb/integrations/handlers/cohere_handler/cohere_handler.py
+++ b/mindsdb/integrations/handlers/cohere_handler/cohere_handler.py
@@ -19,10 +19,12 @@ class CohereHandler(BaseMLEngine):
     name = 'cohere'
 
     def create(self, target: str, df: Optional[pd.DataFrame] = None, args: Optional[Dict] = None) -> None:
+        super().__init__(*args)
 
         if 'using' not in args:
             raise Exception("Cohere engine requires a USING clause! Refer to its documentation for more details.")
 
+        self.generative = True
         self.model_storage.json_set('args', args)
 
     def predict(self, df: Optional[pd.DataFrame] = None, args: Optional[Dict] = None) -> None:

--- a/mindsdb/integrations/handlers/langchain_handler/langchain_handler.py
+++ b/mindsdb/integrations/handlers/langchain_handler/langchain_handler.py
@@ -47,6 +47,7 @@ class LangChainHandler(OpenAIHandler):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.generative = True
         self.stops = []
         self.default_model = _DEFAULT_MODEL
         self.default_max_tokens = _DEFAULT_MAX_TOKENS

--- a/mindsdb/integrations/handlers/llama_index_handler/llama_index_handler.py
+++ b/mindsdb/integrations/handlers/llama_index_handler/llama_index_handler.py
@@ -22,8 +22,8 @@ class LlamaIndexHandler(BaseMLEngine):
     name = 'llama_index'
 
     def __init__(self, *args, **kwargs):
-
         super().__init__(*args, **kwargs)
+        self.generative = True
         self.default_index_class  = 'GPTVectorStoreIndex'
         self.supported_index_class = ['GPTVectorStoreIndex']
         self.default_reader = 'DFReader'

--- a/mindsdb/integrations/handlers/openai_handler/openai_handler.py
+++ b/mindsdb/integrations/handlers/openai_handler/openai_handler.py
@@ -28,6 +28,7 @@ class OpenAIHandler(BaseMLEngine):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.generative = True
         self.default_model = 'gpt-3.5-turbo'
         self.default_mode = 'default'  # can also be 'conversational' or 'conversational-full'
         self.supported_modes = ['default', 'conversational', 'conversational-full', 'image']

--- a/mindsdb/integrations/handlers/writer_handler/writer_handler.py
+++ b/mindsdb/integrations/handlers/writer_handler/writer_handler.py
@@ -32,6 +32,7 @@ class WriterHandler(BaseMLEngine):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.generative = True
 
     @staticmethod
     def create_validation(target, args=None, **kwargs):

--- a/mindsdb/integrations/libs/base.py
+++ b/mindsdb/integrations/libs/base.py
@@ -143,6 +143,7 @@ class BaseMLEngine:
         """
         self.model_storage = model_storage
         self.engine_storage = engine_storage
+        self.generative = False  # if True, the target column name does not have to be specified at creation time
 
         if kwargs.get('base_model_storage'):
             self.base_model_storage = kwargs['base_model_storage']  # available when updating a model

--- a/mindsdb/integrations/libs/ml_exec_base.py
+++ b/mindsdb/integrations/libs/ml_exec_base.py
@@ -127,7 +127,7 @@ def learn_process(class_path, engine, context_dump, integration_id,
             **kwargs
         )
 
-        if target not in training_data_df.columns and not ml_handler.generative:
+        if not ml_handler.generative and target not in training_data_df.columns:
             raise Exception(
                 f'Prediction target "{target}" not found in training dataframe: {list(training_data_df.columns)}')
 

--- a/mindsdb/integrations/libs/ml_exec_base.py
+++ b/mindsdb/integrations/libs/ml_exec_base.py
@@ -105,10 +105,6 @@ def learn_process(class_path, engine, context_dump, integration_id,
             training_data_columns_count = len(training_data_df.columns)
             training_data_rows_count = len(training_data_df)
 
-            if target not in training_data_df.columns:
-                raise Exception(
-                    f'Prediction target "{target}" not found in training dataframe: {list(training_data_df.columns)}')
-
         predictor_record.training_data_columns_count = training_data_columns_count
         predictor_record.training_data_rows_count = training_data_rows_count
         db.session.commit()
@@ -130,6 +126,10 @@ def learn_process(class_path, engine, context_dump, integration_id,
             model_storage=modelStorage,
             **kwargs
         )
+
+        if target not in training_data_df.columns and not ml_handler.generative:
+            raise Exception(
+                f'Prediction target "{target}" not found in training dataframe: {list(training_data_df.columns)}')
 
         # create new model
         if base_predictor_id is None:

--- a/mindsdb/integrations/libs/ml_exec_base.py
+++ b/mindsdb/integrations/libs/ml_exec_base.py
@@ -127,9 +127,10 @@ def learn_process(class_path, engine, context_dump, integration_id,
             **kwargs
         )
 
-        if not ml_handler.generative or target not in training_data_df.columns:
-            raise Exception(
-                f'Prediction target "{target}" not found in training dataframe: {list(training_data_df.columns)}')
+        if training_data_df is not None:
+            if not ml_handler.generative or target not in training_data_df.columns:
+                raise Exception(
+                    f'Prediction target "{target}" not found in training dataframe: {list(training_data_df.columns)}')
 
         # create new model
         if base_predictor_id is None:

--- a/mindsdb/integrations/libs/ml_exec_base.py
+++ b/mindsdb/integrations/libs/ml_exec_base.py
@@ -127,7 +127,7 @@ def learn_process(class_path, engine, context_dump, integration_id,
             **kwargs
         )
 
-        if not ml_handler.generative and target not in training_data_df.columns:
+        if not ml_handler.generative or target not in training_data_df.columns:
             raise Exception(
                 f'Prediction target "{target}" not found in training dataframe: {list(training_data_df.columns)}')
 

--- a/mindsdb/integrations/libs/ml_exec_base.py
+++ b/mindsdb/integrations/libs/ml_exec_base.py
@@ -127,8 +127,8 @@ def learn_process(class_path, engine, context_dump, integration_id,
             **kwargs
         )
 
-        if training_data_df is not None:
-            if not ml_handler.generative or target not in training_data_df.columns:
+        if not ml_handler.generative:
+            if training_data_df is not None and target not in training_data_df.columns:
                 raise Exception(
                     f'Prediction target "{target}" not found in training dataframe: {list(training_data_df.columns)}')
 


### PR DESCRIPTION
## Description

Fixes an unlogged issue that affects generative handlers like Writer, LlamaIndex, etc.

## Type of change


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### What is the solution?

Add flags to generative handlers, and use this in the check that would previously raise an exception if the target column was not found in the input dataset.