### PR TITLE
Updated link in home rentals tutorial

### DIFF
--- a/docs/sql/tutorials/home-rentals.mdx
+++ b/docs/sql/tutorials/home-rentals.mdx
@@ -120,7 +120,7 @@ x variable in simple linear regression).
 ## Training a Predictor
 
 Let's create and train the machine learning model. For that, we use the
-[`CREATE MODEL`](/sql/create/predictor) statement and specify the
+[`CREATE MODEL`](/sql/create/model) statement and specify the
 input columns used to train `FROM` (features) and what we want to
 `PREDICT` (labels).
 


### PR DESCRIPTION
## Description

I changed an outdated link in the documentation.

**Fixes** #6455

## Type of change

### What is the solution?

I searched for the old link in the documentation, and then replaced it with a new one.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
