### PR TITLE
Fixed Incorrect Syntax in GitHub README

### DIFF
--- a/mindsdb/integrations/handlers/github_handler/README.md
+++ b/mindsdb/integrations/handlers/github_handler/README.md
@@ -73,7 +73,7 @@ CREATE DATABASE mindsdb_github
 WITH ENGINE = 'github',
 PARAMETERS = {
   "repository": "mindsdb/mindsdb",
-  "api_key": "your_api_key",    -- optional GitHub API key
+  "api_key": "your_api_key"    -- optional GitHub API key
 };
 ~~~~
 

--- a/mindsdb/integrations/handlers/github_handler/README.md
+++ b/mindsdb/integrations/handlers/github_handler/README.md
@@ -17,10 +17,10 @@ GitHub handler for MindsDB provides interfaces to connect to GitHub via APIs and
 
 ---
 
-## About GithHub
+## About GitHub
 
 GitHub is a web-based hosting service for version control using Git. It is mostly used for computer code.
-It offers all of the distributed version control and source code management (SCM) functionality
+It offers all the distributed version control and source code management (SCM) functionality
 of Git as well as adding its own features. It provides access control and several collaboration
 features such as bug tracking, feature requests, task management, and wikis for every project.
 


### PR DESCRIPTION
Fixed the `CREATE DATABASE` statement in the GitHub handler's README by removing an extra comma and made a couple of small grammatical changes.