### PR TITLE
Fix img source link for supported python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 <p>
 	<a href="https://github.com/mindsdb/mindsdb/actions"><img src="https://github.com/mindsdb/mindsdb/workflows/MindsDB%20workflow/badge.svg" alt="MindsDB workflow"></a>
-	<a href="https://www.python.org/downloads/" target="_blank"><img src=" https://img.shields.io/badge/python-3.8.x%7C%203.9.x-brightgreen.svg" alt="Python supported"></a>
+	<a href="https://www.python.org/downloads/" target="_blank"><img src="https://img.shields.io/badge/python-3.8.x%7C%203.9.x-brightgreen.svg" alt="Python supported"></a>
 	<a href="https://pypi.org/project/MindsDB/" target="_blank"><img src="https://badge.fury.io/py/MindsDB.svg" alt="PyPi Version"></a>
 	<br />
 	<img alt="PyPI - Downloads" src="https://img.shields.io/pypi/dm/Mindsdb">  <a href="https://hub.docker.com/u/mindsdb" target="_blank"><img src="https://img.shields.io/docker/pulls/mindsdb/mindsdb" alt="Docker pulls"></a>


### PR DESCRIPTION
Fixed the img source link for supported python version
Before:
![image](https://github.com/mindsdb/mindsdb/assets/55058959/01255a3d-d550-4f90-b0c7-13bf3f98ee2c)
After:
![image](https://github.com/mindsdb/mindsdb/assets/55058959/46a8721c-f7bd-4dcc-a1d6-b7986f0534e1)


