### PR TITLE
Updated instructions for OceanBase

### DIFF
--- a/docs/data-integrations/oceanbase.mdx
+++ b/docs/data-integrations/oceanbase.mdx
@@ -19,6 +19,10 @@ The required arguments to establish a connection are as follows:
 * `port` is the port used to make TCP/IP connection.
 * `database` is the database name.
 
+<Tip>
+If you installed MindsDB locally via pip, you need to install all handler dependencies manually. To do so, go to the handler's folder (mindsdb/integrations/handlers/oceanbase_handler) and run this command: `pip install -r requirements.txt`.
+</Tip>
+
 ## Usage
 
 In order to make use of this handler and connect to the OceanBase server in MindsDB, the following syntax can be used:


### PR DESCRIPTION
## Description

Update instructions for OceanBase  file

**FIxes**  Issue #6696


## Type of change
Added additional content under implementations chapter of OceanBase file

- [ ] 📄 This change requires a documentation update

### What is the solution?

Solution is adding-: 

If you installed MindsDB locally via pip, you need to install all handler dependencies manually. To do so, go to the handler's folder (mindsdb/integrations/handlers/oceanbase_handler) and run this command: `pip install -r requirements.txt` 

So that all dependencies are installed 

## Change made-:
<img width="1037" alt="Screenshot 2023-06-29 at 2 06 57 AM" src="https://github.com/mindsdb/mindsdb/assets/73593914/dab3230a-ec52-44e9-a7e2-49a42c3009ef">

- [ ] I have shared a short screenshots demonstrating the update 
