### PR TITLE
Remove '.' from project and integrations names

### DIFF
--- a/mindsdb/migrations/versions/2023-06-27_607709e1615b_update_project_names.py
+++ b/mindsdb/migrations/versions/2023-06-27_607709e1615b_update_project_names.py
@@ -1,0 +1,60 @@
+"""update_project_names
+
+Revision ID: 607709e1615b
+Revises: b5bf593ba659
+Create Date: 2023-06-27 18:33:29.436607
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import mindsdb.interfaces.storage.db  # noqa
+
+
+# revision identifiers, used by Alembic.
+revision = '607709e1615b'
+down_revision = 'b5bf593ba659'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+
+    def _rename(table):
+        conn = op.get_bind()
+
+        data = conn.execute(
+            table
+            .select()
+            .where(table.c.name.like("%.%"))
+        ).fetchall()
+
+        for row in data:
+            name = row[0]
+            name2 = name.replace('.', '_')
+
+            op.execute(
+                table
+                .update()
+                .where(table.c.name == name)
+                .values({'name': name2})
+            )
+
+    projects = sa.Table(
+        'project',
+        sa.MetaData(),
+        sa.Column('name', sa.String()),
+    )
+
+    _rename(projects)
+
+    integrations = sa.Table(
+        'integration',
+        sa.MetaData(),
+        sa.Column('name', sa.String()),
+    )
+
+    _rename(integrations)
+
+
+def downgrade():
+    pass


### PR DESCRIPTION

Fixes #6554

## Description

Created migration to update 'project' and 'integration' tables names: replace '.' to '_'

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
