### PR TITLE
Don't import fcntl on windows

### DIFF
--- a/mindsdb/interfaces/storage/fs.py
+++ b/mindsdb/interfaces/storage/fs.py
@@ -1,5 +1,4 @@
 import os
-import fcntl
 import shutil
 import hashlib
 from pathlib import Path
@@ -14,6 +13,10 @@ try:
 except Exception:
     # Only required for remote storage on s3
     pass
+
+if os.name == 'posix':
+    import fcntl
+
 
 from mindsdb.utilities.config import Config
 from mindsdb.utilities.context import context as ctx


### PR DESCRIPTION
## Description

Don't try to import fcntl on windows

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
