### PR TITLE
added a tip message to the oracle.mdx file

### DIFF
--- a/docs/data-integrations/oracle.mdx
+++ b/docs/data-integrations/oracle.mdx
@@ -23,6 +23,10 @@ The required arguments to establish a connection are as follows:
 * `user` is the database user.
 * `password` is the database password.
 
+<Tip>
+If you installed MindsDB locally via pip, you need to install all handler dependencies manually. To do so, go to the handler's folder (mindsdb/integrations/handlers/oracle_handler) and run this command: `pip install -r requirements.txt`.
+</Tip>
+
 ## Usage
 
 In order to make use of this handler and connect to the Oracle database in MindsDB, the following syntax can be used:


### PR DESCRIPTION
## Description

I added this message to the end of the implementation chapter: <Tip>If you installed MindsDB locally via pip, you need to install all handler dependencies manually. To do so, go to the handler's folder (mindsdb/integrations/handlers/oracle_handler) and run this command: `pip install -r requirements.txt`</Tip>

## Type of change

Added some text to a file.


