### PR TITLE
Added tip message to MySQL.mdx file #6695

### DIFF
--- a/docs/data-integrations/mysql.mdx
+++ b/docs/data-integrations/mysql.mdx
@@ -26,6 +26,10 @@ There are several optional arguments that can be used as well.
 * `ssl_cert` stores SSL certificates.
 * `ssl_key` stores SSL keys.
 
+<Tip>
+If you installed MindsDB locally via pip, you need to install all handler dependencies manually. To do so, go to the handler's folder (mindsdb/integrations/handlers/mysql_handler) and run this command: `pip install -r requirements.txt`.
+</Tip>
+
 ## Usage
 
 In order to make use of this handler and connect to the MySQL database in MindsDB, the following syntax can be used:


### PR DESCRIPTION
## Description

I added this message to the end of the implementation chapter: " If you installed MindsDB locally via pip, you need to install all handler dependencies manually. To do so, go to the handler's folder (mindsdb/integrations/handlers/mysql_handler) and run this command: `pip install -r requirements.txt`."

**Fixes** #(issue)

## Type of change

- [ ✓] 🐛 Bug fix (non-breaking change which fixes an issue)

### What is the solution?

Update instructions for MySQL Document #6695

## Checklist:
- [ ✓] I have updated the documentation.

