### PR TITLE
support embedding mode for lightwood models

### DIFF
--- a/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
+++ b/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
@@ -105,8 +105,8 @@ class LightwoodHandler(BaseMLEngine):
 
         with profiler.Context('predict-postprocessing'):
             if embedding_mode:
-                predictions['embedding'] = predictions.values.tolist()
-                return predictions[['embedding']]
+                predictions['prediction'] = predictions.values.tolist()
+                predictions = predictions[['prediction']]
 
             predictions = predictions.to_dict(orient='records')
 

--- a/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
+++ b/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
@@ -98,16 +98,16 @@ class LightwoodHandler(BaseMLEngine):
             predictor = LightwoodHandler.get_predictor(predictor_path, predictor_code)
 
         dtype_dict = predictor.dtype_dict
+        embedding_mode = predictor.problem_definition.embedding_only or pred_args.get('return_embedding', False)
 
         with profiler.Context('predict'):
             predictions = predictor.predict(df, args=pred_args)
 
-        # embedding mode
-        if predictor.problem_definition.embedding_only or pred_args.get('return_embedding', False):
-            predictions['prediction'] = predictions.values.tolist()
-            predictions = predictions[['prediction']]
-
         with profiler.Context('predict-postprocessing'):
+            if embedding_mode:
+                predictions['embedding'] = predictions.values.tolist()
+                return predictions[['embedding']]
+
             predictions = predictions.to_dict(orient='records')
 
             # TODO!!!

--- a/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
+++ b/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
@@ -102,6 +102,11 @@ class LightwoodHandler(BaseMLEngine):
         with profiler.Context('predict'):
             predictions = predictor.predict(df, args=pred_args)
 
+        # embedding mode
+        if predictor.problem_definition.embedding_only or pred_args.get('return_embedding', False):
+            predictions['prediction'] = predictions.values.tolist()
+            predictions = predictions[['prediction']]
+
         with profiler.Context('predict-postprocessing'):
             predictions = predictions.to_dict(orient='records')
 

--- a/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
+++ b/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
@@ -106,7 +106,8 @@ class LightwoodHandler(BaseMLEngine):
         with profiler.Context('predict-postprocessing'):
             if embedding_mode:
                 predictions['prediction'] = predictions.values.tolist()
-                predictions = predictions[['prediction']]
+                # note: return here once ml engine executor supports non-target named outputs
+                predictions = predictions[['prediction']]  
 
             predictions = predictions.to_dict(orient='records')
 

--- a/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
+++ b/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/lightwood_handler.py
@@ -98,7 +98,11 @@ class LightwoodHandler(BaseMLEngine):
             predictor = LightwoodHandler.get_predictor(predictor_path, predictor_code)
 
         dtype_dict = predictor.dtype_dict
-        embedding_mode = predictor.problem_definition.embedding_only or pred_args.get('return_embedding', False)
+
+        if hasattr(predictor.problem_definition, 'embedding_only'):
+            embedding_mode = predictor.problem_definition.embedding_only or pred_args.get('return_embedding', False)
+        else:
+            embedding_mode = False
 
         with profiler.Context('predict'):
             predictions = predictor.predict(df, args=pred_args)
@@ -107,7 +111,7 @@ class LightwoodHandler(BaseMLEngine):
             if embedding_mode:
                 predictions['prediction'] = predictions.values.tolist()
                 # note: return here once ml engine executor supports non-target named outputs
-                predictions = predictions[['prediction']]  
+                predictions = predictions[['prediction']]
 
             predictions = predictions.to_dict(orient='records')
 


### PR DESCRIPTION
## Description

This PR enables usage of lightwood embedding modes. Example:

```
CREATE MODEL 
  mindsdb.home_rentals_model
FROM example_db
  (SELECT * FROM demo_data.home_rentals)
PREDICT rental_price
USING
problem_definition.embedding_only = True;  -- this will set `return_embedding` as `True` by default when predicting, and skip some phases in the learning pipeline

SELECT rental_price, 
FROM home_rentals_model
WHERE sqft = 823
AND location='good'
AND neighborhood='downtown'
AND days_on_market=10
USING
return_embedding = True;  -- this forces an embedding as output
```

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)
- [x] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
