### PR TITLE
add optional cpu huggingface requirements file

### DIFF
--- a/mindsdb/integrations/handlers/huggingface_handler/requirements_cpu.txt
+++ b/mindsdb/integrations/handlers/huggingface_handler/requirements_cpu.txt
@@ -1,0 +1,9 @@
+mindsdb>=22.6.2.1
+mindsdb_sql >= 0.4.0
+pandas <=1.4.3
+transformers==4.21.0
+sentencepiece==0.1.97
+
+tensorflow
+tqdm
+torch==2.0.1+cpu --index-url https://download.pytorch.org/whl/cpu

--- a/mindsdb/integrations/handlers/huggingface_handler/requirements_cpu.txt
+++ b/mindsdb/integrations/handlers/huggingface_handler/requirements_cpu.txt
@@ -6,4 +6,5 @@ sentencepiece==0.1.97
 
 tensorflow
 tqdm
-torch==2.0.1+cpu --index-url https://download.pytorch.org/whl/cpu
+# Needs to be installed with `pip install --extra-index-url https://download.pytorch.org/whl/ .[huggingface_cpu]`
+torch==2.0.1+cpu

--- a/mindsdb/integrations/handlers/huggingface_handler/requirements_cpu.txt
+++ b/mindsdb/integrations/handlers/huggingface_handler/requirements_cpu.txt
@@ -1,9 +1,12 @@
-mindsdb_sql >= 0.4.0
-pandas <=1.4.3
-transformers==4.21.0
+pandas >=2.0.0, <2.1.0
+transformers==4.31.0
 sentencepiece==0.1.97
-
-tensorflow
+accelerate>=0.20.1
+datasets
+evaluate
 tqdm
+rouge-score
+nltk
+huggingface-hub
 # Needs to be installed with `pip install --extra-index-url https://download.pytorch.org/whl/ .[huggingface_cpu]`
 torch==2.0.1+cpu

--- a/mindsdb/integrations/handlers/huggingface_handler/requirements_cpu.txt
+++ b/mindsdb/integrations/handlers/huggingface_handler/requirements_cpu.txt
@@ -1,4 +1,3 @@
-mindsdb>=22.6.2.1
 mindsdb_sql >= 0.4.0
 pandas <=1.4.3
 transformers==4.21.0

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
+import glob
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 
 class Deps:
@@ -38,44 +40,56 @@ def define_deps():
     Returns:
          list of packages, extras and dependency links.
     """
-    with open(os.path.normpath('requirements/requirements.txt')) as req_file:
+    with open(os.path.normpath("requirements/requirements.txt")) as req_file:
         defaults = [req.strip() for req in req_file.read().splitlines()]
 
     links = []
     requirements = []
     for r in defaults:
-        if 'git+https' in r:
-            pkg = r.split('#')[-1]
-            links.append(r + '-9876543210')
-            requirements.append(pkg.replace('egg=', ''))
+        if "git+https" in r:
+            pkg = r.split("#")[-1]
+            links.append(r + "-9876543210")
+            requirements.append(pkg.replace("egg=", ""))
         else:
             requirements.append(r.strip())
 
     extra_requirements = {}
     full_requirements = []
-    for fn in os.listdir(os.path.normpath('./requirements')):
-        if fn.startswith('requirements-') and fn.endswith('.txt'):
-            extra_name = fn.replace('requirements-', '').replace('.txt', '')
+    for fn in os.listdir(os.path.normpath("./requirements")):
+        if fn.startswith("requirements-") and fn.endswith(".txt"):
+            extra_name = fn.replace("requirements-", "").replace(".txt", "")
             with open(os.path.normpath(f"./requirements/{fn}")) as fp:
                 extra = [req.strip() for req in fp.read().splitlines()]
             extra_requirements[extra_name] = extra
             full_requirements += extra
 
-    extra_requirements['all_extras'] = list(set(full_requirements))
+    extra_requirements["all_extras"] = list(set(full_requirements))
 
     full_handlers_requirements = []
-    handlers_dir_path = os.path.normpath('./mindsdb/integrations/handlers')
+    handlers_dir_path = os.path.normpath("./mindsdb/integrations/handlers")
     for fn in os.listdir(handlers_dir_path):
-        if os.path.isdir(os.path.join(handlers_dir_path, fn)) and fn.endswith("_handler"):
-            req_file_path = os.path.join(handlers_dir_path, fn, 'requirements.txt')
-            if os.path.exists(req_file_path):
+        if os.path.isdir(os.path.join(handlers_dir_path, fn)) and fn.endswith(
+            "_handler"
+        ):
+            for req_file_path in glob.glob(
+                os.path.join(handlers_dir_path, fn, "requirements*.txt")
+            ):
+                print(req_file_path)
                 with open(req_file_path) as fp:
                     extra = [req.strip() for req in fp.read().splitlines()]
                 extra_name = fn.replace("_handler", "")
+                file_name = os.path.basename(req_file_path)
+                if file_name != "requirements.txt":
+                    extra_name += "_" + file_name.replace("requirements_", "").replace(
+                        ".txt", ""
+                    )
+                print(extra_name)
                 extra_requirements[extra_name] = extra
+                print(extra_requirements[extra_name])
+                print("")
                 full_handlers_requirements += extra
 
-    extra_requirements['all_handlers_extras'] = list(set(full_handlers_requirements))
+    extra_requirements["all_handlers_extras"] = list(set(full_handlers_requirements))
 
     Deps.pkgs = requirements
     Deps.extras = extra_requirements
@@ -87,14 +101,14 @@ def define_deps():
 deps = define_deps()
 
 setup(
-    name=about['__title__'],
-    version=about['__version__'],
-    url=about['__github__'],
-    download_url=about['__pypi__'],
-    license=about['__license__'],
-    author=about['__author__'],
-    author_email=about['__email__'],
-    description=about['__description__'],
+    name=about["__title__"],
+    version=about["__version__"],
+    url=about["__github__"],
+    download_url=about["__pypi__"],
+    license=about["__license__"],
+    author=about["__author__"],
+    author_email=about["__email__"],
+    description=about["__description__"],
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=deps.pkgs_exclude),
@@ -106,5 +120,5 @@ setup(
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8"
+    python_requires=">=3.8",
 )

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,6 @@ def define_deps():
             for req_file_path in glob.glob(
                 os.path.join(handlers_dir_path, fn, "requirements*.txt")
             ):
-                print(req_file_path)
                 with open(req_file_path) as fp:
                     extra = [req.strip() for req in fp.read().splitlines()]
                 extra_name = fn.replace("_handler", "")
@@ -83,10 +82,7 @@ def define_deps():
                     extra_name += "_" + file_name.replace("requirements_", "").replace(
                         ".txt", ""
                     )
-                print(extra_name)
                 extra_requirements[extra_name] = extra
-                print(extra_requirements[extra_name])
-                print("")
                 full_handlers_requirements += extra
 
     extra_requirements["all_handlers_extras"] = list(set(full_handlers_requirements))


### PR DESCRIPTION
Also modifies setup.py to handle extra requirements files in the form `requirements<x>.txt` inside a handler folder. This allows us multiple setups of a handler (like `huggingface_cpu`, which installs the cpu version of torch instead of the gpu version).

fixes #6538