### PR TITLE
Adding support for GCS based store.

### DIFF
--- a/docker/beta
+++ b/docker/beta
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:latest
+FROM  --platform=linux/amd64 pytorch/pytorch:latest
 
 EXPOSE 47334/tcp
 EXPOSE 47335/tcp
@@ -10,6 +10,17 @@ ENV MDB_RELTYPE=beta
 
 COPY mindsdb_config.beta.json /root/mindsdb_config.json
 COPY mindsdb_launcher.sh /root/
+COPY setup_cloud.sh /root/
+
+RUN chmod +x /root/setup_cloud.sh
+
+# Adding Support for cloud storage setup
+RUN apt install -y jq; \
+    apt install -y fuse; \
+    apt install -y curl; \
+    curl -L -O https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v0.42.5/gcsfuse_0.42.5_amd64.deb ; \
+    dpkg --install gcsfuse_0.42.5_amd64.deb; \
+    rm gcsfuse_0.42.5_amd64.deb;
 
 # run launcher to install beta MindsDB as specified at
 # https://public.api.mindsdb.com/installer/beta/docker___success___None

--- a/docker/docker-compose-cloud.yml
+++ b/docker/docker-compose-cloud.yml
@@ -1,0 +1,24 @@
+version: "3.2"
+
+services:
+
+  mindsdb:
+    image:
+      mindsdb:cloud
+    ports:
+      - '47334:47334'
+      - '47335:47335'
+      - '47336:47336'
+    command: bash -c "cd /mindsdb && ./mindsdb_launcher.sh start"
+    privileged: true
+    volumes:
+      - /home/h1t35h/.gcs_creds:/tmp/creds.json:ro
+    environment:
+      MINDSDB_CLOUD_DIR: "/root/cloud"
+      GCS_BUCKET: "minds-db-cloud"
+      GOOGLE_APPLICATION_CREDENTIALS: "/tmp/creds.json"
+    healthcheck:
+      test:  ["CMD", "curl", "-f", "http://localhost:47334/api/util/ping"]
+      interval: 30s
+      timeout: 4s
+      retries: 100

--- a/docker/mindsdb_config.beta.json
+++ b/docker/mindsdb_config.beta.json
@@ -1,6 +1,7 @@
 {
     "config_version":"1.4",
     "storage_dir": "/root/mdb_storage",
+    "cloud_storage_dir": "/root/cloud",
     "log": {
         "level": {
             "console": "ERROR",

--- a/docker/mindsdb_launcher.sh
+++ b/docker/mindsdb_launcher.sh
@@ -4,6 +4,8 @@ if [[ -n "$MDB_CONFIG_CONTENT" ]]; then
   echo "$MDB_CONFIG_CONTENT" > /root/mindsdb_config.json;
 fi;
 
+bash /root/setup_cloud.sh
+
 if [[ -n "$MDB_AUTOUPDATE" ]]; then
   URL="https://public.api.mindsdb.com/installer/$MDB_RELTYPE/docker___started___None"
   VERSION=$(python -c "import urllib.request as r; print(r.urlopen('$URL').read().decode())")

--- a/docker/release
+++ b/docker/release
@@ -1,4 +1,4 @@
-FROM docker.io/pytorch/pytorch:1.13.0-cuda11.6-cudnn8-runtime
+FROM --platform=linux/amd64 docker.io/pytorch/pytorch:1.13.0-cuda11.6-cudnn8-runtime
 
 EXPOSE 47334/tcp
 EXPOSE 47335/tcp
@@ -89,6 +89,17 @@ ARG VERSION=
 RUN pip install --no-cache-dir mindsdb${VERSION:+"==$VERSION"}
 
 COPY mindsdb_config.release.json /root/mindsdb_config.json
+COPY setup_cloud.sh /root/
 COPY mindsdb_launcher.sh /root/
+
+RUN chmod +x /root/setup_cloud.sh
+
+# Adding Support for cloud storage setup
+RUN apt install -y jq; \
+    apt install -y fuse; \
+    apt install -y curl; \
+    curl -L -O https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v0.42.5/gcsfuse_0.42.5_amd64.deb ; \
+    dpkg --install gcsfuse_0.42.5_amd64.deb; \
+    rm gcsfuse_0.42.5_amd64.deb;
 
 CMD bash /root/mindsdb_launcher.sh start

--- a/docker/setup_cloud.sh
+++ b/docker/setup_cloud.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Create mount directory for service
+# Currently only setting up GCS will update for multiple cloud storages.
+
+MINDSDB_CLOUD_DIR=$(jq '."cloud_storage_dir" //empty' /root/mindsdb_config.json)
+echo "Cloud Mount dir configuration : $MINDSDB_CLOUD_DIR"
+if [ -n "$MINDSDB_CLOUD_DIR" ] && [ -n "$GOOGLE_APPLICATION_CREDENTIALS" ] && [ -n "$GCS_BUCKET" ]
+then
+  echo "Mounting GCS Fuse."
+  echo "Using application default target as : $GOOGLE_APPLICATION_CREDENTIALS\n"
+  mkdir -p $MINDSDB_CLOUD_DIR;
+  gcsfuse --debug_gcs --debug_fuse --debug_http $GCS_BUCKET $MINDSDB_CLOUD_DIR;
+  echo "Mounting completed."
+  echo "Cloud setup complete."
+else
+  echo "Cloud configuration not present using disk store."
+fi;
+
+exit 0

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -76,7 +76,7 @@ class Config():
 
         if os.path.isdir(root_storage_dir) is False:
             os.makedirs(root_storage_dir)
-        if os.path.isdir(cloud_storage_dir) is False:
+        if cloud_storage_dir is not None and os.path.isdir(cloud_storage_dir) is False:
             os.makedirs(cloud_storage_dir)
 
         if 'storage_db' in self._override_config:

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -64,7 +64,7 @@ class Config():
         else:
             root_storage_dir = get_or_create_data_dir()
             os.environ['MINDSDB_STORAGE_DIR'] = root_storage_dir
-            os.environ['MINDSDB_CLOUD_DIR'] = root_storage_dir # backward compatibility for cloud dir
+            os.environ['MINDSDB_CLOUD_DIR'] = root_storage_dir  # backward compatibility for cloud dir
         # endregion
 
         # cloud storage setup
@@ -91,10 +91,9 @@ class Config():
 
         paths = {
             'root': os.environ['MINDSDB_STORAGE_DIR'],
-            'cloud_root': os.environ['MINDSDB_CLOUD_DIR'] 
+            'cloud_root': os.environ['MINDSDB_CLOUD_DIR']
         }
-        
-
+      
         # content - temporary storage for entities
         paths['content'] = os.path.join(paths['root'], 'content')
         # storage - persist storage for entities

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -93,7 +93,7 @@ class Config():
             'root': os.environ['MINDSDB_STORAGE_DIR'],
             'cloud_root': os.environ['MINDSDB_CLOUD_DIR']
         }
-      
+
         # content - temporary storage for entities
         paths['content'] = os.path.join(paths['root'], 'content')
         # storage - persist storage for entities


### PR DESCRIPTION
## Description

This changes adds support for using GCS as a storage volume for storing mindsdb DB. Allowing container failures to not impact

**Fixes** #2425 

## Type of change

(Please delete options that are not relevant)

- [x] ⚡ New feature (non-breaking change which adds functionality)
- [x] 📄 This change requires a documentation update

### What is the solution?

1. Added scripts for adding `gcsfuse` file system mount.
2. Updated configuration for storing sqllitedb file on mounted file system and cache,logs etc on disk.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, or created issues to update them.
