### PR TITLE
Add tip for MonetDB dependencies

### DIFF
--- a/docs/data-integrations/monetdb.mdx
+++ b/docs/data-integrations/monetdb.mdx
@@ -20,6 +20,10 @@ The required arguments to establish a connection are as follows:
 * `database` is the database name to be connected.
 * `schema_name` is the schema name to get tables. It is optional and defaults to the current schema if not provided.
 
+<Tip>
+If you installed MindsDB locally via pip, you need to install all handler dependencies manually. To do so, go to the handler's folder (mindsdb/integrations/handlers/monetdb_handler) and run this command: `pip install -r requirements.txt`.
+</Tip>
+
 ## Usage
 
 In order to make use of this handler and connect to the MonetDB database in MindsDB, the following syntax can be used:


### PR DESCRIPTION
## Description

Added a tip to manually install dependencies for MonetDB in the case where MindsDB was installed locally via pip.

**Fixes** #6693 

## Type of change

- [x] 📄 This change requires a documentation update

### What is the solution?

Added more documentation using html in the `docs/data-integrations/monetdb.mdx` file

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, or created issues to update them.
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] I have shared a short loom video or screenshots demonstrating any new functionality.
