### PR TITLE
fix:typo

### DIFF
--- a/docker/handler_discovery/sd.py
+++ b/docker/handler_discovery/sd.py
@@ -9,7 +9,7 @@ app = Flask(__name__)
 
 @app.route("/")
 def index():
-    return "MindsDB Hanler Discovery", 200
+    return "MindsDB Handler Discovery", 200
 
 
 @app.route("/register", methods=["POST"])


### PR DESCRIPTION
## Description

In docker/handler_discovery/sd.py 

@app.route("/")
def index():
    return "MindsDB Hanler Discovery", 200

changed to 

@app.route("/")
def index():
    return "MindsDB Handler Discovery", 200

**Fixes** #(issue)

## Typo fix

(Please delete options that are not relevant)



### What is the solution?

Changed Hanlet to Handler

## Checklist:

- [ X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
