### PR TITLE
Fixed the Example CREATE DATABASE Statement in Apache Ignite README

### DIFF
--- a/mindsdb/integrations/handlers/ignite_handler/README.md
+++ b/mindsdb/integrations/handlers/ignite_handler/README.md
@@ -4,6 +4,7 @@ This is the implementation of the Apache Ignite handler for MindsDB.
 
 ## Apache Ignite
 Apache Ignite is a distributed database for high-performance computing with in-memory speed.
+<br>
 https://ignite.apache.org/docs/latest/
 
 ## Implementation
@@ -19,12 +20,11 @@ There are several optional arguments that can be used as well,
 * `schema`: the schema to use for the connection to the Apache Ignite cluster. This parameter is optional. Default: PUBLIC.
 
 ## Usage
-In order to make use of this handler and connect to a Apache Ignite cluster in MindsDB, the following syntax can be used,
+In order to make use of this handler and connect to an Apache Ignite cluster in MindsDB, the following syntax can be used,
 ~~~~sql
 CREATE DATABASE ignite_datasource
 WITH ENGINE = 'ignite',
 PARAMETERS = {
-    "db_engine": "ignite",
     "host": "127.0.0.1",
     "port": 10800,
     "username": "admin",
@@ -39,4 +39,5 @@ SELECT * FROM ignite_datasource.example_tbl
 ~~~~
 
 At the moment, a connection can be established to only a single node in the cluster. Steps will be taken in the future, to configure the client to automatically fail over to another node if the connection to the current node fails or times out by providing the hosts and ports for many nodes as explained here,
+<br>
 https://ignite.apache.org/docs/latest/thin-clients/python-thin-client


### PR DESCRIPTION
I made a small change to the example CREATE DATABASE statement given in the README for the Apache Ignite handler by removing an incorrect parameter.