### PR TITLE
mark predictor as 'error' if cant get training data

### DIFF
--- a/mindsdb/integrations/libs/learn_process.py
+++ b/mindsdb/integrations/libs/learn_process.py
@@ -129,6 +129,7 @@ def learn_process(class_path, engine, context_dump, integration_id,
             print(traceback.format_exc())
             error_message = format_exception_error(e)
 
+            predictor_record = db.Predictor.query.with_for_update().get(predictor_id)
             predictor_record.data = {"error": error_message}
             predictor_record.status = PREDICTOR_STATUS.ERROR
             db.session.commit()


### PR DESCRIPTION
## Description

Mark predictor as 'error' if can't get training data

Close #6832

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
