### PR TITLE
Show error message from frappe api

### DIFF
--- a/mindsdb/integrations/handlers/frappe_handler/frappe_client.py
+++ b/mindsdb/integrations/handlers/frappe_handler/frappe_client.py
@@ -93,7 +93,8 @@ class FrappeClient(object):
             json=data,
             headers=self.headers)
         if not post_response.ok:
-            post_response.raise_for_status()
+            if 400 <= post_response.status_code < 600:
+                raise requests.HTTPError(f'{post_response.reason}: {post_response.text}', response=post_response)
         return post_response.json()['data']
 
     def ping(self) -> bool:


### PR DESCRIPTION
## Description

Now in case of error frappe_client shows only 'Expectation Failed'
After update content of error message should be visible

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
