### PR TITLE
Include learn_args When Getting Models via REST API

### DIFF
--- a/mindsdb/api/http/namespaces/models.py
+++ b/mindsdb/api/http/namespaces/models.py
@@ -103,7 +103,7 @@ class ModelsList(Resource):
                 'mindsdb_version': model_df.at[0, 'MINDSDB_VERSION'],
                 'error': model_df.at[0, 'ERROR'],
                 'fetch_data_query': model_df.at[0, 'SELECT_DATA_QUERY'],
-                'learn_args': model_df.at[0, 'TRAINING_OPTIONS']
+                'problem_definition': model_df.at[0, 'TRAINING_OPTIONS']
             }, HTTPStatus.CREATED
         except Exception as e:
             return http_error(

--- a/mindsdb/interfaces/model/model_controller.py
+++ b/mindsdb/interfaces/model/model_controller.py
@@ -83,7 +83,7 @@ class ModelController():
         full_model_data = self.get_model_data(name=name, predictor_record=predictor_record, ml_handler_name=ml_handler_name)
         reduced_model_data = {}
         for k in ['id', 'name', 'version', 'is_active', 'predict', 'status',
-                  'learn_args', 'current_phase', 'accuracy', 'data_source', 'update', 'active',
+                  'problem_definition', 'current_phase', 'accuracy', 'data_source', 'update', 'active',
                   'mindsdb_version', 'error', 'created_at', 'fetch_data_query']:
             reduced_model_data[k] = full_model_data.get(k, None)
 

--- a/tests/api/http/models_test.py
+++ b/tests/api/http/models_test.py
@@ -73,7 +73,7 @@ def test_train_model(client):
         'predict': 'rental_price',
         'status': 'generating',
         'version': 1,
-        'learn_args': "{'target': 'rental_price'}"
+        'problem_definition': "{'target': 'rental_price'}"
     }
 
     assert created_model == expected_model


### PR DESCRIPTION
## Description

We should include `learn_args` when getting models with the REST API since it contains useful information to the user (API keys, model params, etc).

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
