### PR TITLE
Singlestore conn attr

### DIFF
--- a/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
+++ b/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
@@ -51,6 +51,9 @@ class MySQLHandler(DatabaseHandler):
             'password': self.connection_data.get('password'),
             'database': self.connection_data.get('database')
         }
+        
+        if 'conn_attrs' in self.connection_data:
+            config['conn_attrs'] = self.connection_data['conn_attrs']
 
         ssl = self.connection_data.get('ssl')
         if ssl is True:

--- a/mindsdb/integrations/handlers/singlestore_handler/singlestore_handler.py
+++ b/mindsdb/integrations/handlers/singlestore_handler/singlestore_handler.py
@@ -1,5 +1,5 @@
 from ..mysql_handler import Handler as MySQLHandler
-
+from .__about__ import __version__ as version
 
 class SingleStoreHandler(MySQLHandler):
     """
@@ -8,4 +8,5 @@ class SingleStoreHandler(MySQLHandler):
     name = 'singlestore'
 
     def __init__(self, name, **kwargs):
+        kwargs['conn_attrs'] = {'mindsdb', 'MindsDB', version}
         super().__init__(name, **kwargs)


### PR DESCRIPTION
## Description

This PR adds an additional `conn_attrs` key to the MySQL config required for providing a partner name for the SingleStore integration.

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
