### PR TITLE
Unknown argument validation + fix openai handler test

### DIFF
--- a/mindsdb/integrations/handlers/openai_handler/openai_handler.py
+++ b/mindsdb/integrations/handlers/openai_handler/openai_handler.py
@@ -65,6 +65,37 @@ class OpenAIHandler(BaseMLEngine):
                         4) a `prompt' and 'user_column' and 'assistant_column`
                 '''))
 
+        # for all args that are not expected, raise an error
+        known_args = set()
+        # flatten of keys_collection
+        for keys in keys_collection:
+            known_args = known_args.union(set(keys))
+
+        # TODO: need a systematic way to maintain a list of known args
+        known_args = known_args.union(
+            {
+                "target",
+                "model_name",
+                "mode",
+                "predict_params",
+                "input_text",
+                "ft_api_info",
+                "ft_result_stats",
+                "runtime",
+                "max_tokens",
+                "temperature",
+                "api_key",
+                "openai_api_key",
+            }
+        )
+
+        unknown_args = set(args.keys()) - known_args
+        if unknown_args:
+            # return a list of unknown args as a string
+            raise Exception(
+                f"Unknown arguments: {', '.join(unknown_args)}.\n Known arguments are: {', '.join(known_args)}"
+            )
+
     def create(self, target, args=None, **kwargs):
         args = args['using']
 

--- a/tests/unit/ml_handlers/test_openai.py
+++ b/tests/unit/ml_handlers/test_openai.py
@@ -8,6 +8,7 @@ import pandas as pd
 from mindsdb_sql import parse_sql
 
 from tests.unit.executor_test_base import BaseExecutorTest
+from mindsdb.integrations.handlers.openai_handler.openai_handler import OpenAIHandler
 
 
 OPEN_AI_API_KEY = os.environ.get("OPEN_AI_API_KEY")
@@ -79,7 +80,7 @@ class TestOpenAI(BaseExecutorTest):
                     engine='openai',
                     question_column='question',
                     openai_api_key='{OPEN_AI_API_KEY}',
-                    model='unknown_argument';  --- this is a wrong argument name
+                    evidently_wrong_argument='wrong value';  --- this is a wrong argument name
             """
             )
 
@@ -222,8 +223,11 @@ class TestOpenAI(BaseExecutorTest):
         """Tests normal completions (e.g. text-davinci-003) with bulk joins that are larger than the max batch_size"""
         # create project
         self.run_sql("create database proj")
-        max_batch_size = 10
-        N = 1 + max_batch_size  # get N larger than default batch size
+        handler = OpenAIHandler(
+            model_storage=None,  # the storage does not matter for this test
+            engine_storage=None,
+        )
+        N = 1 + handler.max_batch_size  # get N larger than default batch size
         df = pd.DataFrame.from_dict({"input": ["I feel happy!"] * N})
         self.set_handler(mock_handler, name="pg", tables={"df": df})
         self.run_sql(

--- a/tests/unit/ml_handlers/test_openai.py
+++ b/tests/unit/ml_handlers/test_openai.py
@@ -9,7 +9,6 @@ from mindsdb_sql import parse_sql
 
 from tests.unit.executor_test_base import BaseExecutorTest
 
-from mindsdb.integrations.handlers.openai_handler.openai_handler import OpenAIHandler
 
 OPEN_AI_API_KEY = os.environ.get("OPEN_AI_API_KEY")
 os.environ["OPENAI_API_KEY"] = OPEN_AI_API_KEY


### PR DESCRIPTION
## Description

When creating the openAI handler, we validate the arguments provided by a user against a known list of arguments.
We throw an error an unexpected argument was found.

This solution is a bit hacky, in the sense we need to keep maintaining and updating the right argument list on the handler level. I am proposing a [design doc](https://docs.google.com/document/d/1mE64JEXmn0Kz60c0_qVAWhjvNKCpiNvg5wVLxHPoKjY/edit?usp=sharing) to ask handler developers to self declare and document
the argument specifications in the handler implementation.



**Fixes** #6845

Error message if wrong arguments are provided:
<img width="663" alt="image" src="https://github.com/mindsdb/mindsdb/assets/74702693/518b708d-6bb1-4418-9fee-ebfd0bad0ee7">


## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

We maintain a list of known arguments that can be accepted.
Anything beyond this list will be regarded as invalid. The handler throws an error when creating it with unknown arguments.


## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
