### PR TITLE
Don't rise exception if table has more than 2 parts

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
+++ b/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
@@ -94,12 +94,10 @@ def get_preditor_alias(step, mindsdb_database):
 def get_table_alias(table_obj, default_db_name):
     # (database, table, alias)
     if isinstance(table_obj, Identifier):
-        if len(table_obj.parts) > 2:
-            raise ErSqlWrongArguments(f'Table name must contain no more than 2 parts. Got name: {table_obj.parts}')
-        elif len(table_obj.parts) == 1:
+        if len(table_obj.parts) == 1:
             name = (default_db_name, table_obj.parts[0])
         else:
-            name = tuple(table_obj.parts)
+            name = (table_obj.parts[0], table_obj.parts[-1])
     elif isinstance(table_obj, Select):
         # it is subquery
         if table_obj.alias is None:
@@ -715,7 +713,7 @@ class SQLQuery():
                 result = steps_data[-1]
                 self.fetched_data = result
         except Exception as e:
-            raise SqlApiUnknownError("error in preparing result quiery step") from e
+            raise SqlApiUnknownError("error in preparing result query step") from e
 
         try:
             if hasattr(self, 'columns_list') is False:

--- a/mindsdb/interfaces/database/views.py
+++ b/mindsdb/interfaces/database/views.py
@@ -90,7 +90,9 @@ class ViewController:
                 company_id=ctx.company_id
             ).all()
         if len(records) == 0:
-            raise Exception(f"Can't find view with name/id: {name}/{id}")
+            if name is None:
+                name = f'id={id}'
+            raise Exception(f"Can't find view '{name}' in project '{project_name}'")
         elif len(records) > 1:
             raise Exception(f"There are multiple views with name/id: {name}/{id}")
         record = records[0]


### PR DESCRIPTION
#6507

Don't rise exception if table has more than 2 parts and try to send select as is in integration


## Description

Please include a summary of the change and the issue it solves. 

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
