### PR TITLE
Fix oracle: connection with sys should be sysdba or sysoper

### DIFF
--- a/mindsdb/integrations/handlers/oracle_handler/README.md
+++ b/mindsdb/integrations/handlers/oracle_handler/README.md
@@ -26,7 +26,9 @@ PARAMETERS = {
     "port": "1521",
     "sid": "ORCL",
     "user": "admin",
-    "password": "pass"
+    "password": "pass",
+    "disable_oob": true, -- optional, disable out-of-band breaks, sometimes may help with connection see https://python-oracledb.readthedocs.io/en/latest/api_manual/module.html
+    "auth_mode": "SYSDBA" -- optional, to connect with database privilege: SYSDBA, SYSOPER or others
 };
 ```
 


### PR DESCRIPTION
Changes:

- added disable_oob param (disable out-of-band breaks)
- added auth_mode param (connect with database privilege)
- fixed get_tables methdo 

#6746

## Description

Please include a summary of the change and the issue it solves. 

**Fixes** #(issue)

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
