### PR TITLE
[Bug, Docker] Shopify bug fixed

### DIFF
--- a/docker/release
+++ b/docker/release
@@ -85,7 +85,8 @@ RUN python -m pip install --prefer-binary --no-cache-dir --upgrade pip==23.1.2 &
     pip install --no-cache-dir 'wikipedia==1.4.0' 'langchain==0.0.146' || true && \
     pip install --no-cache-dir 'pysurrealdb' 'websocket' || true && \
     pip install --no-cache-dir 'pygithub' || true && \
-    pip install --prefer-binary --no-cache-dir hugging_py_face || true 
+    pip install --prefer-binary --no-cache-dir hugging_py_face || true && \
+    pip install --prefer-binary --no-cache-dir ShopifyApi || true
 
 ARG VERSION=
 RUN pip install --no-cache-dir mindsdb${VERSION:+"==$VERSION"}


### PR DESCRIPTION
## Description

In order to use  `Shopify` integration, the dependency was not mentioned in the `release` file. So, it was breaking while using Docker environment

**Fixes** #6913 

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### What is the solution?
Added the dependency in the `release` file for docker env

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
