### PR TITLE
Better error message if handler cannot be used

### DIFF
--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -237,22 +237,6 @@ if __name__ == '__main__':
             db.session.commit()
         # endregion
 
-        for integration_name in config.get('integrations', {}):
-            try:
-                it = integration_controller.get(integration_name)
-                if it is not None:
-                    integration_controller.delete(integration_name)
-                print(f'Adding: {integration_name}')
-                integration_data = config['integrations'][integration_name]
-                engine = integration_data.get('type')
-                if engine is not None:
-                    del integration_data['type']
-                integration_controller.add(integration_name, engine, integration_data)
-            except Exception as e:
-                log.logger.error(f'\n\nError: {e} adding database integration {integration_name}\n\n')
-
-    # @TODO Backwards compatibility for tests, remove later
-
     if args.api is None:
         api_arr = ['http', 'mysql']
     else:

--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -9,6 +9,7 @@ import asyncio
 import secrets
 import traceback
 import threading
+from textwrap import dedent
 from packaging import version
 
 from mindsdb.__about__ import __version__ as mindsdb_version
@@ -189,16 +190,14 @@ if __name__ == '__main__':
     print(f'Configuration file:\n   {config.config_path}')
     print(f"Storage path:\n   {config['paths']['root']}")
 
-    # @TODO Backwards compatibility for tests, remove later
     for handler_name, handler_meta in integration_controller.get_handlers_import_status().items():
         import_meta = handler_meta.get('import', {})
-        dependencies = import_meta.get('dependencies')
         if import_meta.get('success', False) is not True:
-            print(f"Dependencies for the handler '{handler_name}' are not installed by default.\n",
-                  f'If you want to use "{handler_name}" please install "{dependencies}"')
-
-    # from mindsdb.utilities.fs import get_marked_processes_and_threads
-    # marks = get_marked_processes_and_threads()
+            print(dedent('''
+                Some handlers cannot be imported. You can check list of available handlers by execute command in sql editor:
+                    select * from information_schema.handlers;
+            '''))
+            break
 
     if not is_cloud:
         # region creating permanent integrations

--- a/mindsdb/interfaces/database/integrations.py
+++ b/mindsdb/interfaces/database/integrations.py
@@ -11,6 +11,7 @@ from time import time
 from pathlib import Path
 from copy import deepcopy
 from typing import Optional
+from textwrap import dedent
 from collections import OrderedDict
 
 from sqlalchemy import func
@@ -428,8 +429,18 @@ class IntegrationController:
             raise Exception(f"Can't find handler for '{integration_name}' ({integration_engine})")
 
         integration_meta = self.handlers_import_status[integration_engine]
-        if not integration_meta["import"]["success"]:
-            msg = f"to use {integration_engine} please install 'pip install mindsdb[{integration_engine}]'"
+        if integration_meta["import"]["success"] is False:
+            msg = dedent(f'''\
+                Handler '{integration_engine}' cannot be used. Reason is:
+                    {integration_meta['import']['error_message']}
+            ''')
+            is_cloud = Config().get('cloud', False)
+            if is_cloud is False:
+                msg += dedent(f'''
+
+                If error is related to missing dependencies, then try to run command in shell and restart mindsdb:
+                    pip install mindsdb[{integration_engine}]
+                ''')
             logger.debug(msg)
             raise Exception(msg)
 


### PR DESCRIPTION
## Description

 - do not show at start list of handlers that cannot be imported
 - improve error message if handler cannot be imported
 - delete ability to create integration via config file

**Fixes**
[Fix 6208](https://github.com/mindsdb/mindsdb/issues/6208)

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
