### PR TITLE
Fix for files locking

### DIFF
--- a/docker/mindsdb.Dockerfile
+++ b/docker/mindsdb.Dockerfile
@@ -14,9 +14,11 @@ WORKDIR /
 
 COPY . /mindsdb/
 WORKDIR /mindsdb
-RUN pip install ".[grpc]" ".[telemetry]"
+# RUN pip install ".[grpc]" ".[telemetry]"
 
 RUN pip install git+https://github.com/mindsdb/lightwood.git@staging --upgrade --no-cache-dir
+RUN python3 -c 'import nltk; nltk.download("punkt");'
+RUN pip install neuralforecast
 # COPY ./mindsdb /mindsdb/mindsdb
 
 ENV PYTHONPATH "/mindsdb"

--- a/mindsdb/api/http/namespaces/tab.py
+++ b/mindsdb/api/http/namespaces/tab.py
@@ -1,4 +1,7 @@
 import json
+import traceback
+from http import HTTPStatus
+
 from flask import request
 from flask_restx import Resource
 
@@ -6,6 +9,7 @@ from mindsdb.interfaces.storage.fs import FileStorageFactory, RESOURCE_GROUP
 from mindsdb.api.http.namespaces.configs.tabs import ns_conf
 from mindsdb.utilities.log import get_log
 from mindsdb.utilities.context import context as ctx
+from mindsdb.api.http.utils import http_error
 
 logger = get_log("main")
 
@@ -52,6 +56,11 @@ class Tab(Resource):
             storage.file_set(TABS_FILENAME, b_types)
         except Exception as e:
             logger.warning("unable to store tabs data - %s", e)
-            return str(e), 500
+            print(traceback.format_exc())
+            return http_error(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                "Can't save tabs",
+                'something went wrong during tabs saving'
+            )
 
         return '', 200

--- a/mindsdb/interfaces/storage/fs.py
+++ b/mindsdb/interfaces/storage/fs.py
@@ -159,7 +159,9 @@ class FileLock:
             except Exception:
                 pass
         try:
-            self._file = open(self._lock_file_path, 'r')
+            # On at least some systems, LOCK_EX can only be used if the file
+            # descriptor refers to a file opened for writing.
+            self._file = open(self._lock_file_path, 'w')
             fd = self._file.fileno()
             fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except (ValueError, FileNotFoundError):


### PR DESCRIPTION
## Description

 On at least some systems, LOCK_EX can only be used if the file descriptor refers to a file opened for writing. Previously we opened files for read.

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
