### PR TITLE
Fix Database Connection Issue With Ignite by Ensuring Port is an Integer

### DIFF
--- a/mindsdb/integrations/handlers/ignite_handler/ignite_handler.py
+++ b/mindsdb/integrations/handlers/ignite_handler/ignite_handler.py
@@ -68,7 +68,12 @@ class IgniteHandler(DatabaseHandler):
             password=self.connection_data['password']
         )
 
-        nodes = [(self.connection_data['host'], self.connection_data['port'])]
+        try:
+            port = int(self.connection_data['port'])
+        except ValueError:
+            raise ValueError("Invalid port number")
+
+        nodes = [(self.connection_data['host'], port)]
         self.connection = self.client.connect(nodes)
         self.is_connected = True
 


### PR DESCRIPTION
## Description

This PR ensures that the port value, retrieved from connection configurations, is properly converted to an integer before attempting the connection. Additionally, a ValueError is raised if the provided port number is not a valid integer.


## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update


## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
