### PR TITLE
[fix] correct passing of finetuning args in lightwood

### DIFF
--- a/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/functions.py
+++ b/mindsdb/integrations/handlers/lightwood_handler/lightwood_handler/functions.py
@@ -190,7 +190,7 @@ def run_finetune(df: DataFrame, args: dict, model_storage):
         )
         predictor = lightwood.predictor_from_state(base_fs.folder_path / base_fs.folder_name,
                                                    base_predictor_record.code)
-        predictor.adjust(df, adjust_args=args)
+        predictor.adjust(df, adjust_args=args.get('using', {}))
 
         fs = FileStorage(
             resource_group=RESOURCE_GROUP.PREDICTOR,


### PR DESCRIPTION
## Description

For example, this command:
```sql
FINETUNE model
FROM mindsdb (
    SELECT * FROM data
)
USING
trainer_args = {"max_steps": 10};
```

Will pass to the `.partial_fit()` method the following `args` variable:

```python
args = {
     <any other training-time key-value pairs here>
     ...
     'trainer_args': {"max_steps": 10}  # will override any pair provided above under the same key
}
```


## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
