### PR TITLE
Statsforecast: allow to create model without group column

### DIFF
--- a/mindsdb/integrations/handlers/statsforecast_handler/statsforecast_handler.py
+++ b/mindsdb/integrations/handlers/statsforecast_handler/statsforecast_handler.py
@@ -99,6 +99,11 @@ class StatsForecastHandler(BaseMLEngine):
         model_args["target"] = target
         model_args["horizon"] = time_settings["horizon"]
         model_args["order_by"] = time_settings["order_by"]
+        if 'group_by' not in time_settings:
+            # add group column
+            group_col = '__groupy_by'
+            time_settings["group_by"] = [group_col]
+
         model_args["group_by"] = time_settings["group_by"]
         model_args["frequency"] = (
             using_args["frequency"] if "frequency" in using_args else infer_frequency(df, time_settings["order_by"])

--- a/mindsdb/integrations/utilities/time_series_utils.py
+++ b/mindsdb/integrations/utilities/time_series_utils.py
@@ -31,6 +31,10 @@ def transform_to_nixtla_df(df, settings_dict, exog_vars=[]):
     else:
         group_col = settings_dict["group_by"][0]
 
+    if group_col not in df.columns:
+        # add to dataframe
+        nixtla_df[group_col] = '1'
+
     # Rename columns to statsforecast names
     nixtla_df = nixtla_df.rename(
         {settings_dict["target"]: "y", settings_dict["order_by"]: "ds", group_col: "unique_id"}, axis=1


### PR DESCRIPTION
## Description

Updated statsforecast handler to accept dataframes without grouping column. Grouping column is added inside of handler.

Usage:

Fix #6948

Because [NFLX.xls](https://github.com/mindsdb/mindsdb/files/12171104/NFLX.xls) dataset doesn't contain group values need to create model without 'group by' clause:


```sql
CREATE MODEL 
netflix_stock 
FROM files (select * from nflx)
 PREDICT High 
ORDER BY Date 
 HORIZON 30 
USING ENGINE = 'statsforecast';
```

Usage of model:

```sql
SELECT *
FROM mindsdb.netflix_stock as m
JOIN files.nflx as t
WHERE t.date > LATEST
```








## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
