### PR TITLE
WEB handler: no error if result is empty

### DIFF
--- a/mindsdb/integrations/handlers/web_handler/urlcrawl_helpers.py
+++ b/mindsdb/integrations/handlers/web_handler/urlcrawl_helpers.py
@@ -241,8 +241,7 @@ def get_all_websites(urls, limit=1, html=False):
         columns_to_ignore += ['html_content']
     df = dict_to_dataframe(reviewd_urls, columns_to_ignore=columns_to_ignore, index_name='url')
 
-
-    if df[df.error.isna()].empty:
+    if not df.empty and df[df.error.isna()].empty:
         # no real data - rise exception from first row
         raise Exception(str(df.iloc[0].error))
     return df


### PR DESCRIPTION
## Description

Fixed: this query rose exception because output dataframe is empty and doesn't content error column
```
select * from web ( https://docs.mindsdb.com, limit=0)
```

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
