### PR TITLE
Raise SlackApiError in Select Method

### DIFF
--- a/mindsdb/integrations/handlers/slack_handler/slack_handler.py
+++ b/mindsdb/integrations/handlers/slack_handler/slack_handler.py
@@ -116,6 +116,7 @@ class SlackChannelsTable(APITable):
             conversation_history = result["messages"]
         except SlackApiError as e:
             log.logger.error("Error creating conversation: {}".format(e))
+            raise e
 
         # Get columns for the query and convert SlackResponse object to pandas DataFrame
         columns = []


### PR DESCRIPTION
## Description

If the Slack API returns an error in the `select` method of the `SlackHandler`, the error isn't very helpful to users:

`local variable result referenced before assignment`

This way, we return the underlying cause of the error if a request to the API fails.

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)