### PR TITLE
Allow Web Handler to Process URLs Wrapped in Single Quotes

### DIFF
--- a/mindsdb/integrations/handlers/web_handler/urlcrawl_helpers.py
+++ b/mindsdb/integrations/handlers/web_handler/urlcrawl_helpers.py
@@ -223,6 +223,10 @@ def get_all_websites(urls, limit=1, html=False):
     # reviewd_urls = fetch_url(urls[0])
     # Define a helper function that will be run in parallel.
     def fetch_url(url):
+        # Allow URLs to be passed wrapped in quotation marks so they can be used
+        # directly from the SQL editor.
+        if url.startswith("'") and url.endswith("'"):
+            url = url[1:-1]
         url = url.rstrip('/')
         if urlparse(url).scheme == "":
             # Try HTTPS first


### PR DESCRIPTION
## Description

Currently we're limited when it comes to the URLs we can crawl with Web Handler. They can't contain characters that MindsDB SQL cannot parse (e.g. &, #, etc).

This change makes it so that we can use the web handler from SQL like so:

`RETRAIN news_model FROM web('https://bbc.com?param=1&another=2', limit=1)` 

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
