### PR TITLE
Add duckdb to Docker 

### DIFF
--- a/docker/release
+++ b/docker/release
@@ -88,7 +88,8 @@ RUN python -m pip install --prefer-binary --no-cache-dir --upgrade pip==23.1.2 &
     pip install --no-cache-dir 'pysurrealdb' 'websocket' || true && \
     pip install --no-cache-dir 'pygithub' || true && \
     pip install --prefer-binary --no-cache-dir hugging_py_face || true && \
-    pip install --no-cache-dir pyignite || true && \
+    pip install --no-cache-dir pyignite  || true && \
+    pip install --no-cache-dir duckdb  || true && \
     pip install --prefer-binary --no-cache-dir ShopifyApi || true
 
 ARG VERSION=

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -26,7 +26,7 @@ appdirs >= 1.0.0
 mindsdb-sql >= 0.7.0, < 0.8.0
 mindsdb-evaluator >= 0.0.7, < 0.1.0
 checksumdir >= 1.2.0
-duckdb == 0.6.0
+duckdb == 0.6.1
 requests >= 2.0.0
 mysql-connector-python
 charset-normalizer


### PR DESCRIPTION
## Description

This PR adds duckdb as a dependency required for google sheet integration to Docker. Note, soon we should migrate this handler and avoid loading the sheet to duckdb, but for now it is required.

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update


