### PR TITLE
Safely Fetch 'href' Attribute from 'a' Tag in Web Crawling

### DIFF
--- a/mindsdb/integrations/handlers/web_handler/urlcrawl_helpers.py
+++ b/mindsdb/integrations/handlers/web_handler/urlcrawl_helpers.py
@@ -151,7 +151,7 @@ def get_readable_text_from_soup(soup):
         elif tag.name == 'p':
             markdown_output += tag.get_text().strip() + "\n\n"
         elif tag.name == 'a':
-            markdown_output += f"[{tag.get_text().strip()}]({tag['href']})\n\n"
+            markdown_output += f"[{tag.get_text().strip()}]({tag.get('href')})\n\n"
         elif tag.name == 'ul':
             for li in tag.find_all('li'):
                 markdown_output += f"* {li.get_text().strip()}\n"


### PR DESCRIPTION
## Description

An `<a>` tag is not guaranteed to have the `href` attribute. If it does not, now we do not raise an exception and continue with an empty value for `'href'`


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
