### PR TITLE
fix: add installing option without ssh

### DIFF
--- a/docs/setup/self-hosted/pip/source.mdx
+++ b/docs/setup/self-hosted/pip/source.mdx
@@ -18,7 +18,7 @@ Please note that this method of MindsDB installation requires a minimum of 6 GB 
 1. Clone the MindsDB repository:
 
    ```bash
-   git clone git@github.com:mindsdb/mindsdb.git
+   git clone https://github.com/mindsdb/mindsdb.git
    ```
 
 2. Create a new virtual environment called `mindsdb-venv`:


### PR DESCRIPTION
## Description

The self-hosted restriction suggests using SSH keys to clone the mindsdb repo (`git clone git@github.com:mindsdb/mindsdb.git`). In some cases, this could be restrictive for some users. See #7142. 

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

Suggesting installing using https. 

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, or created issues to update them.
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
