### PR TITLE
fix: house sales statsforecast tutorial

### DIFF
--- a/docs/sql/tutorials/house-sales-statsforecast.mdx
+++ b/docs/sql/tutorials/house-sales-statsforecast.mdx
@@ -82,7 +82,7 @@ Let's create a model table to predict the house price moving average values:
 CREATE MODEL mindsdb.house_sales_predictor
 FROM mysql_demo_db
   (SELECT * FROM house_sales)
-PREDICT MA
+PREDICT house_price_moving_average
 ORDER BY saledate
 GROUP BY bedrooms, type
 WINDOW 8


### PR DESCRIPTION
## Description

This PR fixes the bug related to the target variable forecasted by StatsForecast in https://docs.mindsdb.com/sql/tutorials/house-sales-statsforecast. 

Here's the screenshot of the error:

<img width="985" alt="image" src="https://github.com/FedericoGarza/mindsdb/assets/10517170/ec534370-8370-4c6b-8fd1-37d486187431">

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, or created issues to update them.
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] I have shared a short loom video or screenshots demonstrating any new functionality.
