### PR TITLE
fix: describe rest api with query params

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,6 +14,6 @@ tasks:
   - name: mindsdb
     init: |
       pip install -U pip
-      pip install -r requirements.txt
+      pip install -r requirements/requirements.txt -r requirements_dev.txt
     command: |
       python -m mindsdb

--- a/mindsdb/api/http/namespaces/models.py
+++ b/mindsdb/api/http/namespaces/models.py
@@ -269,9 +269,7 @@ class ModelDescribe(Resource):
                 'Model not found',
                 f'Model with name {model_name} not found')
 
-        attribute = None
-        if 'attribute' in request.json:
-            attribute = request.json['attribute']
+        attribute = request.args.get('attribute')
 
         try:
             description_df = session.model_controller.describe_model(


### PR DESCRIPTION
## Description

Currently, the `/describe` REST API endpoint with `<project_name>` and `<model_name>` parameter fails on a `GET` request as status `400`:

```json
{
  "message": "400 Bad Request: The browser (or proxy) sent a request that this server could not understand."
}
```
The error boils down to a `JSON` decode error in the logs while running locally. So, it is trying to get the `body` from a `GET` request (the body is empty).

**Fixes** #(issue)

## Type of change


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📄 This change requires a documentation update

### What is the solution?

The fix might be to either include a query parameter in the URL or convert the endpoint to the `POST` method. I have simply kept the method the same except I have retrieved the `attribute` field from the query parameters.

PS: I have also changed the `gitpod.yml` file as it didn't install the dependencies on setup. The path to the requirements file has been changed.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.


Let me know if any changes are required in the fix or if documentation changes are required here.
Thank you.