### PR TITLE
Round timestamps in `binance` handler

### DIFF
--- a/mindsdb/integrations/handlers/binance_handler/binance_handler.py
+++ b/mindsdb/integrations/handlers/binance_handler/binance_handler.py
@@ -114,8 +114,8 @@ class BinanceHandler(APIHandler):
         close_time_i = 6
         for i in range(len(raw_klines)):
             # To train we need timestamps to be in seconds since Unix epoch and Binance returns it in ms.
-            raw_klines[i][open_time_i] /= 1000
-            raw_klines[i][close_time_i] /= 1000
+            raw_klines[i][open_time_i] = int(raw_klines[i][open_time_i] / 1000)
+            raw_klines[i][close_time_i] = int(raw_klines[i][close_time_i] / 1000)
 
         df = pd.DataFrame(raw_klines)
         df.insert(0, 'symbol', [symbol] * len(raw_klines), True)


### PR DESCRIPTION
## Description

Round timestamps in `binance` handler. It allows to not convert timestamp to int in query.

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
