### PR TITLE
Add Bot Scopes Explicitly to Slack Chatbot Tutorial

### DIFF
--- a/docs/sql/tutorials/slack-chatbot.mdx
+++ b/docs/sql/tutorials/slack-chatbot.mdx
@@ -37,6 +37,12 @@ If you have a Slack Account, you have to generate the API token, please follow b
     2. Create a new `App` or select an existing `App`.
     3. In the app settings, go to the `OAuth & Permissions` section.
     4. Under the `Bot Token Scopes` section, add the necessary scopes for your application. You can add more later as well.
+        - channels:history
+        - channels:read
+        - chat:write
+        - groups:read
+        - im:read
+        - mpim:read
     5. Install the bot to your workspace.
     6. In the `OAuth Tokens & Redirect URLs` Section, copy the the `Bot User OAuth Access Token` (This is the API token which we need).
     7. Open your Slack, in order to use the bot which we created, we have to add the bot into the channel where we want to use this.


### PR DESCRIPTION
In the Slack Chatbot tutorial, the required permissions are more extensive than what is currently in the docs. This change updates the tutorial to reflect the correct permissions needed.

![image](https://github.com/mindsdb/mindsdb/assets/124617566/db346312-c8d6-488b-9256-c7f5590b88ee)
