### PR TITLE
Don't Cut Off Langchain Error Message in Langchain Handler

### DIFF
--- a/mindsdb/integrations/handlers/langchain_handler/langchain_handler.py
+++ b/mindsdb/integrations/handlers/langchain_handler/langchain_handler.py
@@ -343,7 +343,7 @@ class LangChainHandler(BaseMLEngine):
                     # Handle parsing errors ourselves instead of using handle_parsing_errors=True in initialize_agent.
                     response = str(e)
                     if not response.startswith(_PARSING_ERROR_PREFIX):
-                        completions.append(f'agent failed with error:\n{str(e)[:50]}...')
+                        completions.append(f'agent failed with error:\n{str(e)}...')
                     else:
                         # By far the most common error is a Langchain parsing error. Some OpenAI models
                         # always output a response formatted correctly. Anthropic, and others, sometimes just output
@@ -354,7 +354,7 @@ class LangChainHandler(BaseMLEngine):
                         response = response.lstrip(_PARSING_ERROR_PREFIX).rstrip('`')
                         completions.append(response)
                 except Exception as e:
-                    completions.append(f'agent failed with error:\n{str(e)[:50]}...')
+                    completions.append(f'agent failed with error:\n{str(e)}...')
             return [c for c in completions]
 
         completion = _completion(agent, prompts)


### PR DESCRIPTION
## Description

Currently we only display the first 50 characters of a Langchain error message. This change returns the whole error in a completion. Is there any reason we want to cut it off short? Even if it's super long it shouldn't be an issue.

**Fixes** #6878 

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
