### PR TITLE
handle case of group_by column not present in the dataframe.

### DIFF
--- a/mindsdb/integrations/utilities/time_series_utils.py
+++ b/mindsdb/integrations/utilities/time_series_utils.py
@@ -121,6 +121,9 @@ def get_hierarchy_from_df(df, model_args):
     nixtla_df = df.rename({model_args["order_by"]: "ds", model_args["target"]: "y"}, axis=1)
     nixtla_df["ds"] = pd.to_datetime(nixtla_df["ds"])
     for col in model_args["group_by"]:
+        # add to dataframe if it doesn't exist
+        if col not in nixtla_df.columns:
+            nixtla_df[col] = '1'
         nixtla_df[col] = nixtla_df[col].astype(str)  # grouping columns need to be string format
     nixtla_df.insert(0, "Total", "total")
 


### PR DESCRIPTION
## Description

Based on the discussion on the Slack channel, I believe the problem comes from the way the group_by is being handled when no group_by argument is specified.

**Fixes** #(issue)

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### What is the solution?

https://github.com/mindsdb/lightwood/issues/1180#issuecomment-1693278552

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them. -> no need
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable). -> no need
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality. -> no need
