### PR TITLE
fix: support for non-grouped data in timegpt

### DIFF
--- a/mindsdb/integrations/utilities/time_series_utils.py
+++ b/mindsdb/integrations/utilities/time_series_utils.py
@@ -51,13 +51,15 @@ def get_results_from_nixtla_df(nixtla_df, model_args):
     This will return the dataframe to the original format supplied by the MindsDB query.
     """
     return_df = nixtla_df.reset_index(drop=True if 'ds' in nixtla_df.columns else False)
-    return_df.columns = ["unique_id", "ds", model_args["target"]]
-    if len(model_args["group_by"]) > 1:
-        for i, group in enumerate(model_args["group_by"]):
-            return_df[group] = return_df["unique_id"].apply(lambda x: x.split("/")[i])
-    else:
-        group_by_col = model_args["group_by"][0]
-        return_df[group_by_col] = return_df["unique_id"]
+    if len(model_args["group_by"]) > 0:
+        return_df.columns = ["unique_id", "ds", model_args["target"]]
+        if len(model_args["group_by"]) > 1:
+            for i, group in enumerate(model_args["group_by"]):
+                return_df[group] = return_df["unique_id"].apply(lambda x: x.split("/")[i])
+        else:
+            group_by_col = model_args["group_by"][0]
+            return_df[group_by_col] = return_df["unique_id"]
+
     return return_df.drop(["unique_id"], axis=1).rename({"ds": model_args["order_by"]}, axis=1)
 
 


### PR DESCRIPTION
## Description

**Fixes** #7196

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### What is the solution?

Refactored time series util function (used by Stats and NeuralForecast, too) and TimeGPT handler to allow non-grouped datasets.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, or created issues to update them.
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
