### PR TITLE
Defensive coding for None connection_args

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/executor/executor_commands.py
+++ b/mindsdb/api/mysql/mysql_proxy/executor/executor_commands.py
@@ -888,7 +888,7 @@ class ExecuteCommands:
                 raise SqlApiException(f"Handler '{engine}' can not be used")
 
             accept_connection_args = handler_meta.get("connection_args")
-            if accept_connection_args is not None:
+            if accept_connection_args is not None and connection_args is not None:
                 for arg_name, arg_value in connection_args.items():
                     if arg_name == "as_service":
                         continue

--- a/mindsdb/interfaces/database/integrations.py
+++ b/mindsdb/interfaces/database/integrations.py
@@ -179,7 +179,7 @@ class IntegrationController:
         logger.debug("%s: accept_connection_args - %s", self.__class__.__name__, accept_connection_args)
 
         files_dir = None
-        if accept_connection_args is not None:
+        if accept_connection_args is not None and connection_args is not None:
             for arg_name, arg_value in connection_args.items():
                 if (
                     arg_name in accept_connection_args


### PR DESCRIPTION
## Description
The following query will fail when creating an ML_engine with empty arguments
```
CREATE ML_ENGINE test_lw
FROM lightwood;
```
This is a bug brought by  #7087


## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
