### PR TITLE
Fix deprecated requirement `sklearn`

### DIFF
--- a/mindsdb/integrations/handlers/autokeras_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/autokeras_handler/requirements.txt
@@ -1,5 +1,5 @@
 tensorflow
 autokeras
-sklearn
+scikit-learn
 pandas
 numpy


### PR DESCRIPTION
## Description

`sklearn` is deprecated, `scikit-learn` must be used instead

**Fixes**

related to https://github.com/mindsdb/mindsdb/issues/6899

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
