### PR TITLE
Add Skills Table to Backend

### DIFF
--- a/mindsdb/interfaces/storage/db.py
+++ b/mindsdb/interfaces/storage/db.py
@@ -334,7 +334,6 @@ class ChatBotsHistory(Base):
     error = Column(String)
 
 
-
 class Triggers(Base):
     __tablename__ = 'triggers'
     id = Column(Integer, primary_key=True)
@@ -372,7 +371,7 @@ class Tasks(Base):
     updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
     created_at = Column(DateTime, default=datetime.datetime.now)
 
-    
+
 class Skills(Base):
     __tablename__ = 'skills'
     id = Column(Integer, primary_key=True)

--- a/mindsdb/migrations/versions/2023-08-31_4c26ad04eeaa_add_skills_table.py
+++ b/mindsdb/migrations/versions/2023-08-31_4c26ad04eeaa_add_skills_table.py
@@ -7,8 +7,6 @@ Create Date: 2023-08-31 17:04:26.898015
 """
 from alembic import op
 import sqlalchemy as sa
-import mindsdb.interfaces.storage.db
-
 
 
 # revision identifiers, used by Alembic.


### PR DESCRIPTION
## Description

See [LLM Agents design doc](https://docs.google.com/document/d/1QsgqJkhqusp1Ay9YCudoFXuoNzFHoDMMkXhr7AsW9IQ/edit#heading=h.rogj89libxhm)and [Knowledge Bases design doc](https://docs.google.com/document/d/1s5Bi3bwKCTOkHMFn811xuC0OVouxAqZla8AzLCCv1vo/edit) for more context.

Skills should be their own independent resources on the backend, and this PR introduces the DB schema for them.

**Fixes** #(issue)

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
