### PR TITLE
fixed langchain parameter name

### DIFF
--- a/mindsdb/integrations/handlers/langchain_handler/langchain_handler.py
+++ b/mindsdb/integrations/handlers/langchain_handler/langchain_handler.py
@@ -302,12 +302,12 @@ class LangChainHandler(BaseMLEngine):
 
     def run_agent(self, df, agent, args, pred_args):
         # TODO abstract prompt templating into a common utility method, this is also used in vanilla OpenAI
-        if args.get('prompt_template', False):
-            base_template = args['prompt_template']  # override with predict-time template if available
-        elif 'prompt_template' in pred_args:
-            base_template = pred_args['prompt_template']
+        if 'prompt_template' in pred_args:
+            base_template = pred_args['prompt_template']   # override with predict-time template if available
+        elif 'prompt_template' in args:
+            base_template = args['prompt_template']  # use create-time template if not
         else:
-            base_template = '{{question}}'
+            base_template = '{{question}}'  # default template otherwise
 
         input_variables = []
         matches = list(re.finditer("{{(.*?)}}", base_template))

--- a/mindsdb/integrations/handlers/langchain_handler/langchain_handler.py
+++ b/mindsdb/integrations/handlers/langchain_handler/langchain_handler.py
@@ -210,9 +210,9 @@ class LangChainHandler(BaseMLEngine):
         # fill memory
 
         # system prompt
-        prompt = args['prompt']
-        if 'prompt' in pred_args and pred_args['prompt'] is not None:
-            prompt = pred_args['prompt']
+        prompt = args['prompt_template']
+        if 'prompt_template' in pred_args and pred_args['prompt_template'] is not None:
+            prompt = pred_args['prompt_template']
         if 'context' in pred_args:
             prompt += '\n\n' + 'Useful information:\n' + pred_args['context'] + '\n'
         memory.chat_memory.messages.insert(0, SystemMessage(content=prompt))


### PR DESCRIPTION
## Description

fixed langchain parameter name

- using `prompt_template` locally works fine - but the model's answer is null

![image](https://github.com/mindsdb/mindsdb/assets/109554435/74365991-01b6-4e19-9ae1-1a35b152fe7f)

- using `prompt` on cloud works fine (after deploying this fix, use `prompt_template` on cloud as well)

![image](https://github.com/mindsdb/mindsdb/assets/109554435/972c2cec-60dc-4526-a122-24cd5d2cc744)

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
