### PR TITLE
Add an option to extend the default host, port

### DIFF
--- a/mindsdb/api/postgres/postgres_proxy/postgres_proxy.py
+++ b/mindsdb/api/postgres/postgres_proxy/postgres_proxy.py
@@ -461,7 +461,9 @@ class PostgresProxyHandler(socketserver.StreamRequestHandler):
     @staticmethod
     def startProxy():
         config = Config()
-        server = TcpServer(("localhost", 55432), PostgresProxyHandler)
+        host = config['api']['postgres']['host']
+        port = int(config['api']['postgres']['port'])
+        server = TcpServer((host, port), PostgresProxyHandler)
         server.connection_id = 0
         server.mindsdb_config = config
         server.check_auth = partial(check_auth, config=config)


### PR DESCRIPTION
## Description

This PR reads the host and port from the default or extend config when starting the PostgreSQL API.

**Fixes** Reported issue on Slack

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📄 This change requires a documentation update

### What is the solution?

(Describe at a high level how the feature was implemented)

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, or created issues to update them.
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] I have shared a short loom video or screenshots demonstrating any new functionality.
