### PR TITLE
Mysql port default

### DIFF
--- a/docs/integrations/data-integrations/mysql.mdx
+++ b/docs/integrations/data-integrations/mysql.mdx
@@ -16,7 +16,7 @@ The required arguments to establish a connection are as follows:
 * `user` is the database user.
 * `password` is the database password.
 * `host` is the host name, IP address, or URL.
-* `port` is the port used to make TCP/IP connection.
+* `port` is the port used to make TCP/IP connection. Default: 3306.
 * `database` is the database name.
 
 There are several optional arguments that can be used as well.

--- a/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
+++ b/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
@@ -45,7 +45,7 @@ class MySQLHandler(DatabaseHandler):
             return self.connection
 
         port = self.connection_data.get('port')
-        if port is None or not port.is_integer() or port == 0:
+        if port is None or isinstance(port, int):
             port = 3306
 
         config = {

--- a/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
+++ b/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
@@ -44,9 +44,13 @@ class MySQLHandler(DatabaseHandler):
         if self.is_connected is True:
             return self.connection
 
+        port = self.connection_data.get('port')
+        if port is None or not port.is_integer() or port == 0:
+            port = 3306
+
         config = {
             'host': self.connection_data.get('host'),
-            'port': self.connection_data.get('port'),
+            'port': port,
             'user': self.connection_data.get('user'),
             'password': self.connection_data.get('password'),
             'database': self.connection_data.get('database')

--- a/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
+++ b/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
@@ -45,7 +45,7 @@ class MySQLHandler(DatabaseHandler):
             return self.connection
 
         port = self.connection_data.get('port')
-        if port is None or isinstance(port, int):
+        if port is None:
             port = 3306
 
         config = {


### PR DESCRIPTION
## Description

If MySQL integration port is not specifiedm use 3306.

**Fixes** #7230

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)
- [x] 📄 This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



