### PR TITLE
MySQL: remove show tables

### DIFF
--- a/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
+++ b/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
@@ -151,10 +151,21 @@ class MySQLHandler(DatabaseHandler):
 
     def get_tables(self) -> Response:
         """
-        Get a list with all of the tabels in MySQL
+        Get a list with all of the tabels in MySQL selected database
         """
-        q = "SHOW TABLES;"
-        result = self.native_query(q)
+        sql = """
+            SELECT
+                TABLE_SCHEMA AS table_schema,
+                TABLE_NAME AS table_name,
+                TABLE_TYPE AS table_type
+            FROM
+                information_schema.TABLES
+            WHERE
+                TABLE_TYPE IN ('BASE TABLE', 'VIEW') 
+                AND TABLE_SCHEMA = DATABASE()
+            ;
+        """
+        result = self.native_query(sql)
         df = result.data_frame
         result.data_frame = df.rename(columns={df.columns[0]: 'table_name'})
         return result

--- a/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
+++ b/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
@@ -163,6 +163,7 @@ class MySQLHandler(DatabaseHandler):
             WHERE
                 TABLE_TYPE IN ('BASE TABLE', 'VIEW') 
                 AND TABLE_SCHEMA = DATABASE()
+            ORDER BY 2
             ;
         """
         result = self.native_query(sql)

--- a/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
+++ b/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
@@ -167,8 +167,6 @@ class MySQLHandler(DatabaseHandler):
             ;
         """
         result = self.native_query(sql)
-        df = result.data_frame
-        result.data_frame = df.rename(columns={df.columns[0]: 'table_name'})
         return result
 
     def get_columns(self, table_name) -> Response:


### PR DESCRIPTION
## Description

Previously `get_tables()` run `SHOW TABLE` against MySQL. With this change, it now runs a `SELECT` against `information_schema.TABLES`. It returns the same columns as the PostgreSQL integration and it has an `ORDER BY`.

This change guarantees that `SHOW TABLES` (when run in a MySQL integration) shows the tables in an alphabetical order.

Including more columns means that we also allows MindsDB to distinguish tables from views. Not sure if this information is currently used.

**Fixes** #7232

## Type of change

(Please delete options that are not relevant)

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.

