### PR TITLE
Gmail auth: get secret key from gateway

### DIFF
--- a/mindsdb/api/http/namespaces/config.py
+++ b/mindsdb/api/http/namespaces/config.py
@@ -127,6 +127,10 @@ class Integration(Resource):
                 params[key] = file_path
 
         is_test = params.get('test', False)
+
+        config = Config()
+        secret_key = config.get('secret_key', 'dummy-key')
+
         if is_test:
             del params['test']
 
@@ -148,7 +152,6 @@ class Integration(Resource):
                     export = handler.handler_storage.export_files()
                     if export:
                         # encrypt with flask secret key
-                        secret_key = request.headers.get('gw-secret', 'dummy-key')
                         encrypted = encrypt(export, secret_key)
                         resp['storage'] = encrypted.decode()
 
@@ -169,7 +172,6 @@ class Integration(Resource):
             if params.get('storage'):
                 handler = ca.integration_controller.get_handler(name)
 
-                secret_key = request.headers.get('gw-secret', 'dummy-key')
                 export = decrypt(params['storage'].encode(), secret_key)
                 handler.handler_storage.import_files(export)
 

--- a/mindsdb/api/http/namespaces/config.py
+++ b/mindsdb/api/http/namespaces/config.py
@@ -148,7 +148,8 @@ class Integration(Resource):
                     export = handler.handler_storage.export_files()
                     if export:
                         # encrypt with flask secret key
-                        encrypted = encrypt(export, ca.secret_key)
+                        secret_key = request.headers.get('gw-secret', 'dummy-key')
+                        encrypted = encrypt(export, secret_key)
                         resp['storage'] = encrypted.decode()
 
             return resp, 200
@@ -168,7 +169,8 @@ class Integration(Resource):
             if params.get('storage'):
                 handler = ca.integration_controller.get_handler(name)
 
-                export = decrypt(params['storage'].encode(), ca.secret_key)
+                secret_key = request.headers.get('gw-secret', 'dummy-key')
+                export = decrypt(params['storage'].encode(), secret_key)
                 handler.handler_storage.import_files(export)
 
         except Exception as e:

--- a/mindsdb/integrations/handlers/gmail_handler/gmail_handler.py
+++ b/mindsdb/integrations/handlers/gmail_handler/gmail_handler.py
@@ -355,7 +355,7 @@ class GmailHandler(APIHandler):
 
             # get host url from flask
             from flask import request
-            flow.redirect_uri = request.headers['ORIGIN'] + '/editor'
+            flow.redirect_uri = request.headers['ORIGIN'] + '/verify-auth'
 
             if self.connection_args.get('code'):
                 flow.fetch_token(code=self.connection_args['code'])


### PR DESCRIPTION
## Description

Because different instances has different secret keys we need to get secret key from gateway server in special header
It this header doesn't exist: then it is local version and simple key is used

Related to https://github.com/mindsdb/mindsdb_gateway/pull/629

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



