### PR TITLE
Aurora: Remove the note to use 127.0.0.1 instead of localhost

### DIFF
--- a/mindsdb/integrations/handlers/aurora_handler/aurora_handler.py
+++ b/mindsdb/integrations/handlers/aurora_handler/aurora_handler.py
@@ -157,7 +157,7 @@ connection_args = OrderedDict(
     },
     host={
         'type': ARG_TYPE.STR,
-        'description': 'The host name or IP address of the Amazon Aurora DB cluster. NOTE: use \'127.0.0.1\' instead of \'localhost\' to connect to local server.'
+        'description': 'The host name or IP address of the Amazon Aurora DB cluster.'
     },
     port={
         'type': ARG_TYPE.INT,


### PR DESCRIPTION
## Description

Aurora integration, connection arguments: remove hint to use 127.0.0.1 instead of localhost.

Aurora can't run on localhost.

**Fixes** 

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



