### PR TITLE
Update slack_handler.py

### DIFF
--- a/mindsdb/integrations/handlers/slack_handler/slack_handler.py
+++ b/mindsdb/integrations/handlers/slack_handler/slack_handler.py
@@ -59,7 +59,7 @@ class SlackChannelsTable(APITable):
         
         # Extract comparison conditions from the query
         conditions = extract_comparison_conditions(query.where)
-        channel_name = conditions[0][2];
+        channel_name = conditions[0][2]
         filters = []
         params = {}
         order_by_conditions = {}


### PR DESCRIPTION
statement ends with a semicolon.

It's currently on:
[mindsdb\integrations\handlers\slack_handler\slack_handler.py:62]

## Description
Found a minor issue: The statement ends with a semicolon

It's currently on:
[mindsdb\integrations\handlers\slack_handler\slack_handler.py:62]

Code:
channel_name = conditions[0][2];

Unlike programming languages like Java and C++, statements in Python do not need to end with a semicolon. They can be removed.

**Fixes** #(issue)
removed ``;`` from [mindsdb\integrations\handlers\slack_handler\slack_handler.py:62]