### PR TITLE
Allow providing an empty API list arg

### DIFF
--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -237,11 +237,11 @@ if __name__ == '__main__':
             db.session.commit()
         # endregion
 
-    if args.api is None:
+    if args.api is None:  # If "--api" option is not specified, start the default APIs
         api_arr = ['http', 'mysql']
-    elif args.api == "":
+    elif args.api == "":  # If "--api=" (blank) is specified, don't start any APIs
         api_arr = []
-    else:
+    else:  # The user has provided a list of APIs to start
         api_arr = args.api.split(',')
 
     with_nlp = False

--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -239,6 +239,8 @@ if __name__ == '__main__':
 
     if args.api is None:
         api_arr = ['http', 'mysql']
+    elif args.api == "":
+        api_arr = []
     else:
         api_arr = args.api.split(',')
 


### PR DESCRIPTION
This change is required for the jobs microservice [here](https://github.com/mindsdb/INTERNAL-mindsdb-build-deploy-to-kubernetes/pull/13)

This allows supplying an empty api list with `--api=`, which will then only run the jobs and tasks services (depending on the user's config).