### PR TITLE
ScyllaDB Fix Field (secure_connect_bundle)

### DIFF
--- a/mindsdb/integrations/handlers/scylla_handler/scylla_handler.py
+++ b/mindsdb/integrations/handlers/scylla_handler/scylla_handler.py
@@ -240,9 +240,10 @@ connection_args = OrderedDict(
         'label': 'Keyspace'
     },
     secure_connect_bundle={
-        'type': ARG_TYPE.STR,
-        'description': 'Path or URL to the secure connect bundle',
-        'required': True,
-        'label': 'Host'
+        'type': ARG_TYPE.PATH,
+        'description': 'Optional. Needed only for connections to DataStax Astra.',
+        'required': False,
+        'label': 'secure connect bundle'
     }
+     
 )


### PR DESCRIPTION
## Description

fix secure_connect_bundle field that has some errors when it displays on GUI

![image](https://github.com/mindsdb/mindsdb/assets/3981512/7d4299b1-5688-4e78-ac3c-506b814e8515)

**Fixes** #(issue)

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

On GUI try to add a ScyllaDB handler.  the field secure_connect_bundle will be show correctly

To ensure the changes are working as expected:

 - [x]   Test Location: Specify the URL or path for testing.
 - [x]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

