### PR TITLE
Add agent_id FK to Chatbots

### DIFF
--- a/mindsdb/interfaces/storage/db.py
+++ b/mindsdb/interfaces/storage/db.py
@@ -302,7 +302,9 @@ class ChatBots(Base):
 
     name = Column(String, nullable=False)
     project_id = Column(Integer, nullable=False)
+    agent_id = Column(ForeignKey('agents.id', name='fk_agent_id'))
 
+    # To be removed when existing chatbots are backfilled with newly created Agents.
     model_name = Column(String, nullable=False)
     database_id = Column(Integer)
     params = Column(JSON)

--- a/mindsdb/migrations/versions/2023-09-18_011e6f2dd9c2_backfill_agent_id.py
+++ b/mindsdb/migrations/versions/2023-09-18_011e6f2dd9c2_backfill_agent_id.py
@@ -1,0 +1,82 @@
+"""backfill_agent_id
+
+Revision ID: 011e6f2dd9c2
+Revises: f16d4ab03091
+Create Date: 2023-09-18 11:02:36.795544
+
+"""
+from alembic import op
+import datetime
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '011e6f2dd9c2'
+down_revision = 'f16d4ab03091'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    chatbots_table = sa.Table(
+        'chat_bots',
+        sa.MetaData(),
+        sa.Column('id', sa.Integer()),
+        sa.Column('project_id', sa.Integer()),
+        sa.Column('agent_id', sa.Integer()),
+        sa.Column('name', sa.String()),
+        sa.Column('model_name', sa.String())
+    )
+
+    agents_table = sa.Table(
+        'agents',
+        sa.MetaData(),
+        sa.Column('id', sa.Integer()),
+        sa.Column('company_id', sa.Integer()),
+        sa.Column('user_class', sa.Integer()),
+        sa.Column('name', sa.String()),
+        sa.Column('project_id', sa.Integer()),
+        sa.Column('model_name', sa.String()),
+        sa.Column('updated_at', sa.DateTime()),
+        sa.Column('created_at', sa.DateTime())
+    )
+
+    tasks_table = sa.Table(
+        'tasks',
+        sa.MetaData(),
+        sa.Column('company_id', sa.Integer()),
+        sa.Column('user_class', sa.Integer()),
+        sa.Column('object_type', sa.String()),
+        sa.Column('object_id', sa.Integer())
+    )
+
+    all_chatbots = conn.execute(chatbots_table.select()).fetchall()
+    for chatbot_row in all_chatbots:
+        id, project_id, _, name, model_name = chatbot_row
+
+        # Get the corresponding task.
+        task_select = tasks_table.select().where(tasks_table.c.object_type == 'chatbot').where(tasks_table.c.object_id == id)
+        task_row = conn.execute(task_select).first()
+        if task_row is None:
+            continue
+        company_id, user_class, _, _ = task_row
+        # Create the new agent.
+        op.execute(agents_table.insert().values(
+            company_id=company_id,
+            user_class=user_class,
+            name=name,
+            project_id=project_id,
+            model_name=model_name,
+            updated_at=datetime.datetime.now(),
+            created_at=datetime.datetime.now()
+        ))
+
+        # Get the new agent and associate the chatbot with it.
+        created_agent = conn.execute(agents_table.select().where(agents_table.c.name == name)).first()
+        agent_id = created_agent[0]
+        op.execute(chatbots_table.update().where(chatbots_table.c.id == id).values(agent_id=agent_id))
+
+
+def downgrade():
+    pass

--- a/mindsdb/migrations/versions/2023-09-18_f16d4ab03091_add_agent_id.py
+++ b/mindsdb/migrations/versions/2023-09-18_f16d4ab03091_add_agent_id.py
@@ -1,0 +1,28 @@
+"""add_agent_id
+
+Revision ID: f16d4ab03091
+Revises: e187961e844a
+Create Date: 2023-09-18 10:49:36.290319
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f16d4ab03091'
+down_revision = 'e187961e844a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('chat_bots') as batch_op:
+        batch_op.add_column(sa.Column('agent_id', sa.Integer()))
+        batch_op.create_foreign_key('fk_agent_id', 'agents', ['agent_id'], ['id'])
+
+
+def downgrade():
+    with op.batch_alter_table('chat_bots') as batch_op:
+        batch_op.drop_constraint('fk_agent_id', type_='foreignkey')
+        batch_op.drop_column('agent_id')


### PR DESCRIPTION
## Description

Now that chatbots are associated with an underlying agent, this PR adds an `agent_id` column to the `chat_bots` table to reflect that.

This PR also includes a migration to backfill existing chatbots with newly created agents.

**Closes** #7223 

## Type of change

(Please delete options that are not relevant)

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [x]   Verification Steps: Run the migrations locally with existing chatbot(s) in database

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



