### PR TITLE
Fix: LIMIT -1 in Web Crawler

### DIFF
--- a/mindsdb/integrations/handlers/web_handler/README.md
+++ b/mindsdb/integrations/handlers/web_handler/README.md
@@ -32,25 +32,10 @@ LIMIT 1;
 ```
 
 
-This should return the conteants of docs.mindsdb.com
+This should return the contents of docs.mindsdb.com
 
 
-Now lets assume that we want to search for the contents on more than one website
-
-
-```
-SELECT 
-   * 
-FROM my_web.crawler 
-WHERE 
-   url IN ('docs.mindsdb.com', 'docs.python.com') 
-LIMIT 1;
-```
-
-That should obtain two rows, LIMIT 1 limits how deep you go on each
-
-
-now lets get 10 pages deep on both:
+Now let's assume that we want to search for the contents on more than one website
 
 
 ```
@@ -59,13 +44,12 @@ SELECT
 FROM my_web.crawler 
 WHERE 
    url IN ('docs.mindsdb.com', 'docs.python.com') 
-LIMIT 10;
+LIMIT 30;
 ```
 
-You will get 20 results, as the crawler went 10 levels deeper into each url
+This command will crawl two sites and stop when the count of results hit 30. The total count of rows in result will be 30.
 
-
-NOTE: If you dont pass a limit, it will crawl until there are no more links to crawl, you should try it, it may take a while but it is pretty useful if say you wan to train a 
-model to answer questions for you given the info on this website
+NOTE: limit is mandatory. If you want to crawl all pages on site you can pass a big number in limit (for example 10000), more than expected count of pages on site. 
+But big limit also increases time to waiting for response.
 
 

--- a/mindsdb/integrations/handlers/web_handler/web_handler.py
+++ b/mindsdb/integrations/handlers/web_handler/web_handler.py
@@ -48,20 +48,16 @@ class CrawlerTable(APITable):
             raise NotImplementedError(
                 f'You must specify what url you want to crawl, for example: SELECT * FROM crawl WHERE url IN ("someurl", ..)')
 
-        limit = None
+        if query.limit is None:
+            raise NotImplementedError(f'You must specify a LIMIT which defines the number of pages to crawl')
+        limit = query.limit.value
 
-        if query.limit is not None:
-            limit = query.limit.value
-            if limit < 0:
-                limit = None
-                raise NotImplementedError(
-                f'You must specify a LIMIT which defines how deep to crawl, a LIMIT 10000 means that will crawl ALL websites and subwebsites in that domain (this can take a while)')
-
-        if limit is None or limit == 0:
-            limit = 1
+        if limit < 0:
+            limit = 0
             
         result = get_all_websites(urls, limit, html=False)
-
+        if len(result) > limit:
+            result = result[:limit]
         # filter targets
         result = project_dataframe(result, query.targets, self.get_columns())
         return result

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -23,7 +23,7 @@ redis==4.6.0
 walrus==0.9.2
 flask-compress >= 1.0.0
 appdirs >= 1.0.0
-mindsdb-sql >= 0.7.0, < 0.8.0
+mindsdb-sql >= 0.7.1, < 0.8.0
 mindsdb-evaluator >= 0.0.7, < 0.1.0
 checksumdir >= 1.2.0
 duckdb == 0.6.1


### PR DESCRIPTION
## Description

Changes:
- limit is required now
   - negative limit is the same as 0 
- limit is total count of rows on output (not depended on count of input urls) 
- updated mindsdb_sql dependency (to accept negative limit)

Fixes: #7118

**Fixes** #(issue)

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



