### PR TITLE
Fix Cassandra handler: secure_connect_bundle is path

### DIFF
--- a/mindsdb/integrations/handlers/cassandra_handler/cassandra_handler.py
+++ b/mindsdb/integrations/handlers/cassandra_handler/cassandra_handler.py
@@ -52,7 +52,7 @@ connection_args = OrderedDict(
         'label': 'Keyspace'
     },
     secure_connect_bundle={
-        'type': ARG_TYPE.PATH,
+        'type': ARG_TYPE.STR,
         'description': 'Path or URL to the secure connect bundle',
         'required': False,
         'label': 'Host'


### PR DESCRIPTION

Fixed Cassandra handler parameters:
- secure_connect_bundle replaced to STR (was PATH), because cassandra handler doesn't expect PATH

Creation cassandra handler via form returns error:
![image](https://github.com/mindsdb/mindsdb/assets/8502631/d8c5965e-0053-4f2a-8f5a-ae1c490252d6)

## Description

Please include a summary of the change and the issue it solves. 

**Fixes** #(issue)

## Type of change


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



