### PR TITLE
Added the Microsoft Teams Handler Dependencies to the Docker Image

### DIFF
--- a/docker/release
+++ b/docker/release
@@ -97,7 +97,8 @@ RUN python -m pip install --prefer-binary --no-cache-dir --upgrade pip==23.1.2 &
     pip install --prefer-binary --no-cache-dir 'monkeylearn==3.6.0' || true && \
     pip install --prefer-binary --no-cache-dir 'nixtlats>=0.1.4' || true && \
     pip install --prefer-binary --no-cache-dir 'stripe' || true && \
-    pip install --prefer-binary --no-cache-dir 'python-gitlab' || true
+    pip install --prefer-binary --no-cache-dir 'python-gitlab' || true && \
+    pip install --prefer-binary --no-cache-dir 'pymsteams' || true
 
 ARG VERSION=
 RUN pip install --no-cache-dir mindsdb${VERSION:+"==$VERSION"}


### PR DESCRIPTION
This PR adds the dependencies required to run the Microsoft Teams handler in MindsDB Docker image.