### PR TITLE
[PR] Validate AWS S3 Credentials at CREATE DATABASE Step

### DIFF
--- a/mindsdb/integrations/handlers/s3_handler/s3_handler.py
+++ b/mindsdb/integrations/handlers/s3_handler/s3_handler.py
@@ -87,7 +87,8 @@ class S3Handler(DatabaseHandler):
         need_to_close = self.is_connected is False
 
         try:
-            self.connect()
+            connection = self.connect()
+            connection.head_object(Bucket=self.connection_data['bucket'], Key=self.connection_data['key'])
             response.success = True
         except Exception as e:
             log.logger.error(f'Error connecting to AWS with the given credentials, {e}!')


### PR DESCRIPTION
## Description

This PR adds a call to extract the metadata of the object the user is trying to connect to, in the `check_connection()` method. This handles the situation where the credentials are incorrect as well as the situation where the bucket or the object itself does not exist.

**Fixes** #(issue)

https://github.com/mindsdb/mindsdb/issues/7434

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [X]   Test Location: `mindsdb/integrations/handlers/s3_handler/tests/test_s3_handler.py`
 - [X]   Verification Steps: Attempted running `CREATE DATABASE` statements with incorrect credentials, non-existent bucket and non-existent object.

## Additional Media:

When the credentials are incorrect,
![image](https://github.com/mindsdb/mindsdb/assets/49385643/062e065d-6004-4a9c-ba73-c18f72eb40ac)

When the bucket does not exist,
![image](https://github.com/mindsdb/mindsdb/assets/49385643/0e71dd5b-1422-4873-a0a8-e35a72e2cc16)

When the object does not exist,
![image](https://github.com/mindsdb/mindsdb/assets/49385643/7eac6a9b-1bce-43e0-a2ac-a273be1a3733)

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [X] Necessary documentation updates are either made or tracked in issues.
- [X] Relevant unit and integration tests are updated or added.