### PR TITLE
Fix: update problem definition in model record

### DIFF
--- a/mindsdb/interfaces/model/model_controller.py
+++ b/mindsdb/interfaces/model/model_controller.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import sys
 import json
@@ -420,6 +421,13 @@ class ModelController():
             raise Exception("ML handler doesn't updating")
 
         ml_handler.update(args=problem_definition)
+
+        # update model record
+        if 'using' in problem_definition:
+            learn_args = copy.deepcopy(model_record.learn_args)
+            learn_args['using'].update(problem_definition['using'])
+            model_record.learn_args = learn_args
+            db.session.commit()
 
     def get_model_info(self, predictor_record):
         from mindsdb.interfaces.database.projects import ProjectController


### PR DESCRIPTION
## Description

When request to update of model is sent:
```bash
curl -X PUT 'https://cloud.mindsdb.com/api/projects/mindsdb/models/chatbot_agent' \
  -H 'Accept: application/json, text/plain, */*' \
  --data-raw '{"problem_definition":{"using":{"prompt":"answer only in German"}}}' 
```

It calls only .update method of model's handler. 

If we call 'select * from models where name = 'chatbot_agent' we will see the old prompt there.

This PR updates model record.


## Type of change


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



