### PR TITLE
Shopify location table

### DIFF
--- a/mindsdb/integrations/handlers/shopify_handler/README.md
+++ b/mindsdb/integrations/handlers/shopify_handler/README.md
@@ -107,3 +107,11 @@ VALUES
 
 A limited number of columns are supported for INSERT: 'first_name', 'last_name', 'email', 'phone', 'tags' and 'currency'. Of these either 'first_name', 'last_name', 'email' or 'phone' must be provided. 
 
+For querying locations, you can use the `locations` table:
+
+~~~~sql
+SELECT  id, name, address
+FROM shopify_datasource.locations
+ORDER BY id
+LIMIT 5
+~~~~

--- a/mindsdb/integrations/handlers/shopify_handler/shopify_handler.py
+++ b/mindsdb/integrations/handlers/shopify_handler/shopify_handler.py
@@ -1,6 +1,6 @@
 import shopify
 
-from mindsdb.integrations.handlers.shopify_handler.shopify_tables import ProductsTable, CustomersTable, OrdersTable
+from mindsdb.integrations.handlers.shopify_handler.shopify_tables import ProductsTable, CustomersTable, OrdersTable, LocationTable
 from mindsdb.integrations.libs.api_handler import APIHandler
 from mindsdb.integrations.libs.response import (
     HandlerStatusResponse as StatusResponse,
@@ -41,6 +41,9 @@ class ShopifyHandler(APIHandler):
 
         orders_data = OrdersTable(self)
         self._register_table("orders", orders_data)
+
+        location_data = LocationTable(self)
+        self._register_table("location", location_data)
 
     def connect(self):
         """

--- a/mindsdb/integrations/handlers/shopify_handler/shopify_handler.py
+++ b/mindsdb/integrations/handlers/shopify_handler/shopify_handler.py
@@ -43,7 +43,7 @@ class ShopifyHandler(APIHandler):
         self._register_table("orders", orders_data)
 
         location_data = LocationTable(self)
-        self._register_table("location", location_data)
+        self._register_table("locations", location_data)
 
     def connect(self):
         """


### PR DESCRIPTION
## Description

This PR introduces the `LocationTable` to the Shopify integration in MindsDB, enabling users to query location data directly from their Shopify stores.

Fixes #7512 (assuming this is the issue number for the Location Table Implementation)

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: `https://your-mindsdb-instance-url.com/v3/datasources/shopify_datasource` (This is an example. Replace with the actual MindsDB instance URL).
 - [x]   Verification Steps:
      1. Setup the Shopify integration by providing the required `shop_url` and `access_token`.
      2. Query the location data using: 
      ```sql
      SELECT id, name, address
      FROM shopify_datasource.locations
      ORDER BY id
      LIMIT 5
      ```
      3. Verify that the data fetched matches the locations in the Shopify store.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.
