### PR TITLE
Update chromadb doc

### DIFF
--- a/mindsdb/integrations/handlers/chromadb_handler/README.md
+++ b/mindsdb/integrations/handlers/chromadb_handler/README.md
@@ -12,7 +12,6 @@ This handler uses `chromadb` python library connect to a chromadb instance, it u
 
 The required arguments to establish a connection are:
 
-* `chroma_api_impl`: the api implementation, likely should be `rest` or `local`
 * `chroma_server_host`: the host name or IP address of the ChromaDB instance
 * `chroma_server_http_port`: the port to use when connecting
 * `persist_directory`: the directory to use for persisting data, this should only be used when `chroma_api_impl` is set to `local`
@@ -26,9 +25,8 @@ In order to make use of this handler and connect to a ChromaDB server in MindsDB
 CREATE DATABASE chroma_dev
 WITH ENGINE = "chromadb",
 PARAMETERS = {
-   "chroma_api_impl": "rest",
    "chroma_server_host": "localhost",
-   "chroma_server_http_port": 8000,
+   "chroma_server_http_port": 8000
     }
 ```
 

--- a/mindsdb/integrations/handlers/chromadb_handler/README.md
+++ b/mindsdb/integrations/handlers/chromadb_handler/README.md
@@ -14,7 +14,7 @@ The required arguments to establish a connection are:
 
 * `chroma_server_host`: the host name or IP address of the ChromaDB instance
 * `chroma_server_http_port`: the port to use when connecting
-* `persist_directory`: the directory to use for persisting data, this should only be used when `chroma_api_impl` is set to `local`
+* `persist_directory`: the directory to use for persisting data
 
 
 ## Usage


### PR DESCRIPTION
## Description


`"chroma_api_impl": "rest",` is no longer a valid connection parameter while connecting to chromadb. Hence, removed the parameter from readme file.

Fixes #7531 

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📄 This change requires a documentation update

## Additional Media:
![Screenshot 2023-10-04 at 6 38 16 AM](https://github.com/mindsdb/mindsdb/assets/19553184/70475b97-51e7-487c-a7b7-b0c2d69931ae)


## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



