### PR TITLE
Trino additional auth support

### DIFF
--- a/mindsdb/integrations/handlers/trino_handler/trino_handler.py
+++ b/mindsdb/integrations/handlers/trino_handler/trino_handler.py
@@ -60,7 +60,6 @@ class TrinoHandler(DatabaseHandler):
             'port': self.connection_data.get('port', ''),
             'user': self.connection_data.get('user', ''),
         }
-        # TODO: password in required here? (def not for kerberos)
         # optional config passed in trino connect method
         optional_config = {'http_scheme': 'http'}
         if 'catalog' in self.connection_data:


### PR DESCRIPTION
## Description

Adds a few more auth method in addition to `basic`: `jwt`, `cert`, `oauth2`, `kerberos`.
There are a few problems though:
- The methods are not tested since they require an `https` connection
- I tried using a self signed certificate but it does not seem to work
- I am not sure if OAuth is going to work with MindsDb, if someone has implemented similar functionality, please refer me to it.
- I need access to one of these in order to test these methods:
    - If someone can help me setup a SSL enabled Trino instance on my Linux machine
    - If someone at MindsDB with an SSL enabled Trino instance can provide me with credentials
    - If someone at MindsDB can test it themself

Fixes #7633 

## Type of change

(Please delete options that are not relevant)

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Additional Media:

This just shows that no auth is not broken:

![Screenshot 2023-10-08 182237](https://github.com/mindsdb/mindsdb/assets/26451004/7478f0bd-1dc9-4b4e-ab5b-a7241e7799ae)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.