### PR TITLE
fix: do not use `fcntl` at not posix os

### DIFF
--- a/mindsdb/interfaces/storage/fs.py
+++ b/mindsdb/interfaces/storage/fs.py
@@ -165,6 +165,9 @@ class FileLock:
                 relative_path (Path): path to resource directory relative to storage root
                 mode (str): lock for read (r) or write (w)
         """
+        if os.name != 'posix':
+            return
+
         self._local_path = FileLock.lock_folder_path(relative_path)
         self._lock_file_name = DIR_LOCK_FILE_NAME
         self._lock_file_path = self._local_path / self._lock_file_name


### PR DESCRIPTION
## Description

do not use `fcntl` at not posix os

Fixes #7668

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



