### PR TITLE
Add showstories endpoint

### DIFF
--- a/mindsdb/integrations/handlers/hackernews_handler/README.md
+++ b/mindsdb/integrations/handlers/hackernews_handler/README.md
@@ -61,6 +61,14 @@ FROM my_hackernews.jobstories
 LIMIT 7;
 ```
 
+OR
+
+```sql
+SELECT *
+FROM my_hackernews.showstories
+LIMIT 5;
+```
+
 Each Post has a unique ID. You can use this ID to fetch comments for a particular post.
 
 ```sql

--- a/mindsdb/integrations/handlers/hackernews_handler/hn_handler.py
+++ b/mindsdb/integrations/handlers/hackernews_handler/hn_handler.py
@@ -5,7 +5,7 @@ from mindsdb.utilities.config import Config
 from mindsdb_sql.parser import ast
 from mindsdb.integrations.libs.api_handler import APIHandler, APITable
 from mindsdb.integrations.libs.response import HandlerStatusResponse as StatusResponse, HandlerResponse as Response, RESPONSE_TYPE
-from .hn_table import StoriesTable, CommentsTable , HNStoriesTable ,JobStoriesTable
+from .hn_table import StoriesTable, CommentsTable , HNStoriesTable ,JobStoriesTable, ShowStoriesTable
 
 class HackerNewsHandler(APIHandler):
     """
@@ -25,6 +25,9 @@ class HackerNewsHandler(APIHandler):
 
         jobstories = JobStoriesTable(self)
         self._register_table('jobstories',jobstories)
+
+        showstories = ShowStoriesTable(self)
+        self._register_table('showstories', showstories)
 
         comments = CommentsTable(self)
         self._register_table('comments', comments)
@@ -85,6 +88,17 @@ class HackerNewsHandler(APIHandler):
                     story_data = response.json()
                     stories_data.append(story_data)
                 df = pd.DataFrame(stories_data, columns=['id', 'time', 'title', 'url', 'score', 'type'])
+            elif method_name == 'show_hn_stories':
+                url = f'{self.base_url}/showstories.json'
+                response = requests.get(url)
+                data = response.json()
+                stories_data = []
+                for story_id in data:
+                    url = f'{self.base_url}/item/{story_id}.json'
+                    response = requests.get(url)
+                    story_data = response.json()
+                    stories_data.append(story_data)
+                df = pd.DataFrame(stories_data, columns=['id', 'time', 'title', 'text', 'score', 'descendants'])
             elif method_name == 'get_comments':
                 item_id = params.get('item_id')
                 url = f'{self.base_url}/item/{item_id}.json'

--- a/mindsdb/integrations/handlers/hackernews_handler/hn_table.py
+++ b/mindsdb/integrations/handlers/hackernews_handler/hn_table.py
@@ -221,6 +221,79 @@ class JobStoriesTable(APITable):
                 columns.append(target.value)
         df = df[columns]
         return df
+    
+
+class ShowStoriesTable(APITable):
+    def select(self, query: ast.Select) -> pd.DataFrame:
+        """Select data from the stories table and return it as a pandas DataFrame.
+        Args:
+            query (ast.Select): The SQL query to be executed.
+        Returns:
+            pandas.DataFrame: A pandas DataFrame containing the selected data.
+        """
+        hn_handler = self.handler
+
+        # Extract the limit value from the SQL query, if it exists
+        limit = None
+        if query.limit is not None:
+            limit = query.limit.value
+
+        # Call the Hacker News API to get the show hn stories
+        url = f'{hn_handler.base_url}/showstories.json'
+        response = requests.get(url)
+        data = response.json()
+
+        # Fetch the details of the HN stories, up to the specified limit
+        stories_data = []
+        for story_id in data[:limit]:
+            url = f'{hn_handler.base_url}/item/{story_id}.json'
+            response = requests.get(url)
+            story_data = response.json()
+            stories_data.append(story_data)
+
+        # Create a DataFrame from the fetched data
+        df = pd.DataFrame(
+            stories_data,
+            columns=['id', 'time', 'title', 'text', 'score', 'descendants']
+            )
+
+        # Apply any WHERE clauses in the SQL query to the DataFrame
+        conditions = extract_comparison_conditions(query.where)
+        for condition in conditions:
+            if condition[0] == '=' and condition[1] == 'id':
+                df = df[df['id'] == int(condition[2])]
+            elif condition[0] == '>' and condition[1] == 'time':
+                timestamp = int(condition[2])
+                df = df[df['time'] > timestamp]
+
+        # Filter the columns in the DataFrame according to the SQL query
+        self.filter_columns(df, query)
+
+        return df
+
+
+    def get_columns(self):
+        """Get the list of column names for the stories table.
+        Returns:
+            list: A list of column names for the stories table.
+        """
+        return ['id', 'time', 'title', 'text', 'score', 'descendants']
+
+    def filter_columns(self, df, query):
+        """Filter the columns in the DataFrame according to the SQL query.
+        Args:
+            df (pandas.DataFrame): The DataFrame to filter.
+            query (ast.Select): The SQL query to apply to the DataFrame.
+        """
+        columns = []
+        for target in query.targets:
+            if isinstance(target, ast.Star):
+                columns = self.get_columns()
+                break
+            elif isinstance(target, ast.Identifier):
+                columns.append(target.value)
+        df = df[columns]
+        return df
 
 
 class CommentsTable(APITable):


### PR DESCRIPTION
## Description

Implemented the Hacker News GET `/showstories.json` endpoint ([show-hn-stories](https://hackernews.api-docs.io/v0/live-data/show-hn-stories))
Created separate table (`showstories`) for storing the data from GET `/showstories.json` endpoint. Also added the sample query in the Hacker News handler readme.

Fixes #7737 

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

1. Create database using following command:
`CREATE DATABASE my_hackernews WITH ENGINE = 'hackernews'`

2. Test the implemented endpoint data:
`SELECT * FROM my_hackernews.showstories LIMIT 5;`

## Additional Media:

![image](https://github.com/mindsdb/mindsdb/assets/90889682/11ad6380-aa2a-4a83-9a7a-9c330c2fa859)


## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



