### PR TITLE
Minor lint fix

### DIFF
--- a/tests/handler_tests/test_pinecone_handler.py
+++ b/tests/handler_tests/test_pinecone_handler.py
@@ -140,7 +140,6 @@ class TestPineconeHandler(BaseExecutorTest):
             }
         )
         self.set_handler(postgres_handler_mock, "pg", tables={"df": df, "df2": df2})
-        num_record = df.shape[0]
 
         sql = """
             CREATE TABLE pinecone_test.testtable (


### PR DESCRIPTION
## Description

Fixes a minor code formatting error introduced in a previous merge (`F841 local variable 'num_record' is assigned to but never used` to be specific) that is causing CI to halt.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)