### PR TITLE
Reduce count of parallel tasks if use redis queue

### DIFF
--- a/mindsdb/utilities/ml_task_queue/consumer.py
+++ b/mindsdb/utilities/ml_task_queue/consumer.py
@@ -116,7 +116,7 @@ class MLTaskConsumer:
         """ Sleep in thread untill there are free resources. Checks:
             - avg CPU usage is less than 60%
             - current CPU usage is less than 60%
-            - current tasks count is less than (N CPU cores) / 2
+            - current tasks count is less than (N CPU cores) / 8
         """
         config = Config()
         is_cloud = config.get('cloud', False)
@@ -126,7 +126,7 @@ class MLTaskConsumer:
                 time.sleep(1)
             if is_cloud and processes_dir.is_dir():
                 clean_unlinked_process_marks()
-                while (len(list(processes_dir.iterdir())) * 2) >= os.cpu_count():
+                while (len(list(processes_dir.iterdir())) * 8) >= os.cpu_count():
                     time.sleep(1)
                     clean_unlinked_process_marks()
             if (self.get_avg_cpu_usage() > 60 or max(self.cpu_stat[-3:]) > 60) is False:


### PR DESCRIPTION
## Description

Count of parallel tasks reduced from 1 per 2 CPU cores to 1 per 8 CPU cores

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



