### PR TITLE
Chore: Typo fixed in multiple files of mindsdb folder

### DIFF
--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -76,7 +76,7 @@ services:
         source: ../
         target: /mindsdb
     environment:
-      # have to share mindsdb database, because it doens't work without it
+      # have to share mindsdb database, because it doesn't work without it
       REGISTRY_URL: "http://handler_discovery:5000"
       PORT: 50051
       HOST: "lightwood"
@@ -98,7 +98,7 @@ services:
         source: ../
         target: /mindsdb
     environment:
-      # have to share mindsdb database, because it doens't work without it
+      # have to share mindsdb database, because it doesn't work without it
       PORT: 50053
       HOST: "huggingface"
       MINDSDB_SERVICE_TYPE: "huggingface"
@@ -138,7 +138,7 @@ services:
     depends_on:
       - mindsdb
     environment:
-      # have to share mindsdb database, because it doens't work without it
+      # have to share mindsdb database, because it doesn't work without it
       PORT: 50052
       MINDSDB_STORAGE_DIR: "/mindsdb/var"
       MINDSDB_DB_CON: "postgresql://postgres:postgres@db:15432/mindsdb"

--- a/mindsdb/integrations/handlers/binance_handler/README.md
+++ b/mindsdb/integrations/handlers/binance_handler/README.md
@@ -17,7 +17,7 @@ WITH
 ```
 
 ### Select Data
-To see if the connection was succesful, try searching for the most recent trade data. By default, aggregate data (klines) from the latest 1000 trading intervals with a length of 1m each are returned.
+To see if the connection was successful, try searching for the most recent trade data. By default, aggregate data (klines) from the latest 1000 trading intervals with a length of 1m each are returned.
 
 ```
 SELECT *

--- a/mindsdb/integrations/handlers/clickhouse_handler/README.md
+++ b/mindsdb/integrations/handlers/clickhouse_handler/README.md
@@ -18,7 +18,7 @@ pip install clickhouse-sqlalchemy
 
 ## Usage
 
-To connect to ClickHouse use add `engine=clickhouse` to the CREATE DATABSE statement as:
+To connect to ClickHouse use add `engine=clickhouse` to the CREATE DATABASE statement as:
 
 ```sql
 CREATE DATABASE clic

--- a/mindsdb/integrations/handlers/couchbase_handler/README.md
+++ b/mindsdb/integrations/handlers/couchbase_handler/README.md
@@ -12,7 +12,7 @@ The required arguments to establish a connection are:
 * `bucket`: the bjcket name to use when connecting with the Couchbase server
 * `user`: the user to authenticate with the Couchbase server
 * `password`: the password to authenticate the user with the Couchbase server
-* `scope`:  scopes are a level of data organization within a bucket. If ommited, will default to `_default`
+* `scope`:  scopes are a level of data organization within a bucket. If omitted, will default to `_default`
 
 If you are using Couchbase Capella, the `host` should be the connection string for the cluster. When you navigate to your cluster, the connection string can be found under the Connect tab.
 It will also be required to whitelist the machine(s) that will be running MindsDB and database credentials will need to be created for the user. These steps can also be taken under the Connect tab.

--- a/mindsdb/integrations/handlers/crate_handler/README.md
+++ b/mindsdb/integrations/handlers/crate_handler/README.md
@@ -10,7 +10,7 @@ CrateDB is a distributed SQL database management system that integrates a fully 
 This handler was implemented using the `crate`, a Python library that allows you to use Python code to run SQL commands on Crate DB.
 
 The required arguments to establish a connection are,
-* `user`: username asscociated with database
+* `user`: username associated with database
 * `password`: password to authenticate your access
 * `host`: host to server IP Address or hostname
 * `port`: port through which  connection is to be made.

--- a/mindsdb/integrations/handlers/d0lt_handler/README.md
+++ b/mindsdb/integrations/handlers/d0lt_handler/README.md
@@ -11,7 +11,7 @@ Branch/merge semantics are supported allowing for the tables to evolve at a diff
 This handler was implemented using the `mysql-connector`, a Python library that allows you to use Python code to run SQL commands on D0lt Database.
 
 The required arguments to establish a connection are,
-* `user`: username asscociated with database
+* `user`: username associated with database
 * `password`: password to authenticate your access
 * `host`: host to server IP Address or hostname
 * `port`: port through which TCPIP connection is to be made

--- a/mindsdb/integrations/handlers/google_calendar_handler/README.md
+++ b/mindsdb/integrations/handlers/google_calendar_handler/README.md
@@ -1,7 +1,7 @@
 # Google Calendar API Integration
 
 This handler integrates with the [Google Calendar API](https://developers.google.com/calendar/api/guides/overview)
-to make evnet data available to use for model training and predictions.
+to make event data available to use for model training and predictions.
 
 ## Example: Automate your Calendar
 

--- a/mindsdb/integrations/handlers/hive_handler/README.md
+++ b/mindsdb/integrations/handlers/hive_handler/README.md
@@ -9,7 +9,7 @@ The Apache Hive ™ data warehouse software facilitates reading, writing, and ma
 This handler was implemented using the `pyHive`, a Python library that allows you to use Python code to run SQL commands on Hive.
 
 The required arguments to establish a connection are,
-* `user`: username asscociated with database
+* `user`: username associated with database
 * `password`: password to authenticate your access
 * `host`: host to server IP Address or hostname
 * `port`: port through which TCPIP connection is to be made

--- a/mindsdb/integrations/handlers/hsqldb_handler/README.md
+++ b/mindsdb/integrations/handlers/hsqldb_handler/README.md
@@ -30,7 +30,7 @@ CommLog         = 1
 UsageCount      = 1
 ```
 
-then, in mindsDB, the following syntax can be used to acces your database,
+then, in mindsDB, the following syntax can be used to access your database,
 
 ```sql
 CREATE DATABASE exampledb

--- a/mindsdb/integrations/handlers/influxdb_handler/README.md
+++ b/mindsdb/integrations/handlers/influxdb_handler/README.md
@@ -31,7 +31,7 @@ parameters={
 };
 ~~~~
 
-For querying different tables, you need to create another database with `influxdb` handler as engine & mention the appropriate databse & table name in the following  parameters `influxdb_db_name` & `influxdb_table_name`
+For querying different tables, you need to create another database with `influxdb` handler as engine & mention the appropriate database & table name in the following  parameters `influxdb_db_name` & `influxdb_table_name`
 
 Now, you can use this established connection to query your table as follows,
 ~~~~sql

--- a/mindsdb/integrations/handlers/jira_handler/README.md
+++ b/mindsdb/integrations/handlers/jira_handler/README.md
@@ -13,7 +13,7 @@ This handler was implemented as per the MindsDB API Handler documentation.
 
 The required arguments to establish a connection are,
 * `jira_url`: Jira  hosted url instance
-* `jira_api_token`: API key for acessing the Jira url instance
+* `jira_api_token`: API key for accessing the Jira url instance
 * `project`: Jira project name 
 
 

--- a/mindsdb/integrations/handlers/matrixone_handler/README.md
+++ b/mindsdb/integrations/handlers/matrixone_handler/README.md
@@ -11,7 +11,7 @@ For more Info Click [HERE](https://github.com/matrixorigin/matrixone)
 This handler was implemented using the `PyMySQL`, a Python library that allows you to use Python code to run SQL commands on Matrixone Database.
 
 The required arguments to establish a connection are,
-* `user`: username asscociated with database
+* `user`: username associated with database
 * `password`: password to authenticate your access
 * `host`: host to server IP Address or hostname
 * `port`: port through which TCPIP connection is to be made

--- a/mindsdb/integrations/handlers/milvus_handler/README.md
+++ b/mindsdb/integrations/handlers/milvus_handler/README.md
@@ -104,7 +104,7 @@ WHERE search_vector = '[3.0, 1.0, 2.0, 4.5]'
 LIMIT 10;
 ```
 
-If you omit the `search_vector`, this becomes a basic search and `LIMIT` or `search_default_limit` amount of entires in collection are returned
+If you omit the `search_vector`, this becomes a basic search and `LIMIT` or `search_default_limit` amount of entries in collection are returned
 
 ```sql
 SELECT * from milvus_datasource.test

--- a/mindsdb/integrations/handlers/mysql_handler/Manual_QA.md
+++ b/mindsdb/integrations/handlers/mysql_handler/Manual_QA.md
@@ -31,7 +31,7 @@ COMMAND THAT YOU RAN TO DO A SELECT FROM.
 ### Results
 
 Drop a remark based on your observation.
-- [ ] Works Great 💚 (This means that all the steps were executed successfuly and the expected outputs were returned.)
+- [ ] Works Great 💚 (This means that all the steps were executed successfully and the expected outputs were returned.)
 - [ ] There's a Bug 🪲 [Issue Title](URL To the Issue you created) ( This means you encountered a Bug. Please open an issue with all the relevant details with the Bug Issue Template)
 
 ---
@@ -81,7 +81,7 @@ WHERE torque =40;
 ### Results
 
 Drop a remark based on your observation.
-- [X] Works Great 💚 (This means that all the steps were executed successfuly and the expected outputs were returned.)
+- [X] Works Great 💚 (This means that all the steps were executed successfully and the expected outputs were returned.)
 - [ ] There's a Bug 🪲 [Issue Title](URL To the Issue you created) ( This means you encountered a Bug. Please open an issue with all the relevant details with the Bug Issue Template)
 
 ---

--- a/mindsdb/integrations/handlers/neuralforecast_handler/README.md
+++ b/mindsdb/integrations/handlers/neuralforecast_handler/README.md
@@ -23,7 +23,7 @@ Do not use this integration for short time-series, as they won't have enough dat
 Instead, we recommend using the Statsforecast handler, whose classical methods are more suited to small datasets.
 
 # Are models created with this integration fast and scalable, in general?
-Model training can be slow, as the default implementation will search differet network architectures and hyperparameters.
+Model training can be slow, as the default implementation will search different network architectures and hyperparameters.
 Once the model is trained, forecasting is very fast.
 
 # What are the recommended system specifications for models created with this framework?

--- a/mindsdb/integrations/handlers/newsapi_handler/README.md
+++ b/mindsdb/integrations/handlers/newsapi_handler/README.md
@@ -19,7 +19,7 @@ WITH
 
 ### Select Data
 
-To see if the connection was succesful, try searching for the most recent article data.
+To see if the connection was successful, try searching for the most recent article data.
 
 ```
 SELECT *
@@ -68,7 +68,7 @@ LIMIT 40;
 
 **exclude_domains** : A comma-seperated string of domains (eg bbc.co.uk, techcrunch.com, engadget.com) to remove from the results.
 
-**searchIn** : The fields to restrict your query search to possible options are title, description,  conten. Multiple options can be specified by separating them with a comma, for example: `title,content`
+**searchIn** : The fields to restrict your query search to possible options are title, description,  content. Multiple options can be specified by separating them with a comma, for example: `title,content`
 
 **lamguage** : The 2-letter ISO-639-1 code of the language you want to get headlines for. Possible options: `ar de, en es, fr he, it nl, no pt, ru,  sv, ud , zh`.
 

--- a/mindsdb/integrations/handlers/nuo_jdbc_handler/README.md
+++ b/mindsdb/integrations/handlers/nuo_jdbc_handler/README.md
@@ -21,7 +21,7 @@ Other optional arguments are,
 * `schema`: The schema name to use when connecting with the NuoDB.
 * `jar_location`: The location of the jar files which contain the JDBC class. This need not be specified if the required classes are already added to the CLASSPATH variable.
 * `driver_args`: The extra arguments which can be specified to the driver. Specify this in the format: "arg1=value1,arg2=value2. 
-More information on the supported paramters can be found at: https://doc.nuodb.com/nuodb/latest/deployment-models/physical-or-vmware-environments-with-nuodb-admin/reference-information/connection-properties/
+More information on the supported parameters can be found at: https://doc.nuodb.com/nuodb/latest/deployment-models/physical-or-vmware-environments-with-nuodb-admin/reference-information/connection-properties/
 
 ## Usage
 In order to make use of this handler and connect to Apache Derby in MindsDB, the following syntax can be used,

--- a/mindsdb/integrations/handlers/pinot_handler/README.md
+++ b/mindsdb/integrations/handlers/pinot_handler/README.md
@@ -41,7 +41,7 @@ To quickly spin up Apache Pinot in Docker, run the following command,
 docker run --name pinot-quickstart -p 2123:2123 -p 9000:9000 -p 8000:8000 -d apachepinot/pinot:latest QuickStart -type batch
 ~~~~
 
-Install MindsDB on your local Python enviornment,
+Install MindsDB on your local Python environment,
 ~~~~bash
 pip install mindsdb
 ~~~~

--- a/mindsdb/integrations/handlers/reddit_handler/README.md
+++ b/mindsdb/integrations/handlers/reddit_handler/README.md
@@ -38,7 +38,7 @@ The Reddit handler is initialized with the following parameters:
 1. Visit Reddit App Preferences (https://www.reddit.com/prefs/apps) or [https://old.reddit.com/prefs/apps/](https://old.reddit.com/prefs/apps/)
 2. Scroll to the bottom and click "create another app..."
 3. Fill out the name, description, and redirect url for your app, then click "create app"
-4. Now you should be able to see the personal use script, secret, and name of your app. Store those as environment variables CLIENT_ID, CLIENT_SECRET, and USER_AGENT respecitvely.
+4. Now you should be able to see the personal use script, secret, and name of your app. Store those as environment variables CLIENT_ID, CLIENT_SECRET, and USER_AGENT respectively.
 
 ## Implemented Features
 

--- a/mindsdb/integrations/handlers/rocket_chat_handler/README.md
+++ b/mindsdb/integrations/handlers/rocket_chat_handler/README.md
@@ -17,7 +17,7 @@ WITH
 ```
 
 ### Select Data
-To see if the connection was succesful, try searching for messages in a channel
+To see if the connection was successful, try searching for messages in a channel
 
 ```
 SELECT *

--- a/mindsdb/integrations/handlers/vertica_handler/README.md
+++ b/mindsdb/integrations/handlers/vertica_handler/README.md
@@ -9,7 +9,7 @@ The column-oriented Vertica Analytics Platform was designed to manage large, fas
 This handler was implemented using the `vertica-python`, a Python library that allows you to use Python code to run SQL commands on Vertica Database.
 
 The required arguments to establish a connection are,
-* `user`: username asscociated with database
+* `user`: username associated with database
 * `password`: password to authenticate your access
 * `host`: host to server IP Address or hostname
 * `port`: port through which TCPIP connection is to be made

--- a/mindsdb/integrations/handlers/youtube_handler/README.md
+++ b/mindsdb/integrations/handlers/youtube_handler/README.md
@@ -3,7 +3,7 @@
 Youtube handler for MindsDB provides interfaces to connect with Youtube via APIs and pull the video comments of the particular video.
 
 ## Youtube
-Youtube is app that needs no introduction. It provides a great distrbution for all business and creators and It opens-up a great opportunity to do NLP on youtube comments
+Youtube is app that needs no introduction. It provides a great distribution for all business and creators and It opens-up a great opportunity to do NLP on youtube comments
 
 ## Youtube Handler Initialization
 


### PR DESCRIPTION
## Description

This PR fix the typo that was seen in files of mindsdb folder

```pseudo
doen > does
succesful > succesfull
DATABSE > DATABASE
ommited > omitted
asscociated > associated
acces > access
entires > entries
```

## Type of change

- [X] 📄 This change requires a documentation update




