### PR TITLE
Chore: Typo fixed in multiple files of docs folder

### DIFF
--- a/docs/connect/connect-mariadb-skysql.mdx
+++ b/docs/connect/connect-mariadb-skysql.mdx
@@ -67,7 +67,7 @@ file will download onto your machine.
   allowfullscreen
 ></iframe>
 
-## 4. Publically Expose your service .pem File
+## 4. Publicly Expose your service .pem File
 
 Select secure storage for the `aws_skysql_chain.pem` file that allows a working
 public URL or localpath.

--- a/docs/connect/jupysql.mdx
+++ b/docs/connect/jupysql.mdx
@@ -127,7 +127,7 @@ Please follow the instructions below to connect into your MindsDB via Jupysql an
 
         - Username is your MindsDB Cloud email address
         - Password is your MindsDB Cloud password
-        - Host is the IP address of your dedicated instace
+        - Host is the IP address of your dedicated instance
         - Port is `3306`
         - Database name is `mindsdb`
 

--- a/docs/contribute/contribute.mdx
+++ b/docs/contribute/contribute.mdx
@@ -25,7 +25,7 @@ After you find the issue that you want to contribute to, follow the `fork-and-pu
 7. Make sure that the CI tests are GREEN
 
 <Note>
-  Be sure to merge the latest MindsDB reopsitory from "upstream" before making a Pull Request!
+  Be sure to merge the latest MindsDB repository from "upstream" before making a Pull Request!
 </Note>
 
 Pull Request reviews are done on a regular basis. Please make sure you respond to our feedback/questions and sign our CLA.

--- a/docs/contribute/data-handlers.mdx
+++ b/docs/contribute/data-handlers.mdx
@@ -161,9 +161,9 @@ Here is a step-by-step guide:
     ```py
     def get_tables(self) -> HandlerResponse:
         """ Return list of entities
-        Return list of entities that will be accesible as tables.
+        Return list of entities that will be accessible as tables.
         Returns:
-            HandlerResponse: shoud have same columns as information_schema.tables
+            HandlerResponse: should have same columns as information_schema.tables
                 (https://dev.mysql.com/doc/refman/8.0/en/information-schema-tables-table.html)
                 Column 'TABLE_NAME' is mandatory, other is optional.
         """
@@ -179,7 +179,7 @@ Here is a step-by-step guide:
         Args:
             table_name (str): name of one of tables returned by self.get_tables()
         Returns:
-            HandlerResponse: shoud have same columns as information_schema.columns
+            HandlerResponse: should have same columns as information_schema.columns
                 (https://dev.mysql.com/doc/refman/8.0/en/information-schema-columns-table.html)
                 Column 'COLUMN_NAME' is mandatory, other is optional. Hightly
                 recomended to define also 'DATA_TYPE': it should be one of

--- a/docs/generative-ai-tables.mdx
+++ b/docs/generative-ai-tables.mdx
@@ -52,7 +52,7 @@ On execution, we get:
 
 ## Creating a Generative AI-Table
 
-We can for example create an OpenAI model that will generate a *response* given some *prompt_template* instructions wirtten in plain English.
+We can for example create an OpenAI model that will generate a *response* given some *prompt_template* instructions written in plain English.
 
 ```sql
 CREATE MODEL ai_response_model

--- a/docs/integrations/ai-engines/byom.mdx
+++ b/docs/integrations/ai-engines/byom.mdx
@@ -144,7 +144,7 @@ We upload the custom model, as below:
   <img src="/assets/byom_pro_account.png" />
 </p>
 
-Here we upload the `custom_model.py` file that stores an impletation of the model and the `requirements.txt` file that stores all the dependencies.
+Here we upload the `custom_model.py` file that stores an implementation of the model and the `requirements.txt` file that stores all the dependencies.
 
 Once the model is uploaded, it becomes an ML engine within MindsDB. Now we use this `custom_ML_engine` to create a model as follows:
 

--- a/docs/integrations/ai-engines/huggingface.mdx
+++ b/docs/integrations/ai-engines/huggingface.mdx
@@ -49,7 +49,7 @@ FROM huggingface_api
 USING api_key = 'hf_xxx';
 ```
 
-You can generate Hugging Face tokens in the `Setings -> Access Tokens` tab of your Hugging Face account.
+You can generate Hugging Face tokens in the `Settings -> Access Tokens` tab of your Hugging Face account.
 </Tab>
 </Tabs>
 

--- a/docs/integrations/ai-engines/langchain.mdx
+++ b/docs/integrations/ai-engines/langchain.mdx
@@ -152,7 +152,7 @@ We can ask the model to retrieve specific data.
 ```sql
 SELECT input, completion
 FROM tool_based_agent
-WHERE input = 'There is a property in the south_side neighborhood with an initial price of 2543 the `mysql_demo_db.home_rentals` table. What are some other deatils of this listing?'
+WHERE input = 'There is a property in the south_side neighborhood with an initial price of 2543 the `mysql_demo_db.home_rentals` table. What are some other details of this listing?'
 USING
     verbose = True,
     tools = [],
@@ -165,7 +165,7 @@ On execution, we get:
 +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | input                                                                                                                                                                 | completion                                                                                                                                                                              |
 +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| There is a property in the south_side neighborhood with an initial price of 2543 the `mysql_demo_db.home_rentals` table. What are some other deatils of this listing? | The property in the south_side neighborhood with an initial price of 2543 has 1 bedroom, 1 bathroom, is 630 sqft, has been on the market for 11 days, and has a rental price of 2543.0. |
+| There is a property in the south_side neighborhood with an initial price of 2543 the `mysql_demo_db.home_rentals` table. What are some other details of this listing? | The property in the south_side neighborhood with an initial price of 2543 has 1 bedroom, 1 bathroom, is 630 sqft, has been on the market for 11 days, and has a rental price of 2543.0. |
 +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ```
 

--- a/docs/integrations/ai-engines/ray-serve.mdx
+++ b/docs/integrations/ai-engines/ray-serve.mdx
@@ -116,7 +116,7 @@ WHERE initial_price=3000
 AND rental_price=3000;
 ```
 
-Or you can `JOIN` the model wth a data table to get bulk predictions.
+Or you can `JOIN` the model with a data table to get bulk predictions.
 
 ```sql
 SELECT tb.number_of_rooms, t.rental_price

--- a/docs/integrations/app-integrations/reddit.mdx
+++ b/docs/integrations/app-integrations/reddit.mdx
@@ -25,7 +25,7 @@ Here is how to get your Reddit credentials:
 1. Go to Reddit App Preferences at https://www.reddit.com/prefs/apps or https://old.reddit.com/prefs/apps/
 2. Scroll down to the bottom of the page and click *create another app...*
 3. Fill out the form with the name, description, and redirect URL for your app, then click *create app*
-4. Now you should be able to see the personal user script, secret, and name of your app. Store those as environment variables: `CLIENT_ID`, `CLIENT_SECRET`, and `USER_AGENT`, respecitvely.
+4. Now you should be able to see the personal user script, secret, and name of your app. Store those as environment variables: `CLIENT_ID`, `CLIENT_SECRET`, and `USER_AGENT`, respetively.
 </Tip>
 
 <Tip>

--- a/docs/integrations/app-integrations/web-crawler.mdx
+++ b/docs/integrations/app-integrations/web-crawler.mdx
@@ -46,7 +46,7 @@ WHERE url = 'docs.mindsdb.com'
 LIMIT 10;
 ```
 
-Another option is to get the content from multiple webistes.
+Another option is to get the content from multiple websites.
 
 ```sql
 SELECT * 

--- a/docs/integrations/data-integrations/airtable.mdx
+++ b/docs/integrations/data-integrations/airtable.mdx
@@ -50,5 +50,5 @@ FROM airtable_datasource.example_tbl;
 ```
 
 <Warning>
-At the moment, only the `SELECT` statemet is allowed to be executed through `duckdb`. This, however, has no restriction on running machine learning algorithms against your data in Airtable using the `CREATE PREDICTOR` statement.
+At the moment, only the `SELECT` statement is allowed to be executed through `duckdb`. This, however, has no restriction on running machine learning algorithms against your data in Airtable using the `CREATE PREDICTOR` statement.
 </Warning>

--- a/docs/integrations/data-integrations/clickhouse.mdx
+++ b/docs/integrations/data-integrations/clickhouse.mdx
@@ -49,7 +49,7 @@ FROM clickhouse_datasource.example_table;
 ```
 
 <Tip>
-If you want to swithc to different database instead the one you have connected, you can include it in the query as:
+If you want to switch to different database instead the one you have connected, you can include it in the query as:
 ```sql
 SELECT *
 FROM clickhouse_datasource.new_database.example_table;

--- a/docs/integrations/data-integrations/cratedb.mdx
+++ b/docs/integrations/data-integrations/cratedb.mdx
@@ -15,7 +15,7 @@ The required arguments to establish a connection are as follows:
 
 * `user` is the username associated with the database.
 * `password` is the password to authenticate your access.
-* `host` is the hostname or IP adress of the server.
+* `host` is the hostname or IP address of the server.
 * `port` is the port through which connection is to be made.
 * `schema_name` is schema name to get tables from. Defaults to `doc`.
 

--- a/docs/integrations/data-integrations/d0lt.mdx
+++ b/docs/integrations/data-integrations/d0lt.mdx
@@ -15,9 +15,9 @@ This handler is implemented using `mysql-connector`, a Python library that allow
 
 The required arguments to establish a connection are as follows:
 
-* `user` is the username asscociated with the database.
+* `user` is the username associated with the database.
 * `password` is the password to authenticate your access.
-* `host` is the hostname or IP adress of the server.
+* `host` is the hostname or IP address of the server.
 * `port` is the port through which TCP/IP connection is to be made.
 * `database` is the database name to be connected.
 

--- a/docs/integrations/data-integrations/duckdb.mdx
+++ b/docs/integrations/data-integrations/duckdb.mdx
@@ -12,7 +12,7 @@ This is the implementation of the DuckDB data handler for MindsDB.
 This handler is implemented using the `duckdb` Python client library.
 
 <Tip>
-The DuckDB handler is currently using the `0.7.1.dev187` pre-relase version of the Python client library. In case of issues, make sure your DuckDB database is compatible with this version. See the [`requirements.txt`](https://github.com/mindsdb/mindsdb/blob/staging/mindsdb/integrations/handlers/duckdb_handler/requirements.txt) for details.
+The DuckDB handler is currently using the `0.7.1.dev187` pre-release version of the Python client library. In case of issues, make sure your DuckDB database is compatible with this version. See the [`requirements.txt`](https://github.com/mindsdb/mindsdb/blob/staging/mindsdb/integrations/handlers/duckdb_handler/requirements.txt) for details.
 </Tip>
 
 The required arguments to establish a connection are as follows:

--- a/docs/integrations/data-integrations/google-sheets.mdx
+++ b/docs/integrations/data-integrations/google-sheets.mdx
@@ -54,5 +54,5 @@ FROM sheets_datasource.example_tbl;
 The name of the table will be the name of the relevant sheet, provided as an input to the `sheet_name` parameter.
 
 <Warning>
-At the moment, only the `SELECT` statemet is allowed to be executed through `duckdb`. This, however, has no restriction on running machine learning algorithms against your data in Google Sheets using the `CREATE PREDICTOR` statement.
+At the moment, only the `SELECT` statement is allowed to be executed through `duckdb`. This, however, has no restriction on running machine learning algorithms against your data in Google Sheets using the `CREATE PREDICTOR` statement.
 </Warning>

--- a/docs/integrations/data-integrations/ibm-informix.mdx
+++ b/docs/integrations/data-integrations/ibm-informix.mdx
@@ -71,7 +71,7 @@ sudo tar xvf  OneDB-Linux64-ODBC-Driver.tar -C ./home/informix/cli
 rm OneDB-Linux64-ODBC-Driver.tar
 ```
 
-2. Add enviroment variables in the `.bashrc` file:
+2. Add environment variables in the `.bashrc` file:
 ```bash
 export INFORMIXDIR=$HOME/Informix/home/informix/cli/onedb-odbc-driver
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}${INFORMIXDIR}/lib:${INFORMIXDIR}/lib/esql:${INFORMIXDIR}/lib/cli
@@ -107,7 +107,7 @@ tar xvf  OneDB-Win64-ODBC-Driver.zip -C ./home/informix/cli
 del OneDB-Win64-ODBC-Driver.zip
 ```
 
-2. Add an enviroment variable:
+2. Add an environment variable:
 ```bash
 set INFORMIXDIR=$HOME/Informix/home/informix/cli/onedb-odbc-driver
 ```

--- a/docs/integrations/data-integrations/vertica.mdx
+++ b/docs/integrations/data-integrations/vertica.mdx
@@ -13,7 +13,7 @@ This handler is implemented using `vertica-python`, a Python library that allows
 
 The required arguments to establish a connection are as follows:
 
-* `user` is the username asscociated with the database.
+* `user` is the username associated with the database.
 * `password` is the password to authenticate your access.
 * `host` is the host name or IP address of the server.
 * `port` is the port through which TCP/IP connection is to be made.

--- a/docs/mongo/collection-structure.mdx
+++ b/docs/mongo/collection-structure.mdx
@@ -110,7 +110,7 @@ Where:
 | `NAME`              | The name of the model.                                                          |
 | `ENGINE`            | The engine used to create the model.                                            |
 | `PROJECT`           | The project where the model resides.                                            |
-| `ACTIVE`            | The status of the model's version. The value of `true` if active, the value fo `false` if inactive.|
+| `ACTIVE`            | The status of the model's version. The value of `true` if active, the value of `false` if inactive.|
 | `VERSION`           | The version of the model.                                                       |
 | `STATUS`            | Training status (`generating`, or `training`, or `complete`, or `error`).       |
 | `ACCURACY`          | The model accuracy (`0.999` is a sample accuracy value).                        |

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -36,7 +36,7 @@ components:
           description: Accuracy of trained model between 0 and 1
         active:
           type: boolean
-          description: Whether or not this model is currenty the active version
+          description: Whether or not this model is currently the active version
         version:
           type: number
           description: Version of this model
@@ -211,7 +211,7 @@ paths:
             type: string
       responses:
         '200':
-          description: A JSON object with database informations
+          description: A JSON object with database information
           content:
             application/json:
               schema:

--- a/docs/sdk/javascript-sdk.mdx
+++ b/docs/sdk/javascript-sdk.mdx
@@ -173,7 +173,7 @@ try {
 }
 ```
 
-First, we define the connection paramaters and then use the `createDatabase` function to connect a database.
+First, we define the connection parameters and then use the `createDatabase` function to connect a database.
 
 ### Getting & Deleting a Database
 

--- a/docs/sdk_javascript/create_database.mdx
+++ b/docs/sdk_javascript/create_database.mdx
@@ -34,4 +34,4 @@ try {
 }
 ```
 
-First, we define the connection paramaters and then use the `createDatabase` function to connect a database.
+First, we define the connection parameters and then use the `createDatabase` function to connect a database.

--- a/docs/sdk_javascript/finetune.mdx
+++ b/docs/sdk_javascript/finetune.mdx
@@ -5,7 +5,7 @@ sidebarTitle: Finetune a Model
 
 ## Description
 
-The `adjust()` fuction lets us finetune the model with specific data.
+The `adjust()` function lets us finetune the model with specific data.
 
 ## Syntax
 

--- a/docs/sdk_javascript/get_database.mdx
+++ b/docs/sdk_javascript/get_database.mdx
@@ -3,7 +3,7 @@ title: Get a Data Source
 sidebarTitle: Get a Data Source
 ---
 
-You can save a data sources nto a variable using the code below.
+You can save a data sources not a variable using the code below.
 
 ```
 const db = await MindsDB.Databases.getDatabase('mysql_datasource');

--- a/docs/sdk_javascript/retrain.mdx
+++ b/docs/sdk_javascript/retrain.mdx
@@ -5,7 +5,7 @@ sidebarTitle: Retrain a Model
 
 ## Description
 
-The `retrain()` fuction lets us retrain the model, for example, when there is a new version of MindsDB available.
+The `retrain()` function lets us retrain the model, for example, when there is a new version of MindsDB available.
 
 ## Syntax
 

--- a/docs/sql/api/describe.mdx
+++ b/docs/sql/api/describe.mdx
@@ -398,7 +398,7 @@ Models that utlize LangChain or are brought to MindsDB via MLflow can be describ
 DESCRIBE other_model;
 ```
 
-The above command returs `["info"]` in its first output column.
+The above command returns `["info"]` in its first output column.
 
 ```sql
 DESCRIBE other_model.info;

--- a/docs/sql/tutorials/byom.mdx
+++ b/docs/sql/tutorials/byom.mdx
@@ -104,7 +104,7 @@ dtype_dict={"number_of_rooms": "categorical", "initial_price": "integer", "renta
 format='ray_server';
 ```
 
-And you can query predictions as usual, either by conditioning on a subset of input colums:
+And you can query predictions as usual, either by conditioning on a subset of input columns:
 
 ```sql
 SELECT * FROM byom_ray_serve WHERE initial_price=3000 AND rental_price=3000;

--- a/docs/sql/tutorials/create-chatbot.mdx
+++ b/docs/sql/tutorials/create-chatbot.mdx
@@ -5,7 +5,7 @@ sidebarTitle: Customize Chatbot
 
 MindsDB provides the `CREATE CHATBOT` statement that is used under the hood by the [Chatbot Interface](/sql/tutorials/llm-chatbot-ui). But, if you want to customize your chatbot to learn from the underlying database or use a different model, check out this tutorial.
 
-The `CREATE CHATBOT` statement requires three componenets:
+The `CREATE CHATBOT` statement requires three components:
 
 1. The AI model in the `conversational` mode.
 

--- a/docs/sql/tutorials/house-sales-statsforecast.mdx
+++ b/docs/sql/tutorials/house-sales-statsforecast.mdx
@@ -90,7 +90,7 @@ HORIZON 4
 USING ENGINE = 'statsforecast';
 ```
 
-The sytax is the same as in original tutorial. But here, we add the `USING` clause that specifies the ML engine used to make predictions.
+The syntax is the same as in original tutorial. But here, we add the `USING` clause that specifies the ML engine used to make predictions.
 
 We can check the training status with the following query:
 

--- a/docs/sql/tutorials/slack-chatbot.mdx
+++ b/docs/sql/tutorials/slack-chatbot.mdx
@@ -169,7 +169,7 @@ api_key = 'your openai key,
 model_name = 'gpt-4', -- you can also use 'text-davinci-003' or ''
 prompt_template = 'From input message: {{messages}}\
 write a short response in less than 40 words to some user in the following format:\
-Hi there, WhizFizz here! <respond with a mind blowing fact about Space and describe the response using cosmic and scientific analogies, where wonders persist. In between quote some hilarious appropriate raps statements based on the context of the question answer as if you are a Physics Space Mad Scientist who relates everythign to the Universe and its strange theories. So lets embark on a journey, where science and magic intertwine. Stay tuned for more enchantment! ✨🚀 -- mdb.ai/bot by @mindsdb';
+Hi there, WhizFizz here! <respond with a mind blowing fact about Space and describe the response using cosmic and scientific analogies, where wonders persist. In between quote some hilarious appropriate raps statements based on the context of the question answer as if you are a Physics Space Mad Scientist who relates everything to the Universe and its strange theories. So lets embark on a journey, where science and magic intertwine. Stay tuned for more enchantment! ✨🚀 -- mdb.ai/bot by @mindsdb';
 ```
 
 Let's test this in action:
@@ -270,7 +270,7 @@ SELECT * FROM jobs WHERE name="gpt4_slack_job";
 SELECT * FROM jobs_history WHERE name="gpt4_slack_job";
 ```
 
-To stop the sheduled job, we can use the following:
+To stop the scheduled job, we can use the following:
 
 ```sql
 DROP JOB gpt4_slack_job;

--- a/docs/sql/tutorials/time-series-community.mdx
+++ b/docs/sql/tutorials/time-series-community.mdx
@@ -26,5 +26,5 @@ Check out the articles and video guides created by our community:
 - Video guide on [Forecasting Quarterly House Sales with MindsDB](https://youtu.be/RPisvY54Tg4)
   by [Hritik Dangi](https://www.linkedin.com/in/hritikd3/)
 
-- Video guide on [Forcasting quarterly house sales with MindsDB](https://www.youtube.com/watch?v=dNjN52xdgVU)
+- Video guide on [Forecasting quarterly house sales with MindsDB](https://www.youtube.com/watch?v=dNjN52xdgVU)
   by [HellFire](https://github.com/Artemis6969)

--- a/docs/tutorials.mdx
+++ b/docs/tutorials.mdx
@@ -230,7 +230,7 @@ sidebarTitle: Community Tutorials List
   by [Syed Zubeen](https://github.com/syedzubeen)
 - [Predicting car prices with MindsDB](https://www.youtube.com/watch?v=pYSlYBjukNA)
   by [Syed Zubeen](https://github.com/syedzubeen)
-- [Forcasting quarterly house sales with MindsDB](https://www.youtube.com/watch?v=dNjN52xdgVU)
+- [Forecasting quarterly house sales with MindsDB](https://www.youtube.com/watch?v=dNjN52xdgVU)
   by [HellFire](https://github.com/Artemis6969)
 - [How Mindsdb is impacting the world of Machine Learning](https://youtu.be/YngjfwJLplA)
   by [Prathik Shetty](https://github.com/prathikshetty2002)

--- a/docs/tutorials/question_asnwering_openai_mongodb.md
+++ b/docs/tutorials/question_asnwering_openai_mongodb.md
@@ -32,7 +32,7 @@ To connect `MongoDB` with `MindsDB`:
 > - [MongoDB Compass](https://docs.mindsdb.com/connect/mongo-compass)
 > - [MongoDB Shell](https://docs.mindsdb.com/connect/mongo-shell)
 
-After you connect `MongoDB` with `MindsDB`, you need to add the dataset using `inserOne` statement.
+After you connect `MongoDB` with `MindsDB`, you need to add the dataset using `insertOne` statement.
 
 ```
 test> use mindsdb

--- a/docs/tutorials/salary_prediction.mdx
+++ b/docs/tutorials/salary_prediction.mdx
@@ -16,7 +16,7 @@ Follow this guide to set up [Mindsdb cloud](https://docs.mindsdb.com/setup/cloud
 
 Download the [employee dataset here](https://www.kaggle.com/datasets/mukeshmanral/employ-earnings-data?select=batch2_jobID_00B80TR.csv) and upload it by navigating to the Add button located in the top right corner then choose Upload File.
 
-Click on the Import File option to browse through your files and select the CSV file containing the dataset. You can add a suitable name. In this case we wil use jobs.
+Click on the Import File option to browse through your files and select the CSV file containing the dataset. You can add a suitable name. In this case we will use jobs.
 
 Let's run a query to preview the data that we will use to train our predictor.
 
@@ -53,7 +53,7 @@ A feature is a column used to train the model.
 
 We will use the CREATE MODEL statement to create and train the machine learning model to predict salaries.
 
-We use the FROM statement to specify the input columns to be used for training. We will not use the companyID column because it does not affect the predictor's perfomance.
+We use the FROM statement to specify the input columns to be used for training. We will not use the companyID column because it does not affect the predictor's performance.
 
 We specify what we want to predict using the PREDICT statement.
 

--- a/docs/tutorials/sentiment-analysis-intercom-data-airbyte.mdx
+++ b/docs/tutorials/sentiment-analysis-intercom-data-airbyte.mdx
@@ -50,7 +50,7 @@ Here is how we can check its status:
 DESCRIBE sentiment_classifier_model;
 ```
 
-Once the status is complete, we can proceeed to make predictions.
+Once the status is complete, we can proceed to make predictions.
 
 ## Making batch predictions
 

--- a/docs/tutorials/sentiment-analysis-on-french-tweets-using-mysql.mdx
+++ b/docs/tutorials/sentiment-analysis-on-french-tweets-using-mysql.mdx
@@ -6,7 +6,7 @@
 
 [MindsDB](https://mindsdb.com/) is is an open-source AI layer for existing databases that allows you to effortlessly develop, train and deploy state-of-the-art machine learning models using SQL queries. 
 [Hugging Face](https://huggingface.co/) is a community and data science platform that provides tools that enables users to build, train and deploy machine learning models based on open source code and technologies. 
-**NLP**, or Natural Language Processing, is a subprocess of artificial intelligence that helps machines process and understand the human langage so that they can automatically perform repetitive tasks. 
+**NLP**, or Natural Language Processing, is a subprocess of artificial intelligence that helps machines process and understand the human language so that they can automatically perform repetitive tasks. 
 Some examples of NLP include machine translation, summarization, ticket classification, and spell check (or "autocorrect").
 
 The following four NLP tasks are currently supported by MindsDB:


### PR DESCRIPTION
## Description

This PR correct the typo that was seen in the files inside docs folder

```pesudo
instace > instance
reopsitory > repository
shoud > should
wirtten > written
impletation > implementation
Setings > Settings
webistes > websites
adress > address
statemet > statement
swithc > switch
```

## Type of change

- [X] 📄 This change requires a documentation update
