### PR TITLE
Newsapi Integration Bugs

### DIFF
--- a/docs/integrations/app-integrations/newsapi.mdx
+++ b/docs/integrations/app-integrations/newsapi.mdx
@@ -44,19 +44,18 @@ Simple Search for recent articles:
 ```sql
 SELECT *
 FROM newsAPI.article
-WHERE query = 'mindsdb';
+WHERE query = 'Python';
 ```
 
-Advanced search for recent articles:
+Advanced search for recent articles per specific sources between dates:
 
 ```sql
 SELECT *
 FROM newsAPI.article
-WHERE query = 'mindsdb'
-AND sources="abc-news"
-AND publishedAt >= "2023-03-23" AND  publishedAt <= "2023-04-23"
-ORDER BY publishedAt
-LIMIT 40;
+WHERE query = 'Python'
+AND sources="bbc-news"
+AND publishedAt >= "2021-03-23" AND  publishedAt <= "2023-04-23"
+LIMIT 4;
 ```
 
 <Info>

--- a/mindsdb/integrations/handlers/newsapi_handler/README.md
+++ b/mindsdb/integrations/handlers/newsapi_handler/README.md
@@ -24,7 +24,7 @@ To see if the connection was successful, try searching for the most recent artic
 ```
 SELECT *
 FROM newsAPI.article
-WHERE query = 'mindsdb';
+WHERE query = 'Python';
 ```
 
 The result come with all these columns
@@ -48,12 +48,10 @@ You can select with multiple clauses
 ```
 SELECT *
 FROM newsAPI.article
-WHERE query = 'mindsdb'
-AND sources="abc-news"
-AND publishedAt >= "2023-03-23" AND  publishedAt <= "2023-04-23"
-AND language = 'en'
-ORDER BY publishedAt
-LIMIT 40;
+WHERE query = 'Python'
+AND sources="bbc-news"
+AND publishedAt >= "2021-03-23" AND  publishedAt <= "2023-04-23"
+LIMIT 4;
 ```
 
 #### **WHERE CLAUSE PARAMETERS:**


### PR DESCRIPTION
## Description

This PR adds a few changes to the NewsAPI handler:

1. Check if there is data. If not, return an empty DF instead of throwing a mapping error
2. Fix the sorting issue by correctly parsing the ORDER BY value
3. Check if the API call is successful
4. Set default page API value if the page value is missing

Fixes #7899 , #7897

The unit tests for this handler will be added in separate PR.

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [X] 📄 This change adds a documentation update

## Verification Process

To ensure the changes are working as expected, run the following queries:

```sql
SELECT *
FROM newsAPI.article
WHERE query = 'mindsdb';
```
And:
```
SELECT *
FROM newsAPI.article
WHERE query = 'Python'
AND sources="bbc-news"
AND publishedAt >= "2021-03-23" AND  publishedAt <= "2023-04-23"
LIMIT 4;
```

## Additional Media:

![Screenshot from 2023-10-19 15-28-10](https://github.com/mindsdb/mindsdb/assets/7192539/579c0b71-23fb-471c-a76e-db759e8407a9)


## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [X] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



