### PR TITLE
update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
+        args: [--skip-string-normalization] #prevents conversion of single to double quotes
   - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-        args: [--skip-string-normalization] #prevents conversion of single to double quotes
+        args: [--skip-string-normalization] #prevents conversion of single to double quotes see https://safjan.com/black-keep-single-quotes-strings/ 
   - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:


### PR DESCRIPTION
## Description

By default, `black` converts single-quotes to double-quotes. Let's skip this behaviour

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.



