### PR TITLE
Added the pysqlite3-binary Dependency for Chroma

### DIFF
--- a/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
@@ -1,12 +1,13 @@
+__import__('pysqlite3')
+
+import sys
+sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
+
 from collections import OrderedDict
 from typing import List, Optional
 
 import chromadb
 import pandas as pd
-
-__import__('pysqlite3')
-import sys
-sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
 
 from mindsdb.integrations.libs.const import HANDLER_CONNECTION_ARG_TYPE as ARG_TYPE
 from mindsdb.integrations.libs.response import RESPONSE_TYPE

--- a/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
@@ -4,6 +4,10 @@ from typing import List, Optional
 import chromadb
 import pandas as pd
 
+__import__('pysqlite3')
+import sys
+sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
+
 from mindsdb.integrations.libs.const import HANDLER_CONNECTION_ARG_TYPE as ARG_TYPE
 from mindsdb.integrations.libs.response import RESPONSE_TYPE
 from mindsdb.integrations.libs.response import HandlerResponse

--- a/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
@@ -1,7 +1,6 @@
 __import__('pysqlite3')
 
 import sys
-sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
 
 from collections import OrderedDict
 from typing import List, Optional
@@ -21,6 +20,8 @@ from mindsdb.integrations.libs.vectordatabase_handler import (
     VectorStoreHandler,
 )
 from mindsdb.utilities import log
+
+sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
 
 
 class ChromaDBHandler(VectorStoreHandler):

--- a/mindsdb/integrations/handlers/chromadb_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/chromadb_handler/requirements.txt
@@ -1,1 +1,2 @@
 chromadb~=0.4.8
+pysqlite3-binary


### PR DESCRIPTION
## Description

This PR adds the `pysqlite3-binary` for the Chroma because it is currently not working in MindsDB Cloud. This is the error that has been encountered,
`Your system has an unsupported version of sqlite3. Chroma requires sqlite3 >= 3.35.0.`

Because the version of the `sqlite3` module is tied to the Python version, I thought this would be the best way to go about it. This works locally after some initial testing, but the problem exists in Cloud.

Fixes https://github.com/mindsdb/mindsdb/issues/7949

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [X]   Initialize the handler locally to ensure it works
 - [ ]   Initialize the handler on Cloud to ensure the fix works

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



