### PR TITLE
Updated Mandatory Parameters for Docker Hub repo_images_summary Table

### DIFF
--- a/mindsdb/integrations/handlers/dockerhub_handler/dockerhub_tables.py
+++ b/mindsdb/integrations/handlers/dockerhub_handler/dockerhub_tables.py
@@ -54,10 +54,10 @@ class DockerHubRepoImagesSummaryTable(APITable):
             elif arg1 in self.get_columns():
                 subset_where_conditions.append([op, arg1, arg2])
 
-        filter_flag = ("namespace" in search_params) or ("repository" in search_params)
+        filter_flag = ("namespace" in search_params) and ("repository" in search_params)
 
         if not filter_flag:
-            raise NotImplementedError("namespace or repository column has to be present in where clause.")
+            raise NotImplementedError("Both namespace and repository columns have to be present in WHERE clause.")
 
         repo_images_summary_df = pd.DataFrame(columns=self.get_columns())
 

--- a/mindsdb/integrations/handlers/dockerhub_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/dockerhub_handler/requirements.txt
@@ -1,2 +1,1 @@
 requests
-json


### PR DESCRIPTION
## Description

This PR handles the error for when both the namespace and repository columns are not part of the `SELECT` query for the Docker Hub `repo_images_summary` table.

Fixes https://github.com/mindsdb/mindsdb/issues/8049

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [X]   Test Location: Running the integration locally

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.
![image](https://github.com/mindsdb/mindsdb/assets/49385643/b2838287-e2cb-424a-8589-b9c479da053f)


## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



