### PR TITLE
Rearranged Imports for Chroma Integratoin

### DIFF
--- a/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
@@ -1,12 +1,13 @@
+__import__('pysqlite3')
+
+import sys
+sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
+
 from collections import OrderedDict
 from typing import List, Optional
 
 import chromadb
 import pandas as pd
-
-__import__('pysqlite3')
-import sys
-sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
 
 from mindsdb.integrations.libs.const import HANDLER_CONNECTION_ARG_TYPE as ARG_TYPE
 from mindsdb.integrations.libs.response import RESPONSE_TYPE

--- a/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
@@ -4,6 +4,10 @@ from typing import List, Optional
 import chromadb
 import pandas as pd
 
+__import__('pysqlite3')
+import sys
+sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
+
 from mindsdb.integrations.libs.const import HANDLER_CONNECTION_ARG_TYPE as ARG_TYPE
 from mindsdb.integrations.libs.response import RESPONSE_TYPE
 from mindsdb.integrations.libs.response import HandlerResponse

--- a/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
@@ -1,9 +1,10 @@
-__import__('pysqlite3')
-
 import sys
 
 from collections import OrderedDict
 from typing import List, Optional
+
+__import__('pysqlite3')
+sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
 
 import chromadb
 import pandas as pd
@@ -20,8 +21,6 @@ from mindsdb.integrations.libs.vectordatabase_handler import (
     VectorStoreHandler,
 )
 from mindsdb.utilities import log
-
-sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
 
 
 class ChromaDBHandler(VectorStoreHandler):

--- a/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
@@ -1,7 +1,6 @@
 __import__('pysqlite3')
 
 import sys
-sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
 
 from collections import OrderedDict
 from typing import List, Optional
@@ -21,6 +20,8 @@ from mindsdb.integrations.libs.vectordatabase_handler import (
     VectorStoreHandler,
 )
 from mindsdb.utilities import log
+
+sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
 
 
 class ChromaDBHandler(VectorStoreHandler):

--- a/mindsdb/integrations/handlers/chromadb_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/chromadb_handler/requirements.txt
@@ -1,1 +1,2 @@
 chromadb~=0.4.8
+pysqlite3-binary


### PR DESCRIPTION
## Description

This PR moves the import of the `pysqlite3` module to before that of `chromadb`.

Fixes #issue_number

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Test on Alpha.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



