### PR TITLE
Add new step for running the ML tests if the user is part of mindsdb org

### DIFF
--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -119,7 +119,25 @@ jobs:
           # Company independent
           echo -e "\n===============test company independent===============\n"
           pytest -vx tests/integration_tests/flows/test_company_independent.py
-
+        fi
+      shell: bash
+      env:
+        CHECK_FOR_UPDATES: False
+        AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+        AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+    - name: Check if actor is an organization member
+      id: check-membership
+      run: |
+        if [[ "${{ github.actor }}" == "mindsdb/"* ]];
+          echo "::set-output name=isOrgMember::true"
+        else
+          echo "::set-output name=isOrgMember::false"
+        fi
+      shell: bash
+    - name: Run ML Engines tests
+      if: steps.check-membership.outputs.isOrgMember == 'true'
+      run: |
+        if [ "$RUNNER_OS" == "Linux" ]; then
           # First-tier ML engines
           echo -e "\n===============test ML engines===============\n"
           pytest -vx tests/unit/ml_handlers/test_openai.py
@@ -130,13 +148,10 @@ jobs:
           # pytest -vx tests/unit/ml_handlers/test_statsforecast.py
           # pytest -vx tests/unit/ml_handlers/test_huggingface.py
           # pytest -vx tests/unit/ml_handlers/test_lightwood.py
-        fi
       shell: bash
       env:
         CHECK_FOR_UPDATES: False
         OPENAI_API_KEY: ${{secrets.OPENAI_API_KEY}}
-        AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-        AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
         ANYSCALE_ENDPOINTS_API_KEY: ${{secrets.ANYSCALE_ENDPOINTS_API_KEY}}
 
   deploy_to_pypi:

--- a/.github/workflows/mindsdb.yml
+++ b/.github/workflows/mindsdb.yml
@@ -128,7 +128,7 @@ jobs:
     - name: Check if actor is an organization member
       id: check-membership
       run: |
-        if [[ "${{ github.actor }}" == "mindsdb/"* ]];
+        if [[ "${{ github.actor }}" == "mindsdb/"* ]]; then
           echo "::set-output name=isOrgMember::true"
         else
           echo "::set-output name=isOrgMember::false"


### PR DESCRIPTION
## Description

This PR moves the ML tests to a new step and runs them only for mindsdb team members. 
Note this check works only from the accounts that have '@mindsdb'

Fixes failing PRs from community members

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update


## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



