### PR TITLE
DataFrame query with increasing butch size for type infer 

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
+++ b/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
@@ -15,7 +15,6 @@ import datetime as dt
 from collections import defaultdict
 
 import dateinfer
-import duckdb
 import pandas as pd
 import numpy as np
 

--- a/mindsdb/api/mysql/mysql_proxy/utilities/sql.py
+++ b/mindsdb/api/mysql/mysql_proxy/utilities/sql.py
@@ -1,6 +1,7 @@
 import copy
 
 import duckdb
+from duckdb.duckdb import InvalidInputException
 import numpy as np
 
 from mindsdb_sql import parse_sql
@@ -13,6 +14,39 @@ from mindsdb_sql.parser.ast import (
 
 from mindsdb.utilities import log
 from mindsdb.utilities.json_encoder import CustomJSONEncoder
+
+
+def query_df_with_type_infer_fallback(query_str: str, dataframes: dict):
+    ''' Duckdb need to infer column types if column.dtype == object. By default it take 100 rows,
+        but that may be not sufficient for some cases. This func try to run query multiple times
+        increasing butch size for type infer
+
+        Args:
+            query_str (str): query to execute
+            dataframes (dict): dataframes
+
+        Returns:
+            pandas.DataFrame
+            pandas.columns
+    '''
+
+    for name, value in dataframes.items():
+        locals()[name] = value
+
+    con = duckdb.connect(database=':memory:')
+    for sample_size in [1000, 10000, 1000000]:
+        try:
+            con.execute(f'set global pandas_analyze_sample={sample_size};')
+            result_df = con.execute(query_str).fetchdf()
+        except InvalidInputException:
+            pass
+        break
+    else:
+        raise InvalidInputException
+    description = con.description
+    con.close()
+
+    return result_df, description
 
 
 def query_df(df, query, session=None):
@@ -94,13 +128,8 @@ def query_df(df, query, session=None):
         if 'TRAINING_OPTIONS' in df.columns:
             df = df.astype({'TRAINING_OPTIONS': 'string'})
 
-    con = duckdb.connect(database=':memory:')
-
-    con.execute('set global pandas_analyze_sample=10000')
-    result_df = con.execute(query_str).fetchdf()
+    result_df, description = query_df_with_type_infer_fallback(query_str, {'df': df})
     result_df = result_df.replace({np.nan: None})
-    description = con.description
-    con.close()
 
     new_column_names = {}
     real_column_names = [x[0] for x in description]


### PR DESCRIPTION
## Description

By default `duckdb`  get only 1000 rows if need do type infer. That may be not sufficient for some cases.

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



