### PR TITLE
remove server selection timeout override for mongodbhandler

### DIFF
--- a/mindsdb/integrations/handlers/mongodb_handler/mongodb_handler.py
+++ b/mindsdb/integrations/handlers/mongodb_handler/mongodb_handler.py
@@ -69,7 +69,6 @@ class MongoDBHandler(DatabaseHandler):
         connection = MongoClient(
             self.host,
             port=self.port,
-            serverSelectionTimeoutMS=5000,
             **kwargs
         )
         self.is_connected = True


### PR DESCRIPTION
## Description

remove server selection timeout override in mongodb handler. 
[default is best/safe at 30000ms](https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.serverSelectionTimeoutMS) and can be configured in connection string if needing to override

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [x]   Test Location: NA / tested locally
 - [x]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

set serverSelectionTimeoutMS to 0 in connection string and observe failure
set serverSelectionTimeoutMS to 30000 in connection string and observe success
don't set serverSelectionTimeoutMS in connection string and observe success for connections above the previous 5000ms

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.
