### PR TITLE
feat(youtube_handler): implement youtube transcripts retrieval in video table

### DIFF
--- a/mindsdb/integrations/handlers/youtube_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/youtube_handler/requirements.txt
@@ -1,1 +1,2 @@
 google-api-python-client
+youtube-transcript-api

--- a/mindsdb/integrations/handlers/youtube_handler/youtube_handler.py
+++ b/mindsdb/integrations/handlers/youtube_handler/youtube_handler.py
@@ -1,4 +1,8 @@
-from mindsdb.integrations.handlers.youtube_handler.youtube_tables import YoutubeCommentsTable, YoutubeChannelsTable, YoutubeVideosTable
+from mindsdb.integrations.handlers.youtube_handler.youtube_tables import (
+    YoutubeCommentsTable,
+    YoutubeChannelsTable,
+    YoutubeVideosTable,
+)
 from mindsdb.integrations.libs.api_handler import APIHandler
 from mindsdb.integrations.libs.response import (
     HandlerStatusResponse as StatusResponse,
@@ -12,6 +16,7 @@ from mindsdb.integrations.libs.const import HANDLER_CONNECTION_ARG_TYPE as ARG_T
 from googleapiclient.discovery import build
 
 logger = get_log("integrations.youtube_handler")
+
 
 class YoutubeHandler(APIHandler):
     """Youtube handler implementation"""
@@ -33,7 +38,7 @@ class YoutubeHandler(APIHandler):
         self.connection = None
         self.is_connected = False
 
-        youtube_video_comments_data =YoutubeCommentsTable(self)
+        youtube_video_comments_data = YoutubeCommentsTable(self)
         self._register_table("comments", youtube_video_comments_data)
 
         youtube_channel_data = YoutubeChannelsTable(self)
@@ -52,7 +57,9 @@ class YoutubeHandler(APIHandler):
         if self.is_connected is True:
             return self.connection
 
-        youtube = build('youtube', 'v3', developerKey=self.connection_data['youtube_api_token'])
+        youtube = build(
+            "youtube", "v3", developerKey=self.connection_data["youtube_api_token"]
+        )
         self.connection = youtube
 
         return self.connection
@@ -95,13 +102,11 @@ class YoutubeHandler(APIHandler):
 
 connection_args = OrderedDict(
     youtube_access_token={
-        'type': ARG_TYPE.STR,
-        'description': 'API Token for accessing Youtube Application API',
-        'required': True,
-        'label': 'Youtube access token',
-    }   
+        "type": ARG_TYPE.STR,
+        "description": "API Token for accessing Youtube Application API",
+        "required": True,
+        "label": "Youtube access token",
+    }
 )
 
-connection_args_example = OrderedDict(
-    youtube_api_token ='<your-youtube-api-token>'
-)
+connection_args_example = OrderedDict(youtube_api_token="<your-youtube-api-token>")

--- a/mindsdb/integrations/handlers/youtube_handler/youtube_tables.py
+++ b/mindsdb/integrations/handlers/youtube_handler/youtube_tables.py
@@ -5,13 +5,18 @@ from mindsdb.integrations.utilities.sql_utils import extract_comparison_conditio
 from mindsdb.utilities.log import get_log
 
 from mindsdb_sql.parser import ast
-from mindsdb.integrations.handlers.utilities.query_utilities import SELECTQueryParser, SELECTQueryExecutor
+from mindsdb.integrations.handlers.utilities.query_utilities import (
+    SELECTQueryParser,
+    SELECTQueryExecutor,
+)
 
 import pandas as pd
 import re
-
+from youtube_transcript_api import YouTubeTranscriptApi
+from youtube_transcript_api.formatters import JSONFormatter
 
 logger = get_log("integrations.youtube_handler")
+
 
 class YoutubeCommentsTable(APITable):
     """Youtube List Comments  by video id Table implementation"""
@@ -42,7 +47,7 @@ class YoutubeCommentsTable(APITable):
 
             for an_order in query.order_by:
                 if an_order.field.parts[0] != "id":
-                    next    
+                    next
                 if an_order.field.parts[1] in self.get_columns():
                     order_by_conditions["columns"].append(an_order.field.parts[1])
 
@@ -63,7 +68,6 @@ class YoutubeCommentsTable(APITable):
             else:
                 raise ValueError(f"Unsupported where argument {a_where[1]}")
 
-
         youtube_comments_df = self.call_youtube_comments_api(a_where[2])
 
         selected_columns = []
@@ -76,12 +80,13 @@ class YoutubeCommentsTable(APITable):
             else:
                 raise ValueError(f"Unknown query target {type(target)}")
 
-
         if len(youtube_comments_df) == 0:
             youtube_comments_df = pd.DataFrame([], columns=selected_columns)
         else:
             youtube_comments_df.columns = self.get_columns()
-            for col in set(youtube_comments_df.columns).difference(set(selected_columns)):
+            for col in set(youtube_comments_df.columns).difference(
+                set(selected_columns)
+            ):
                 youtube_comments_df = youtube_comments_df.drop(col, axis=1)
 
             if len(order_by_conditions.get("columns", [])) > 0:
@@ -102,21 +107,21 @@ class YoutubeCommentsTable(APITable):
         List[str]
             List of columns
         """
-        return [
-        'user_id', 
-        'display_name', 
-        'comment'
-        ]
+        return ["user_id", "display_name", "comment"]
 
-    def call_youtube_comments_api(self,video_id):
+    def call_youtube_comments_api(self, video_id):
         """Pulls all the records from the given youtube api end point and returns it select()
-    
+
         Returns
         -------
         pd.DataFrame of all the records of the "commentThreads()" API end point
         """
 
-        resource = self.handler.connect().commentThreads().list(part='snippet',videoId=video_id,textFormat='plainText')
+        resource = (
+            self.handler.connect()
+            .commentThreads()
+            .list(part="snippet", videoId=video_id, textFormat="plainText")
+        )
 
         video_cols = self.get_columns()
         all_youtube_comments_df = pd.DataFrame(columns=video_cols)
@@ -124,28 +129,42 @@ class YoutubeCommentsTable(APITable):
 
         while resource:
             comments = resource.execute()
-            for comment in comments['items']:
-                user_id = comment['snippet']['topLevelComment']['snippet']['authorChannelId']['value']
-                display_name = comment['snippet']['topLevelComment']['snippet']['authorDisplayName']
-                comment_text = comment['snippet']['topLevelComment']['snippet']['textDisplay']
-                data = pd.DataFrame({
-                    'user_id': [user_id],
-                    'display_name': [display_name],
-                    'comment': [comment_text]
-                })
-                all_youtube_comments_df = pd.concat([all_youtube_comments_df, data], ignore_index=True)
-            if 'nextPageToken' in comments:
-                resource = self.handler.connect().commentThreads().list(
-                    part='snippet',
-                    videoId=video_id,
-                    textFormat='plainText',
-                    pageToken=comments['nextPageToken']
+            for comment in comments["items"]:
+                user_id = comment["snippet"]["topLevelComment"]["snippet"][
+                    "authorChannelId"
+                ]["value"]
+                display_name = comment["snippet"]["topLevelComment"]["snippet"][
+                    "authorDisplayName"
+                ]
+                comment_text = comment["snippet"]["topLevelComment"]["snippet"][
+                    "textDisplay"
+                ]
+                data = pd.DataFrame(
+                    {
+                        "user_id": [user_id],
+                        "display_name": [display_name],
+                        "comment": [comment_text],
+                    }
+                )
+                all_youtube_comments_df = pd.concat(
+                    [all_youtube_comments_df, data], ignore_index=True
+                )
+            if "nextPageToken" in comments:
+                resource = (
+                    self.handler.connect()
+                    .commentThreads()
+                    .list(
+                        part="snippet",
+                        videoId=video_id,
+                        textFormat="plainText",
+                        pageToken=comments["nextPageToken"],
+                    )
                 )
             else:
                 break
 
-
         return all_youtube_comments_df
+
 
 class YoutubeChannelsTable(APITable):
 
@@ -153,21 +172,26 @@ class YoutubeChannelsTable(APITable):
 
     def select(self, query: ast.Select) -> pd.DataFrame:
         select_statement_parser = SELECTQueryParser(
-            query,
-            'channel',
-            self.get_columns()
+            query, "channel", self.get_columns()
         )
 
-        selected_columns, where_conditions, order_by_conditions, result_limit = select_statement_parser.parse_query()
+        (
+            selected_columns,
+            where_conditions,
+            order_by_conditions,
+            result_limit,
+        ) = select_statement_parser.parse_query()
 
         channel_id = None
         for op, arg1, arg2 in where_conditions:
-            if arg1 == 'channel_id':
-                if op == '=':
+            if arg1 == "channel_id":
+                if op == "=":
                     channel_id = arg2
                     break
                 else:
-                    raise NotImplementedError("Only '=' operator is supported for channel_id column.")
+                    raise NotImplementedError(
+                        "Only '=' operator is supported for channel_id column."
+                    )
 
         if not channel_id:
             raise NotImplementedError("channel_id has to be present in where clause.")
@@ -175,10 +199,7 @@ class YoutubeChannelsTable(APITable):
         channel_df = self.get_channel_details(channel_id)
 
         select_statement_executor = SELECTQueryExecutor(
-            channel_df,
-            selected_columns,
-            where_conditions,
-            order_by_conditions
+            channel_df, selected_columns, where_conditions, order_by_conditions
         )
 
         channel_df = select_statement_executor.execute_query()
@@ -186,44 +207,63 @@ class YoutubeChannelsTable(APITable):
         return channel_df
 
     def get_channel_details(self, channel_id):
-        details = self.handler.connect().channels().list(part="statistics,snippet,contentDetails",id=channel_id).execute()
+        details = (
+            self.handler.connect()
+            .channels()
+            .list(part="statistics,snippet,contentDetails", id=channel_id)
+            .execute()
+        )
         snippet = details["items"][0]["snippet"]
         statistics = details["items"][0]["statistics"]
-        data = { "country":snippet["country"],
-        "description": snippet["description"],
-        "creation_date": snippet["publishedAt"],
-        "title": snippet["title"],
-        "subscriber_count": statistics["subscriberCount"],
-        "video_count": statistics["videoCount"],
-        "view_count": statistics["viewCount"],
-        "channel_id":channel_id
+        data = {
+            "country": snippet["country"],
+            "description": snippet["description"],
+            "creation_date": snippet["publishedAt"],
+            "title": snippet["title"],
+            "subscriber_count": statistics["subscriberCount"],
+            "video_count": statistics["videoCount"],
+            "view_count": statistics["viewCount"],
+            "channel_id": channel_id,
         }
         return pd.json_normalize(data)
 
     def get_columns(self) -> List[str]:
-        return ["country", "description", "creation_date", "title", "subscriber_count", "video_count","view_count", "channel_id"]
+        return [
+            "country",
+            "description",
+            "creation_date",
+            "title",
+            "subscriber_count",
+            "video_count",
+            "view_count",
+            "channel_id",
+        ]
+
 
 class YoutubeVideosTable(APITable):
 
     """Youtube Video info  by video id Table implementation"""
 
     def select(self, query: ast.Select) -> pd.DataFrame:
-        select_statement_parser = SELECTQueryParser(
-            query,
-            'video',
-            self.get_columns()
-        )
+        select_statement_parser = SELECTQueryParser(query, "video", self.get_columns())
 
-        selected_columns, where_conditions, order_by_conditions, result_limit = select_statement_parser.parse_query()
+        (
+            selected_columns,
+            where_conditions,
+            order_by_conditions,
+            result_limit,
+        ) = select_statement_parser.parse_query()
 
         video_id = None
         for op, arg1, arg2 in where_conditions:
-            if arg1 == 'video_id':
-                if op == '=':
+            if arg1 == "video_id":
+                if op == "=":
                     video_id = arg2
                     break
                 else:
-                    raise NotImplementedError("Only '=' operator is supported for video_id column.")
+                    raise NotImplementedError(
+                        "Only '=' operator is supported for video_id column."
+                    )
 
         if not video_id:
             raise NotImplementedError("video_id has to be present in where clause.")
@@ -231,10 +271,7 @@ class YoutubeVideosTable(APITable):
         video_df = self.get_video_details(video_id)
 
         select_statement_executor = SELECTQueryExecutor(
-            video_df,
-            selected_columns,
-            where_conditions,
-            order_by_conditions
+            video_df, selected_columns, where_conditions, order_by_conditions
         )
 
         video_df = select_statement_executor.execute_query()
@@ -242,20 +279,27 @@ class YoutubeVideosTable(APITable):
         return video_df
 
     def get_video_details(self, video_id):
-        details = self.handler.connect().videos().list(part="statistics,snippet,contentDetails",id=video_id).execute()
+        details = (
+            self.handler.connect()
+            .videos()
+            .list(part="statistics,snippet,contentDetails", id=video_id)
+            .execute()
+        )
         items = details.get("items")[0]
-        snippet         = items["snippet"]
-        statistics      = items["statistics"]
+        snippet = items["snippet"]
+        statistics = items["statistics"]
         content_details = items["contentDetails"]
-        
-        data = {"channel_title": snippet["channelTitle"],
-        "title": snippet["title"],
-        "description": snippet["description"],
-        "publish_time": snippet["publishedAt"],
-        "comment_count": statistics["commentCount"],
-        "like_count": statistics["likeCount"],
-        "view_count": statistics["viewCount"],
-        "video_id": video_id
+        transcript = self.get_captions(video_id)
+        data = {
+            "channel_title": snippet["channelTitle"],
+            "comment_count": statistics["commentCount"],
+            "description": snippet["description"],
+            "like_count": statistics["likeCount"],
+            "publish_time": snippet["publishedAt"],
+            "title": snippet["title"],
+            "transcript": transcript,
+            "video_id": video_id,
+            "view_count": statistics["viewCount"],
         }
         duration = content_details["duration"]
         parsed_duration = re.search(f"PT(\d+H)?(\d+M)?(\d+S)", duration).groups()
@@ -266,6 +310,33 @@ class YoutubeVideosTable(APITable):
         data["duration_str"] = duration_str.strip(":")
         return pd.json_normalize(data)
 
-    def get_columns(self) -> List[str]:
-        return ["channel_title", "title", "description", "publish_time", "comment_count", "like_count","view_count", "view_count", "video_id", "duration_str"]
+    def get_captions(self, video_id):
+        try:
+            transcript_response = YouTubeTranscriptApi.get_transcript(
+                video_id, preserve_formatting=True
+            )
+            json_formatted_transcript = JSONFormatter().format_transcript(
+                transcript_response, indent=2
+            )
+            return json_formatted_transcript
 
+        except Exception as e:
+            logger.error(
+                f"Encountered an error while fetching transcripts for video ${video_id}: ${e}"
+            ),
+            return "Transcript not available for this video"
+
+    def get_columns(self) -> List[str]:
+        return [
+            "channel_title",
+            "title",
+            "description",
+            "publish_time",
+            "comment_count",
+            "like_count",
+            "view_count",
+            "view_count",
+            "video_id",
+            "duration_str",
+            "transcript",
+        ]


### PR DESCRIPTION
## Description

Implemented the option to retrieve video transcripts in JSON format with the YouTube handler with the select query

~~~~sql
SELECT * FROM mindsdb_youtube.comments
WHERE video_id = "raWFGQ20OfA";
~~~~

![image](https://github.com/mindsdb/mindsdb/assets/65364356/6329aaa4-9327-4be9-9a46-be4298c45ce6)

Fixes #7891

## Type of change

(Please delete options that are not relevant)

- [x] ⚡ New feature (non-breaking change which adds functionality)
- [x] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [x]   Test Location: Specify the URL or path for testing.
 - [x]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [x] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



