### PR TITLE
[BREAKING CHANGE]: migrate auth from api keys to OAuth 2.0 Authentication Protocol

### DIFF
--- a/mindsdb/integrations/handlers/youtube_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/youtube_handler/requirements.txt
@@ -1,1 +1,2 @@
 google-api-python-client
+google_auth_oauthlib


### PR DESCRIPTION
## Summary
Fixes #8197 
To read or update YouTube's private data, users will now be required to use OAuth 2.0 to authenticate with Google, in accordance with the Youtube API security requirements.

 ![image](https://github.com/mindsdb/mindsdb/assets/65364356/ab050e3a-7ee0-4335-960b-539e5cd278f1)
 ![image](https://github.com/mindsdb/mindsdb/assets/65364356/7760f401-2aa1-4a1d-a425-a5e78be0bfb2) 


## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [x]   Test Location: Specify the URL or path for testing.
 - [x]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [x] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.
