### PR TITLE
Fix ingress backend service mismatch

### DIFF
--- a/helm/mindsdb/templates/ingress.yaml
+++ b/helm/mindsdb/templates/ingress.yaml
@@ -49,11 +49,11 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ $fullName }}
+                name: {{ $fullName }}-http
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              serviceName: {{ $fullName }}
+              serviceName: {{ $fullName }}-http
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}


### PR DESCRIPTION
## Description

The PR addresses a backend service mismatch issue in our Helm chart's Ingress configuration. The mismatch occurs when the backend service specified in the Ingress resource does not align with the desired service for the application. This discrepancy could lead to routing errors and unreliable service discovery.






