### PR TITLE
LAST: Use all conditions to get last value

### DIFF
--- a/mindsdb/interfaces/query_context/context_controller.py
+++ b/mindsdb/interfaces/query_context/context_controller.py
@@ -2,7 +2,7 @@ from typing import List
 
 import pandas as pd
 
-from mindsdb_sql.parser.ast import Identifier, Select, OrderBy, NullConstant, Constant, BinaryOperation, ASTNode
+from mindsdb_sql.parser.ast import ASTNode
 
 from mindsdb.interfaces.storage import db
 from mindsdb.utilities.context import context as ctx
@@ -121,26 +121,7 @@ class QueryContextController:
            'select <col> from <table> order by <col> desc limit 1"
         """
         last_values = {}
-        for info in l_query.get_last_columns():
-            col = Identifier(info['column_name'])
-
-            query = Select(
-                targets=[
-                    col
-                ],
-                from_table=info['table'],
-                order_by=[
-                    OrderBy(col, direction='DESC')
-                ],
-                where=BinaryOperation(
-                    op='is not',
-                    args=[
-                        col,
-                        NullConstant()
-                    ]
-                ),
-                limit=Constant(1)
-            )
+        for query, info in l_query.get_init_queries():
 
             data, columns_info = dn.query(
                 query=query,

--- a/mindsdb/interfaces/query_context/last_query.py
+++ b/mindsdb/interfaces/query_context/last_query.py
@@ -2,8 +2,9 @@ from typing import Union, List
 import copy
 from collections import defaultdict
 
-from mindsdb_sql.parser.ast import Identifier, Select, BinaryOperation, Last, Constant, Star, ASTNode,\
-    NullConstant, OrderBy
+from mindsdb_sql.parser.ast import (
+    Identifier, Select, BinaryOperation, Last, Constant, Star, ASTNode, NullConstant, OrderBy
+)
 from mindsdb_sql.planner.utils import query_traversal
 
 

--- a/mindsdb/interfaces/query_context/last_query.py
+++ b/mindsdb/interfaces/query_context/last_query.py
@@ -2,7 +2,8 @@ from typing import Union, List
 import copy
 from collections import defaultdict
 
-from mindsdb_sql.parser.ast import Identifier, Select, BinaryOperation, Last, Constant, Star, ASTNode
+from mindsdb_sql.parser.ast import Identifier, Select, BinaryOperation, Last, Constant, Star, ASTNode,\
+    NullConstant, OrderBy
 from mindsdb_sql.planner.utils import query_traversal
 
 
@@ -21,6 +22,7 @@ class LastQuery:
             # just skip it
             return
 
+        self.last_idx = defaultdict(list)
         last_tables = self.__find_last_columns(query)
         if last_tables is None:
             return
@@ -75,12 +77,11 @@ class LastQuery:
 
         self.query_orig = copy.deepcopy(query)
 
-        last_idx = defaultdict(list)
         for parent_query_id, node in conditions:
             # inject constant
             link = Constant(None)
             node.args[1] = link
-            last_idx[parent_query_id].append([node.args[0], link])
+            self.last_idx[parent_query_id].append(node)
 
         # index query targets
         query_id = id(query)
@@ -108,8 +109,9 @@ class LastQuery:
         # make info about query
 
         last_columns = {}
-        for parent_query_id, lasts in last_idx.items():
-            for col, last in lasts:
+        for parent_query_id, nodes in self.last_idx.items():
+            for node in nodes:
+                col, last = node.args
                 tables = tables_idx[parent_query_id]
                 if len(col.parts) > 1:
 
@@ -181,3 +183,31 @@ class LastQuery:
                 last.value = value
 
         return self.query
+
+    def get_init_queries(self):
+
+        back_up_values = []
+        # replace values
+        for nodes in self.last_idx.values():
+            for node in nodes:
+                back_up_values.append([node.op, node.args[1]])
+                node.op = 'is not'
+                node.args[1] = NullConstant()
+
+        query2 = copy.deepcopy(self.query)
+
+        # return values
+        for nodes in self.last_idx.values():
+            for node in nodes:
+                op, arg1 = back_up_values.pop(0)
+                node.op = op
+                node.args[1] = arg1
+
+        for info in self.get_last_columns():
+            col = Identifier(info['column_name'])
+            query2.targets = [col]
+            query2.order_by = [
+                OrderBy(col, direction='DESC')
+            ]
+            query2.limit = Constant(1)
+            yield query2, info

--- a/tests/unit/test_project_structure.py
+++ b/tests/unit/test_project_structure.py
@@ -609,7 +609,7 @@ class TestProjectStructure(BaseExecutorDummyML):
                 SELECT m.*
                    FROM pg.tasks as t
                    JOIN task_model as m
-                   where t.a > last
+                   where t.a > last and t.b='b'
             )
           )  
           start now
@@ -641,7 +641,8 @@ class TestProjectStructure(BaseExecutorDummyML):
         assert len(calls) == 1
         sql = calls[0][0][0].to_string()
         # getting next value, greater than max previous
-        assert ' t.a > 2' in sql
+        assert 't.a > 2' in sql
+        assert "t.b = 'b'" in sql
 
 class TestJobs(BaseExecutorDummyML):
 


### PR DESCRIPTION
## Description

Getting last value for query should keep other query conditons
```sql
select * from a=1 and b>last
``` 
will use this query (with a=1 filter)
```sql
select b where a=1 and b is not null order by b desc limit 1
```

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



