### PR TITLE
Cast `postgres` types to pandas compatible

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/utilities/sql.py
+++ b/mindsdb/api/mysql/mysql_proxy/utilities/sql.py
@@ -17,7 +17,7 @@ from mindsdb.utilities.json_encoder import CustomJSONEncoder
 
 
 def query_df_with_type_infer_fallback(query_str: str, dataframes: dict):
-    ''' Duckdb need to infer column types if column.dtype == object. By default it take 100 rows,
+    ''' Duckdb need to infer column types if column.dtype == object. By default it take 1000 rows,
         but that may be not sufficient for some cases. This func try to run query multiple times
         increasing butch size for type infer
 
@@ -40,7 +40,8 @@ def query_df_with_type_infer_fallback(query_str: str, dataframes: dict):
             result_df = con.execute(query_str).fetchdf()
         except InvalidInputException:
             pass
-        break
+        else:
+            break
     else:
         raise InvalidInputException
     description = con.description

--- a/mindsdb/integrations/handlers/postgres_handler/postgres_handler.py
+++ b/mindsdb/integrations/handlers/postgres_handler/postgres_handler.py
@@ -103,6 +103,15 @@ class PostgresHandler(DatabaseHandler):
     def _cast_dtypes(self, df: DataFrame, description: list) -> None:
         """ Cast df dtypes basing on postgres types
 
+            Note:
+                Date types casting is not provided because of there is no issues (so far).
+                By default pandas will cast postgres date types to:
+                 - date -> object
+                 - time -> object
+                 - timetz -> object
+                 - timestamp -> datetime64[ns]
+                 - timestamptz -> datetime64[ns, {tz}]
+
             Args:
                 df (DataFrame)
                 description (list): psycopg cursor description
@@ -145,10 +154,7 @@ class PostgresHandler(DatabaseHandler):
                     self._cast_dtypes(df, cur.description)
                     response = Response(
                         RESPONSE_TYPE.TABLE,
-                        DataFrame(
-                            result,
-                            columns=[x.name for x in cur.description], dtype={'amount': 'float64'}
-                        )
+                        df
                     )
                 connection.commit()
             except Exception as e:


### PR DESCRIPTION
## Description

Some postgres types cast to pandas 'object' by default. This may cause error in further processing in `duckdb`: it try infer pandas 'object' columns types using butch selection from df.  In most cases it works fine, but in some rare cases type may be inferred wrong.

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



