### PR TITLE
NPM Handler: Fix fetching non-existent column

### DIFF
--- a/mindsdb/integrations/handlers/npm_handler/api.py
+++ b/mindsdb/integrations/handlers/npm_handler/api.py
@@ -22,5 +22,5 @@ class NPM:
             curr_root = curr_root[p]
         req_cols = {}
         for col in cols:
-            req_cols[col] = curr_root[col] if col in curr_root else ""
+            req_cols[col] = curr_root[col] if col in curr_root else {}
         return req_cols


### PR DESCRIPTION
Fix fetching non-existent columns for the handler. New default value is now an empty `dict` instead of an empty string