### PR TITLE
Add INSERT SQL command for Knowledge Bases

### DIFF
--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -479,8 +479,10 @@ class KnowledgeBaseExecutor:
             )
 
     def plan_insert(self, query: Insert):
-        # TODO: to be implemented
-        raise NotImplementedError()
+        _ = SQLQuery(sql=query, session=self.session, execute=True)
+        return ExecuteAnswer(
+            answer_type=ANSWER_TYPE.OK
+        )
 
     def delete_from_kb(self, query: Delete):
         metadata = self._get_knowledge_base_metadata(query.table)


### PR DESCRIPTION
## Description

The SQL syntax is already implemented, just needed to fill in the `plan_insert` method.

Closes #8156 

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [x]   Test Location: `tests/unit/test_knowledge_base.py`
 - [x]   Verification Steps: Try out some INSERT commands locally

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



