### PR TITLE
Added the Unit Tests for the Anthropic Integration

### DIFF
--- a/tests/unit/ml_handlers/base_ml_test.py
+++ b/tests/unit/ml_handlers/base_ml_test.py
@@ -5,6 +5,7 @@ import pandas as pd
 from mindsdb_sql import parse_sql
 from ..executor_test_base import BaseExecutorTest
 
+
 class BaseMLTest(BaseExecutorTest):
     """
     Base test class for ML engines

--- a/tests/unit/ml_handlers/base_ml_test.py
+++ b/tests/unit/ml_handlers/base_ml_test.py
@@ -1,0 +1,31 @@
+import time
+import pandas as pd
+
+from mindsdb_sql import parse_sql
+from ..executor_test_base import BaseExecutorTest
+
+class BaseMLTest(BaseExecutorTest):
+    """
+    Base test class for ML engines
+    """
+    def wait_predictor(self, project, name, timeout=100):
+        """Wait for the predictor to be created, raising an exception if predictor creation fails or exceeds timeout"""
+        for attempt in range(timeout):
+            ret = self.run_sql(f"select * from {project}.models where name='{name}'")
+            if not ret.empty:
+                status = ret["STATUS"][0]
+                if status == "complete":
+                    return
+                elif status == "error":
+                    raise RuntimeError("Predictor failed", ret["ERROR"][0])
+            time.sleep(0.5)
+        raise RuntimeError("Predictor wasn't created")
+    
+    def run_sql(self, sql):
+        """Execute SQL and return a DataFrame, raising an AssertionError if an error occurs"""
+        ret = self.command_executor.execute_command(parse_sql(sql, dialect="mindsdb"))
+        assert ret.error_code is None, f"SQL execution failed with error: {ret.error_code}"
+        if ret.data is not None:
+            columns = [col.alias if col.alias else col.name for col in ret.columns]
+            return pd.DataFrame(ret.data, columns=columns)
+

--- a/tests/unit/ml_handlers/base_ml_test.py
+++ b/tests/unit/ml_handlers/base_ml_test.py
@@ -1,3 +1,4 @@
+import os
 import time
 import pandas as pd
 
@@ -8,7 +9,7 @@ class BaseMLTest(BaseExecutorTest):
     """
     Base test class for ML engines
     """
-    def wait_predictor(self, project, name, timeout=100):
+    def wait_predictor(self, project: str, name: str, timeout:int = 100) -> None:
         """Wait for the predictor to be created, raising an exception if predictor creation fails or exceeds timeout"""
         for attempt in range(timeout):
             ret = self.run_sql(f"select * from {project}.models where name='{name}'")
@@ -21,11 +22,21 @@ class BaseMLTest(BaseExecutorTest):
             time.sleep(0.5)
         raise RuntimeError("Predictor wasn't created")
     
-    def run_sql(self, sql):
+    def run_sql(self, sql: str) -> pd.DataFrame:
         """Execute SQL and return a DataFrame, raising an AssertionError if an error occurs"""
         ret = self.command_executor.execute_command(parse_sql(sql, dialect="mindsdb"))
         assert ret.error_code is None, f"SQL execution failed with error: {ret.error_code}"
         if ret.data is not None:
             columns = [col.alias if col.alias else col.name for col in ret.columns]
             return pd.DataFrame(ret.data, columns=columns)
+        
+
+class BaseMLAPITest(BaseMLTest):
+    """
+    Base test class for API-based ML engines
+    """
+    @staticmethod
+    def get_api_key(env_var: str):
+        """Retrieve API key from environment variables"""
+        return os.environ.get(env_var)
 

--- a/tests/unit/ml_handlers/base_ml_test.py
+++ b/tests/unit/ml_handlers/base_ml_test.py
@@ -9,7 +9,7 @@ class BaseMLTest(BaseExecutorTest):
     """
     Base test class for ML engines
     """
-    def wait_predictor(self, project: str, name: str, timeout:int = 100) -> None:
+    def wait_predictor(self, project: str, name: str, timeout: int = 100) -> None:
         """Wait for the predictor to be created, raising an exception if predictor creation fails or exceeds timeout"""
         for attempt in range(timeout):
             ret = self.run_sql(f"select * from {project}.models where name='{name}'")
@@ -21,7 +21,7 @@ class BaseMLTest(BaseExecutorTest):
                     raise RuntimeError("Predictor failed", ret["ERROR"][0])
             time.sleep(0.5)
         raise RuntimeError("Predictor wasn't created")
-    
+
     def run_sql(self, sql: str) -> pd.DataFrame:
         """Execute SQL and return a DataFrame, raising an AssertionError if an error occurs"""
         ret = self.command_executor.execute_command(parse_sql(sql, dialect="mindsdb"))
@@ -29,7 +29,7 @@ class BaseMLTest(BaseExecutorTest):
         if ret.data is not None:
             columns = [col.alias if col.alias else col.name for col in ret.columns]
             return pd.DataFrame(ret.data, columns=columns)
-        
+
 
 class BaseMLAPITest(BaseMLTest):
     """
@@ -39,4 +39,3 @@ class BaseMLAPITest(BaseMLTest):
     def get_api_key(env_var: str):
         """Retrieve API key from environment variables"""
         return os.environ.get(env_var)
-

--- a/tests/unit/ml_handlers/test_anthropic.py
+++ b/tests/unit/ml_handlers/test_anthropic.py
@@ -2,6 +2,7 @@ import os
 import pytest
 import pandas as pd
 from unittest.mock import patch
+
 from .base_ml_test import BaseMLAPITest
 
 

--- a/tests/unit/ml_handlers/test_anthropic.py
+++ b/tests/unit/ml_handlers/test_anthropic.py
@@ -21,7 +21,7 @@ class TestAnthropic(BaseMLAPITest):
             api_key = '{self.get_api_key('ANTHROPIC_API_KEY')}';
             """
         )
-    
+
     def test_invalid_model_parameter(self):
         """Test for invalid Anthropic model parameter"""
         self.run_sql(

--- a/tests/unit/ml_handlers/test_anthropic.py
+++ b/tests/unit/ml_handlers/test_anthropic.py
@@ -1,18 +1,15 @@
 import os
-import time
 import pytest
 import pandas as pd
 from unittest.mock import patch
-from mindsdb_sql import parse_sql
-from mindsdb.integrations.handlers.anthropic_handler.anthropic_handler import AnthropicHandler
-from ..executor_test_base import BaseExecutorTest
 from .base_ml_test import BaseMLAPITest
+
 
 @pytest.mark.skipif(os.environ.get('ANTHROPIC_API_KEY') is None, reason='Missing API key!')
 class TestAnthropic(BaseMLAPITest):
     """Test Class for Anthropic Integration Testing"""
 
-    def setup_method(self, method):
+    def setup_method(self):
         """Setup test environment, creating a project"""
         super().setup_method()
         self.run_sql("create database proj")

--- a/tests/unit/ml_handlers/test_anthropic.py
+++ b/tests/unit/ml_handlers/test_anthropic.py
@@ -54,7 +54,7 @@ class TestAnthropic(BaseExecutorTest):
             columns = [col.alias if col.alias else col.name for col in ret.columns]
             return pd.DataFrame(ret.data, columns=columns)
     
-    def test_invalid_anthropic_model_parameter(self):
+    def test_invalid_model_parameter(self):
         """Test for invalid Anthropic model parameter"""
         self.run_sql(
             f"""
@@ -70,7 +70,7 @@ class TestAnthropic(BaseExecutorTest):
         with pytest.raises(Exception):
             self.wait_predictor("proj", "test_anthropic_invalid_model")
 
-    def test_unknown_anthropic_model_argument(self):
+    def test_unknown_model_argument(self):
         """Test for unknown argument when creating a Anthropic model"""
         self.run_sql(
             f"""

--- a/tests/unit/ml_handlers/test_anthropic.py
+++ b/tests/unit/ml_handlers/test_anthropic.py
@@ -86,6 +86,28 @@ class TestAnthropic(BaseExecutorTest):
         with pytest.raises(Exception):
             self.wait_predictor("proj", "test_anthropic_unknown_argument")
 
+    def test_single_qa(self):
+        self.run_sql(
+            f"""
+            CREATE MODEL proj.test_anthropic_single_qa
+            PREDICT answer
+            USING
+                engine='anthropic',
+                column='question',
+                api_key='{self.get_api_key()}';
+            """
+        )
+        self.wait_predictor("proj", "test_anthropic_single_qa")
+
+        result_df = self.run_sql(
+            """
+            SELECT answer
+            FROM proj.test_anthropic_single_qa
+            WHERE question = 'What is the capital of Sweden?';
+        """
+        )
+        assert "stockholm" in result_df["answer"].iloc[0].lower()
+
     @patch("mindsdb.integrations.handlers.postgres_handler.Handler")
     def test_bulk_qa(self, mock_handler):
         df = pd.DataFrame.from_dict({"question": [

--- a/tests/unit/ml_handlers/test_anthropic.py
+++ b/tests/unit/ml_handlers/test_anthropic.py
@@ -87,6 +87,7 @@ class TestAnthropic(BaseExecutorTest):
             self.wait_predictor("proj", "test_anthropic_unknown_argument")
 
     def test_single_qa(self):
+        """Test for single question/answer pair"""
         self.run_sql(
             f"""
             CREATE MODEL proj.test_anthropic_single_qa
@@ -110,6 +111,7 @@ class TestAnthropic(BaseExecutorTest):
 
     @patch("mindsdb.integrations.handlers.postgres_handler.Handler")
     def test_bulk_qa(self, mock_handler):
+        """Test for bulk question/answer pairs"""
         df = pd.DataFrame.from_dict({"question": [
             "What is the capital of Sweden?",
             "What is the second planet of the solar system?"

--- a/tests/unit/ml_handlers/test_anthropic.py
+++ b/tests/unit/ml_handlers/test_anthropic.py
@@ -1,0 +1,87 @@
+import os
+import time
+import pytest
+import pandas as pd
+from unittest.mock import patch
+from mindsdb_sql import parse_sql
+from mindsdb.integrations.handlers.anthropic_handler.anthropic_handler import AnthropicHandler
+from ..executor_test_base import BaseExecutorTest
+
+
+@pytest.mark.skipif(os.environ.get('ANTHROPIC_API_KEY') is None, reason='Missing API key!')
+class TestAnthropic(BaseExecutorTest):
+    """Test Class for Anthropic Integration Testing"""
+
+    @staticmethod
+    def get_api_key():
+        """Retrieve Anthropic API key from environment variables"""
+        return os.environ.get("ANTHROPIC_API_KEY")
+
+    def setup_method(self, method):
+        """Setup test environment, creating a project"""
+        super().setup_method()
+        self.run_sql("create database proj")
+        self.run_sql(
+            f"""
+            CREATE ML_ENGINE anthropic
+            FROM anthropic
+            USING
+            api_key = '{self.get_api_key()}';
+            """
+        )
+
+    def wait_predictor(self, project, name, timeout=100):
+        """
+        Wait for the predictor to be created,
+        raising an exception if predictor creation fails or exceeds timeout
+        """
+        for attempt in range(timeout):
+            ret = self.run_sql(f"select * from {project}.models where name='{name}'")
+            if not ret.empty:
+                status = ret["STATUS"][0]
+                if status == "complete":
+                    return
+                elif status == "error":
+                    raise RuntimeError("Predictor failed", ret["ERROR"][0])
+            time.sleep(0.5)
+        raise RuntimeError("Predictor wasn't created")
+    
+    def run_sql(self, sql):
+        """Execute SQL and return a DataFrame, raising an AssertionError if an error occurs"""
+        ret = self.command_executor.execute_command(parse_sql(sql, dialect="mindsdb"))
+        assert ret.error_code is None, f"SQL execution failed with error: {ret.error_code}"
+        if ret.data is not None:
+            columns = [col.alias if col.alias else col.name for col in ret.columns]
+            return pd.DataFrame(ret.data, columns=columns)
+    
+    def test_invalid_anthropic_model_parameter(self):
+        """Test for invalid Anthropic model parameter"""
+        self.run_sql(
+            f"""
+            CREATE MODEL proj.test_anthropic_invalid_model
+            PREDICT answer
+            USING
+                engine='anthropic',
+                column='question',
+                model='this-claude-does-not-exist',
+                api_key='{self.get_api_key()}';
+            """
+        )
+        with pytest.raises(Exception):
+            self.wait_predictor("proj", "test_anthropic_invalid_model")
+
+    def test_unknown_anthropic_model_argument(self):
+        """Test for unknown argument when creating a Anthropic model"""
+        self.run_sql(
+            f"""
+            CREATE MODEL proj.test_anthropic_unknown_argument
+            PREDICT answer
+            USING
+                engine='anthropic',
+                column='question',
+                api_key='{self.get_api_key()}',
+                evidently_wrong_argument='wrong value';
+            """
+        )
+        with pytest.raises(Exception):
+            self.wait_predictor("proj", "test_anthropic_unknown_argument")


### PR DESCRIPTION
## Description

This PR adds the unit tests for the Anthropic integration. It also adds `BaseMLTest` and `BaseMLAPITest` classes, which contains some of the common functionality used throughout the tests for ML Engines (and API-based ML engines).

Fixes https://github.com/mindsdb/mindsdb/issues/8261

## Type of change

- [X] ⚡ Unit tests

## Verification Process

To ensure the changes are working as expected:

 - [X]   Test Location: pytest tests/unit/ml_handlers/test_anthropic.py

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

Test report (summary),
![image](https://github.com/mindsdb/mindsdb/assets/49385643/d833b900-b119-491f-90e6-d784b8e04006)

One unit test is failing due to a limitation in the handler; unknown model arguments are not handled.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [X] Relevant unit and integration tests are updated or added.



