### PR TITLE
add short cut for installing handler requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ setup_dev:
 	pip install -r requirements_dev.txt
 	pre-commit install
 
-install_handler:  setup_dev
+install_handler:
 	pip install -r mindsdb/integrations/handlers/$(HANDLER_NAME)_handler/requirements.txt
 
 precommit:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
 setup_dev:
+	pip install -e .
 	pip install -r requirements_dev.txt
 	pre-commit install
 
-precommit: setup_dev
-	pre-commit run --files $$(shell git diff --cached --name-only)
+install_handler:
+	pip install -r mindsdb/integrations/handlers/$(HANDLER_NAME)_handler/requirements.txt
 
-.PHONY: setup_dev  precommit
+precommit:
+	pre-commit install
+	pre-commit run --files $$(git diff --cached --name-only)
+
+.PHONY: setup_dev precommit install_handler

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ setup_dev:
 	pip install -r requirements_dev.txt
 	pre-commit install
 
-install_handler:
+install_handler:  setup_dev
 	pip install -r mindsdb/integrations/handlers/$(HANDLER_NAME)_handler/requirements.txt
 
 precommit:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-setup_dev:
+install_mindsdb:
 	pip install -e .
 	pip install -r requirements_dev.txt
 	pre-commit install
@@ -10,4 +10,7 @@ precommit:
 	pre-commit install
 	pre-commit run --files $$(git diff --cached --name-only)
 
-.PHONY: setup_dev precommit install_handler
+run_mindsdb:
+	python -m mindsdb
+
+.PHONY: install_mindsdb precommit install_handler  run_mindsdb


### PR DESCRIPTION
## Description

update Makefile to shortcut handler requirements install


**Shortcuts:**

Install mindsdb locally, dev requirements and install pre-commit hooks:

`make install_mindsdb` 

Run precommit on local staged changes:

`make precommit`

Install requirements for a specific handler:

`make install_handler  HANDLER_NAME=writer`

run mindsdb locally with python:

`make run_mindsdb`


## Type of change

(Please delete options that are not relevant)


- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [x]   Test Location: locally



## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



