### PR TITLE
[ENH] OpenAI: add support for dall-e-3

### DIFF
--- a/mindsdb/integrations/handlers/openai_handler/constants.py
+++ b/mindsdb/integrations/handlers/openai_handler/constants.py
@@ -28,4 +28,4 @@ EMBEDDING_MODELS = (
     + tuple(f'code-search-{model}-code-001' for model in COMPLETION_LEGACY_BASE_MODELS)
 )
 
-IMAGE_MODELS = ('dall-e-3',)
+IMAGE_MODELS = ('dall-e-2', 'dall-e-3')

--- a/mindsdb/integrations/handlers/openai_handler/openai_handler.py
+++ b/mindsdb/integrations/handlers/openai_handler/openai_handler.py
@@ -2,7 +2,6 @@ import os
 import math
 import json
 import shutil
-import binascii
 import tempfile
 import datetime
 import textwrap
@@ -24,6 +23,7 @@ from mindsdb.integrations.handlers.openai_handler.helpers import (
 )
 from mindsdb.integrations.handlers.openai_handler.constants import (
     CHAT_MODELS,
+    IMAGE_MODELS,
     FINETUNING_LEGACY_MODELS,
     OPENAI_API_BASE,
 )
@@ -201,7 +201,7 @@ class OpenAIHandler(BaseMLEngine):
             api_args = {
                 k: v for k, v in api_args.items() if v is not None
             }  # filter out non-specified api args
-            model_name = 'image'
+            model_name = args.get('model_name', 'dall-e-2')
 
             if args.get('question_column'):
                 prompts = list(df[args['question_column']].apply(lambda x: str(x)))
@@ -388,7 +388,7 @@ class OpenAIHandler(BaseMLEngine):
                 'api_key': api_key,
                 'organization': args.get('api_organization'),
             }
-            if model_name == 'image':
+            if model_name in IMAGE_MODELS:
                 return _submit_image_completion(kwargs, prompts, api_args)
             elif model_name == 'embedding':
                 return _submit_embedding_completion(kwargs, prompts, api_args)
@@ -534,7 +534,6 @@ class OpenAIHandler(BaseMLEngine):
                     for c in comp
                 ]
 
-            kwargs.pop('model')
             completions = [
                 openai.Image.create(**{'prompt': p, **kwargs, **api_args})['data']
                 for p in prompts

--- a/mindsdb/integrations/handlers/openai_handler/openai_handler.py
+++ b/mindsdb/integrations/handlers/openai_handler/openai_handler.py
@@ -38,6 +38,7 @@ class OpenAIHandler(BaseMLEngine):
         super().__init__(*args, **kwargs)
         self.generative = True
         self.default_model = 'gpt-3.5-turbo'
+        self.default_image_model = 'dall-e-2'
         self.default_mode = (
             'default'  # can also be 'conversational' or 'conversational-full'
         )
@@ -134,17 +135,20 @@ class OpenAIHandler(BaseMLEngine):
         api_key = get_api_key('openai', args, self.engine_storage)
         available_models = get_available_models(api_key)
 
-        if not args.get('model_name'):
-            args['model_name'] = self.default_model
-        elif args['model_name'] not in available_models:
-            raise Exception(f"Invalid model name. Please use one of {available_models}")
-
         if not args.get('mode'):
             args['mode'] = self.default_mode
         elif args['mode'] not in self.supported_modes:
             raise Exception(
                 f"Invalid operation mode. Please use one of {self.supported_modes}"
             )
+
+        if not args.get('model_name'):
+            if args['mode'] == 'image':
+                args['model_name'] = self.default_image_model
+            else:
+                args['model_name'] = self.default_model
+        elif args['model_name'] not in available_models:
+            raise Exception(f"Invalid model name. Please use one of {available_models}")
 
         self.model_storage.json_set('args', args)
 


### PR DESCRIPTION
## Description

This PR adds support for DallE 3.

The `model_name` should now be passed when setting `mode=image`. Otherwise, `dall-e-2` will be used by default.

Example:


```sql
CREATE MODEL mindsdb.dalle
PREDICT img_url
USING
engine = 'openai',
mode = 'image',
model_name = 'dall-e-3',
prompt_template = 'Make a photorealistic image. Here is the description: {{description}}, 4k, digital painting';

DESCRIBE mindsdb.dalle;

SELECT description, img_url
FROM mindsdb.dalle
WHERE 
description = 'a house by the lakeside';
```

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)
- [x] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



