### PR TITLE
Fix for Selecting Emails Within the Last 24 Hrs

### DIFF
--- a/mindsdb/integrations/handlers/email_handler/email_helpers.py
+++ b/mindsdb/integrations/handlers/email_handler/email_helpers.py
@@ -52,9 +52,7 @@ class EmailClient:
 
         if until_date is not None:
             until_date_str = until_date.strftime("%d-%b-%Y")
-        else:
-            until_date_str = datetime.today().strftime("%d-%b-%Y")
-        query_parts.append(f'(BEFORE "{until_date_str}")')
+            query_parts.append(f'(BEFORE "{until_date_str}")')
 
         if since_emailid is not None:
             query_parts.append(f'(UID {since_emailid}:*)')


### PR DESCRIPTION
## Description

This PR updates the Email integration to allow selecting emails within the last 24 hours.

Fixes https://github.com/mindsdb/mindsdb/issues/8282

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [X]   Test Location: Ran MindsDB locally and executed a query against the Email integtation

## Additional Media:

Now, the integration emails within the last 24 hours as well,

![image](https://github.com/mindsdb/mindsdb/assets/49385643/16da3ff4-2f97-43f8-8e8f-a59c271a3839)


## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.