### PR TITLE
Fix Last keyword: expect different types in same dataframe column

### DIFF
--- a/mindsdb/interfaces/query_context/context_controller.py
+++ b/mindsdb/interfaces/query_context/context_controller.py
@@ -81,7 +81,7 @@ class QueryContextController:
         if len(data) == 0:
             return
 
-        max_vals = pd.DataFrame(data).max().to_dict()
+        df = pd.DataFrame(data)
         values = {}
         # get max values
         for info in l_query.get_last_columns():
@@ -89,10 +89,21 @@ class QueryContextController:
             if target_idx is not None:
                 # get by index
                 col_name = columns_info[target_idx]['name']
-                value = max_vals.get(col_name)
             else:
+                col_name = info['column_name']
                 # get by name
-                value = max_vals.get(info['column_name'])
+            if col_name not in df:
+                continue
+
+            column_values = df[col_name]
+            try:
+                value = max(column_values)
+            except (TypeError, ValueError):
+                try:
+                    # try to convert to str
+                    value = max(map(str, column_values))
+                except (TypeError, ValueError):
+                    continue
 
             if value is not None:
                 values[info['table_name']] = {info['column_name']: value}

--- a/mindsdb/interfaces/query_context/context_controller.py
+++ b/mindsdb/interfaces/query_context/context_controller.py
@@ -100,10 +100,14 @@ class QueryContextController:
                 value = max(column_values)
             except (TypeError, ValueError):
                 try:
-                    # try to convert to str
-                    value = max(map(str, column_values))
+                    # try to convert to float
+                    value = max(map(float, column_values))
                 except (TypeError, ValueError):
-                    continue
+                    try:
+                        # try to convert to str
+                        value = max(map(str, column_values))
+                    except (TypeError, ValueError):
+                        continue
 
             if value is not None:
                 values[info['table_name']] = {info['column_name']: value}

--- a/mindsdb/interfaces/query_context/context_controller.py
+++ b/mindsdb/interfaces/query_context/context_controller.py
@@ -95,7 +95,7 @@ class QueryContextController:
             if col_name not in df:
                 continue
 
-            column_values = df[col_name]
+            column_values = df[col_name].dropna()
             try:
                 value = max(column_values)
             except (TypeError, ValueError):


### PR DESCRIPTION
## Description

If result dataframe from data (or api) handler contents different types in the same column as in example, or contents null values with string values:
```
df= pd.DataFrame([[1],['0'] ])

df= pd.DataFrame([[None],['0'] ])
```

finding the current last value lead to error:
```
TypeError: '>=' not supported between instances of 'str' and 'float'
```

This pr fixes it.

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



