### PR TITLE
Fix versions for old BYOM engines

### DIFF
--- a/mindsdb/integrations/handlers/byom_handler/byom_handler.py
+++ b/mindsdb/integrations/handlers/byom_handler/byom_handler.py
@@ -90,7 +90,11 @@ class BYOMHandler(BaseMLEngine):
             engine_version = BYOMHandler.normalize_engine_version(engine_version)
         else:
             connection_args = kwargs['handler_storage'].get_connection_args()
-            engine_version = max([int(x) for x in connection_args['versions'].keys()])
+            versions = connection_args.get('versions')
+            if isinstance(versions, dict):
+                engine_version = max([int(x) for x in versions.keys()])
+            else:
+                engine_version = 1
             using_args['engine_version'] = engine_version
 
     def get_model_engine_version(self) -> int:


### PR DESCRIPTION
## Description

Old BYOM engines dont have 'versions' key in connection args. Set for them 1 as engine version.

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



