### PR TITLE
Fix for Broken PGVector Type Hint

### DIFF
--- a/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
+++ b/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
@@ -1,10 +1,10 @@
-from collections import OrderedDict, defaultdict
-from typing import List, Optional
+from collections import OrderedDict
+from typing import List
 
 import numpy as np
 import pandas as pd
 import psycopg
-from mindsdb_sql import ASTNode, CreateTable, Insert, Select
+from mindsdb_sql import ASTNode
 from pgvector.psycopg import register_vector
 
 from mindsdb.integrations.handlers.postgres_handler.postgres_handler import (
@@ -16,8 +16,6 @@ from mindsdb.integrations.libs.response import HandlerResponse
 from mindsdb.integrations.libs.response import HandlerResponse as Response
 from mindsdb.integrations.libs.vectordatabase_handler import (
     FilterCondition,
-    FilterOperator,
-    TableField,
     VectorStoreHandler,
 )
 from mindsdb.utilities import log

--- a/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
+++ b/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
@@ -33,7 +33,7 @@ class PgVectorHandler(PostgresHandler, VectorStoreHandler):
         self.connect()
 
     @profiler.profile()
-    def connect(self):
+    def connect(self) -> psycopg.connection:
         """
         Handles the connection to a PostgreSQL database instance.
         """

--- a/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
+++ b/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import List
+from typing import List, Union
 
 import pandas as pd
 import psycopg
@@ -57,7 +57,7 @@ class PgVectorHandler(PostgresHandler, VectorStoreHandler):
         return self.connection
 
     @staticmethod
-    def _translate_conditions(conditions: List[FilterCondition]) -> dict | None:
+    def _translate_conditions(conditions: List[FilterCondition]) -> Union[dict, None]:
         """
         Translate filter conditions to a dictionary
         """

--- a/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
+++ b/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 from typing import List
 
-import numpy as np
 import pandas as pd
 import psycopg
 from mindsdb_sql import ASTNode


### PR DESCRIPTION
## Description

This PR fixes a broken type hint that had been used for the `_translate_conditions()` method of the PGVector integration. A few other cosmetic changes such as removing unnecessary imports, adding type hints for other methods etc. have been made.

Fixes https://github.com/mindsdb/mindsdb/issues/8325

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [X]   Test Location: Ran MindsDB locally and ensured that the PGVector integration was being imported successfully

## Additional Media:

![image](https://github.com/mindsdb/mindsdb/assets/49385643/803227dd-0461-48a8-bb5b-7aec0a77dfa4)

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



