### PR TITLE
Fix for query to different versions of the same model

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
+++ b/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
@@ -65,10 +65,7 @@ from mindsdb_sql.planner import query_planner
 from mindsdb_sql.planner.utils import query_traversal
 
 from mindsdb.api.mysql.mysql_proxy.utilities.sql import query_df, query_df_with_type_infer_fallback
-from mindsdb.interfaces.model.functions import (
-    get_model_records,
-    get_predictor_project
-)
+from mindsdb.interfaces.model.functions import get_model_record
 from mindsdb.api.mysql.mysql_proxy.utilities import (
     ErKeyColumnDoesNotExist,
     ErNotSupportedYet,
@@ -466,57 +463,65 @@ class SQLQuery():
         databases = self.session.database_controller.get_list()
 
         predictor_metadata = []
-        predictors_records = get_model_records()
 
         query_tables = []
 
         def get_all_query_tables(node, is_table, **kwargs):
             if is_table and isinstance(node, Identifier):
                 table_name = node.parts[-1]
+                table_version = None
+                project_name = self.session.database
                 if table_name.isdigit():
                     # is predictor version
+                    table_version = int(table_name)
                     table_name = node.parts[-2]
-                query_tables.append(table_name)
+                if table_name != node.parts[0]:
+                    project_name = node.parts[0]
+                query_tables.append((table_name, table_version, project_name))
 
         query_traversal(self.query, get_all_query_tables)
 
-        for predictor_record in predictors_records:
-            model_name = predictor_record.name
+        for table_name, table_version, project_name in query_tables:
+            args = {
+                'name': table_name,
+                'project_name': project_name
+            }
+            if table_version is not None:
+                args['active'] = None
+                args['version'] = table_version
 
-            if model_name not in query_tables:
+            model_record = get_model_record(**args)
+            if model_record is None:
                 continue
 
-            project_record = get_predictor_project(predictor_record)
-            if project_record is None:
+            if isinstance(model_record.data, dict) is False or 'error' in model_record.data:
                 continue
-            project_name = project_record.name
 
-            if isinstance(predictor_record.data, dict) and 'error' not in predictor_record.data:
-                ts_settings = predictor_record.learn_args.get('timeseries_settings', {})
-                predictor = {
-                    'name': model_name,
-                    'integration_name': project_name,   # integration_name,
-                    'timeseries': False,
-                    'id': predictor_record.id
-                }
-                if ts_settings.get('is_timeseries') is True:
-                    window = ts_settings.get('window')
-                    order_by = ts_settings.get('order_by')
-                    if isinstance(order_by, list):
-                        order_by = order_by[0]
-                    group_by = ts_settings.get('group_by')
-                    if isinstance(group_by, list) is False and group_by is not None:
-                        group_by = [group_by]
-                    predictor.update({
-                        'timeseries': True,
-                        'window': window,
-                        'horizon': ts_settings.get('horizon'),
-                        'order_by_column': order_by,
-                        'group_by_columns': group_by
-                    })
-                predictor_metadata.append(predictor)
+            ts_settings = model_record.learn_args.get('timeseries_settings', {})
+            predictor = {
+                'name': table_name,
+                'integration_name': project_name,   # integration_name,
+                'timeseries': False,
+                'id': model_record.id
+            }
+            if ts_settings.get('is_timeseries') is True:
+                window = ts_settings.get('window')
+                order_by = ts_settings.get('order_by')
+                if isinstance(order_by, list):
+                    order_by = order_by[0]
+                group_by = ts_settings.get('group_by')
+                if isinstance(group_by, list) is False and group_by is not None:
+                    group_by = [group_by]
+                predictor.update({
+                    'timeseries': True,
+                    'window': window,
+                    'horizon': ts_settings.get('horizon'),
+                    'order_by_column': order_by,
+                    'group_by_columns': group_by
+                })
+            predictor_metadata.append(predictor)
 
-                self.model_types.update(predictor_record.data.get('dtypes', {}))
+            self.model_types.update(model_record.data.get('dtypes', {}))
 
         database = None if self.session.database == '' else self.session.database.lower()
 


### PR DESCRIPTION
## Description

Models list at start of query planning was get for active model versions. Therefore results in cache was saved for wrong model version.

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



