### PR TITLE
Accept model filters in query

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
+++ b/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
@@ -36,6 +36,7 @@ from mindsdb_sql.parser.ast import (
     Parameter,
     Tuple,
 )
+from mindsdb_sql.planner.step_result import Result
 from mindsdb_sql.planner.steps import (
     ApplyTimeseriesPredictorStep,
     ApplyPredictorRowStep,
@@ -926,9 +927,17 @@ class SQLQuery():
                 where_data = data.get_records()
 
                 # add constants from where
+                row_dict = {}
                 if step.row_dict is not None:
+                    for k, v in step.row_dict.items():
+                        if isinstance(v, Result):
+                            prev_result = steps_data[v.step_num]
+                            # TODO we await only one value: model.param = (subselect)
+                            v = prev_result.get_records_raw()[0][0]
+                        row_dict[k] = v
+
                     for record in where_data:
-                        record.update(step.row_dict)
+                        record.update(row_dict)
 
                 predictor_metadata = {}
                 for pm in self.predictor_metadata:

--- a/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
+++ b/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
@@ -925,6 +925,11 @@ class SQLQuery():
 
                 where_data = data.get_records()
 
+                # add constants from where
+                if step.row_dict is not None:
+                    for record in where_data:
+                        record.update(step.row_dict)
+
                 predictor_metadata = {}
                 for pm in self.predictor_metadata:
                     if pm['name'] == predictor_name and pm['integration_name'].lower() == project_name:

--- a/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
+++ b/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
@@ -1143,10 +1143,10 @@ class SQLQuery():
 
                 records = step_data.get_records_raw()
 
-                if isinstance(step.offset, Constant) and isinstance(step.offset.value, int):
-                    records = records[step.offset.value:]
-                if isinstance(step.limit, Constant) and isinstance(step.limit.value, int):
-                    records = records[:step.limit.value]
+                if isinstance(step.offset, int):
+                    records = records[step.offset:]
+                if isinstance(step.limit, int):
+                    records = records[:step.limit]
 
                 for record in records:
                     step_data2.add_record_raw(record)

--- a/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
+++ b/mindsdb/api/mysql/mysql_proxy/classes/sql_query.py
@@ -1077,6 +1077,9 @@ class SQLQuery():
                 names_a.update(names_b)
                 data = ResultSet().from_df_cols(resp_df, col_names=names_a)
 
+                for col in data.find_columns('__mindsdb_row_id'):
+                    data.del_column(col)
+
             except Exception as e:
                 raise SqlApiUnknownError(f'error in join step: {e}') from e
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -18,7 +18,7 @@ redis >=5.0.0, < 6.0.0
 walrus==0.9.3
 flask-compress >= 1.0.0
 appdirs >= 1.0.0
-mindsdb-sql ~= 0.7.4
+mindsdb-sql ~= 0.8.0
 mindsdb-evaluator >= 0.0.7, < 0.1.0
 checksumdir >= 1.2.0
 duckdb == 0.9.1


### PR DESCRIPTION
## Changes

1. Accept row_dict param in ApplyPredictorStep

Depends on https://github.com/mindsdb/mindsdb_sql/pull/327

Example of supported query:
```sql
SELECT location
FROM (
   select location, neighborhood 
   from example_db.demo_data.home_rentals as t LIMIT 10
   ) as t
JOIN mindsdb.home_rentals_model as m
where m.days_on_market= 1
;
```

2. Support subselect for row_dict param in ApplyPredictorStep
Example query
```sql
SELECT m2.*
FROM example_db.demo_data.home_rentals as t 
JOIN mindsdb.home_rentals_model as m
JOIN mindsdb.home_rentals_model as m2
where  m2.days_on_market=(select days_on_market from example_db.demo_data.home_rentals limit 1)
LIMIT 10
```

3. Support 'model join model'

Example query
```sql

SELECT m2.*
FROM example_db.demo_data.home_rentals as t 
JOIN mindsdb.home_rentals_model as m
JOIN mindsdb.home_rentals_model as m2
where m.days_on_market= 1 and m2.days_on_market=2
LIMIT 10
```



Fixes #issue_number

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



