### PR TITLE
Create gmail db via sql

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/executor/executor_commands.py
+++ b/mindsdb/api/mysql/mysql_proxy/executor/executor_commands.py
@@ -1020,6 +1020,7 @@ class ExecuteCommands:
             connection_args = {}
         status = HandlerStatusResponse(success=False)
 
+        storage = None
         try:
             handlers_meta = (
                 self.session.integration_controller.get_handlers_import_status()
@@ -1067,6 +1068,8 @@ class ExecuteCommands:
                 handler_type=engine, connection_data=connection_args
             )
             status = handler.check_connection()
+            if status.copy_storage:
+                storage = handler.handler_storage.export_files()
         except Exception as e:
             status.error_message = str(e)
 
@@ -1078,6 +1081,9 @@ class ExecuteCommands:
             raise EntityExistsError('Database already exists', name)
 
         self.session.integration_controller.add(name, engine, connection_args)
+        if storage:
+            handler = self.session.integration_controller.get_handler(name)
+            handler.handler_storage.import_files(storage)
 
     def answer_create_ml_engine(self, statement: ASTNode):
         name = statement.name.parts[-1]

--- a/mindsdb/integrations/handlers/gmail_handler/gmail_handler.py
+++ b/mindsdb/integrations/handlers/gmail_handler/gmail_handler.py
@@ -392,6 +392,7 @@ class GmailHandler(APIHandler):
 
             if result and result.get('emailAddress', None) is not None:
                 response.success = True
+                response.copy_storage = True
         except AuthException as error:
             response.error_message = str(error)
             response.redirect_url = error.auth_url
@@ -583,5 +584,10 @@ connection_args = OrderedDict(
         'type': ARG_TYPE.PATH,
         'description': 'Service Account Keys',
         'label': 'Upload Service Account Keys',
+    },
+    code={
+        'type': ARG_TYPE.STR,
+        'description': 'code after authorisation',
+        'label': 'code after authorisation',
     },
 )

--- a/mindsdb/integrations/libs/response.py
+++ b/mindsdb/integrations/libs/response.py
@@ -46,10 +46,15 @@ class HandlerResponse:
             )
 
 class HandlerStatusResponse:
-    def __init__(self, success: bool = True, error_message: str = None, redirect_url: str = None) -> None:
+    def __init__(self, success: bool = True,
+                 error_message: str = None,
+                 redirect_url: str = None,
+                 copy_storage: str = None
+    ) -> None:
         self.success = success
         self.error_message = error_message
         self.redirect_url = redirect_url
+        self.copy_storage = copy_storage
 
     def to_json(self):
         data = {"success": self.success, "error": self.error_message}


### PR DESCRIPTION
Fixes for add gmail db via sql:
- added code param
- copy storage from test database to real

## Description

Please include a summary of the change and the issue it solves. 

Fixes #8097

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

1. Run this command with credentials_file 
```sql 
CREATE DATABASE gm
WITH ENGINE = 'gmail',
parameters = {
    "credentials_file": "/tmp/client_secret_gmail.json"
}; 
```

2. It will return url to authorize. Go there

3. After authorization it should show page with code variable

4. Add code to query and run it again
```sql
CREATE DATABASE gm
WITH ENGINE = 'gmail',
parameters = {
    "credentials_file": "/tmp/client_secret_gmail.json",
    "code": "<put code here>"
}; 
```

5. Check database table:
```sql
select * from gm.emails limit 10;
```


To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



