### PR TITLE
[fix] Wrong BYOM mode if `type` was in connection arguments

### DIFF
--- a/mindsdb/integrations/handlers/byom_handler/byom_handler.py
+++ b/mindsdb/integrations/handlers/byom_handler/byom_handler.py
@@ -283,9 +283,9 @@ class BYOMHandler(BaseMLEngine):
         code_path = Path(connection_args['code'])
         requirements_path = Path(connection_args['modules'])
 
-        connection_args = self.engine_storage.get_connection_args()
-        if isinstance(connection_args, dict) is False or 'handler_version' not in connection_args:
-            connection_args = {
+        engine_connection_args = self.engine_storage.get_connection_args()
+        if isinstance(engine_connection_args, dict) is False or 'handler_version' not in engine_connection_args:
+            engine_connection_args = {
                 'handler_version': __version__,
                 'versions': {
                     '1': {
@@ -295,9 +295,9 @@ class BYOMHandler(BaseMLEngine):
                     }
                 }
             }
-        new_version = str(max([int(x) for x in connection_args['versions'].keys()]) + 1)
+        new_version = str(max([int(x) for x in engine_connection_args['versions'].keys()]) + 1)
 
-        connection_args['versions'][new_version] = {
+        engine_connection_args['versions'][new_version] = {
             'code': code_path.name,
             'requirements': requirements_path.name,
             'type': self.normalize_byom_type(
@@ -316,7 +316,7 @@ class BYOMHandler(BaseMLEngine):
         )
         self.engine_storage.fileStorage.push()
 
-        self.engine_storage.update_connection_args(connection_args)
+        self.engine_storage.update_connection_args(engine_connection_args)
 
         model_proxy = self._get_model_proxy(new_version)
         try:


### PR DESCRIPTION
## Description

Set correct BYOM mode it `type` initially was in connection arguments

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



