### PR TITLE
Create Llama Index Documents Correctly Using DFReader

### DIFF
--- a/mindsdb/integrations/handlers/llama_index_handler/llama_index_handler.py
+++ b/mindsdb/integrations/handlers/llama_index_handler/llama_index_handler.py
@@ -64,7 +64,7 @@ class LlamaIndexHandler(BaseMLEngine):
 
         if args['using']['reader'] == 'DFReader':
             dstrs = df.apply(lambda x: ', '.join([f'{col}: {str(entry)}' for col, entry in zip(df.columns, x)]), axis=1)
-            reader = list(map(lambda x: Document(x), dstrs.tolist()))
+            reader = list(map(lambda x: Document(text=x), dstrs.tolist()))
 
         elif args['using']['reader'] == 'SimpleWebPageReader':
             if 'source_url_link' not in args['using']:


### PR DESCRIPTION
## Description

Currently we pass a string as a positional argument to the `Document` class, [but it should be](https://docs.llamaindex.ai/en/stable/module_guides/loading/documents_and_nodes/root.html#documents) `Document(text=...)` instead.

## Type of change


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)