### PR TITLE
Fix Knowledge Base Insert

### DIFF
--- a/mindsdb/integrations/libs/vectordatabase_handler.py
+++ b/mindsdb/integrations/libs/vectordatabase_handler.py
@@ -329,7 +329,9 @@ class VectorStoreHandler(BaseHandler):
             df[id_col] = df[content_col].apply(gen_hash)
         else:
             # generate for empty
-            df.loc[df[id_col], id_col] = df[content_col].apply(gen_hash)
+            for i in range(len(df)):
+                if pd.isna(df.loc[i, id_col]):
+                    df.loc[i, id_col] = gen_hash(df.loc[i, content_col])
 
         # remove duplicated ids
         df = df.drop_duplicates([TableField.ID.value])

--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -123,11 +123,10 @@ class KnowledgeBaseTable:
 
         # add embeddings
         df_emb = self._df_to_embeddings(df)
-        df = pd.concat([df, df_emb], axis=1)
 
         # send to vector db
         db_handler = self._get_vector_db()
-        db_handler.do_upsert(self._kb.vector_database_table, df)
+        db_handler.do_upsert(self._kb.vector_database_table, df_emb)
 
     def _replace_query_content(self, node, **kwargs):
         if isinstance(node, BinaryOperation):


### PR DESCRIPTION
## Description

When inserting values into a knowledge base (e.g. [this demo](https://pastebin.com/gTCypTW9)), it currently fails with a `"None of [Index([('i', 'd'), ('i', 'd')], dtype='object')] are in the [index]"` error due to how we are inserting. Additionally, the way we fill in missing IDs when the ID column is present causes errors as well.

This PR fixes both of those issues.

Fixes #issue_number

## Type of change


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [x]   Verification Steps: Create and insert into a knowledge base locally

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



