### PR TITLE
Don't Concat Embeddings DF Since it Adds Duplicate Cols

### DIFF
--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -124,11 +124,10 @@ class KnowledgeBaseTable:
 
         # add embeddings
         df_emb = self._df_to_embeddings(df)
-        df = pd.concat([df, df_emb], axis=1)
 
         # send to vector db
         db_handler = self._get_vector_db()
-        db_handler.do_upsert(self._kb.vector_database_table, df)
+        db_handler.do_upsert(self._kb.vector_database_table, df_emb)
 
     def _replace_query_content(self, node, **kwargs):
         if isinstance(node, BinaryOperation):


### PR DESCRIPTION
## Description

The dataframe used already will have `id`, `content`, and `embeddings`, so concatenating the two dataframes leads to duplicate columns and errors.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

 - [ ]   Test Location: Specify the URL or path for testing.
 - [x]   Verification Steps: Create and use knowledge bases locally

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



