### PR TITLE
Minor docs update for ZSH

### DIFF
--- a/docs/setup/self-hosted/pip/macos.mdx
+++ b/docs/setup/self-hosted/pip/macos.mdx
@@ -96,7 +96,7 @@ The dependencies for many of the data or ML integrations are not installed by de
 If you want to use a data or ML integration whose dependencies are not available by default, install it by running this command:
 
 ```
-pip install mindsdb[handler_name]
+pip install 'mindsdb[handler_name]'
 ```
 
 <Tip>

--- a/docs/setup/self-hosted/pip/source.mdx
+++ b/docs/setup/self-hosted/pip/source.mdx
@@ -74,7 +74,7 @@ The dependencies for many of the data or ML integrations are not installed by de
 If you want to use a data or ML integration whose dependencies are not available by default, install it by running this command:
 
 ```
-pip install .[handler_name]
+pip install '.[handler_name]'
 ```
 
 <Tip>


### PR DESCRIPTION
Users have issues installing handlers on macOS because by default it uses zsh which can't handle the pip syntax for extras.
Putting the package name in quotes fixes the issue