### PR TITLE
[fix] Update lightwood handler requirements

### DIFF
--- a/mindsdb/integrations/handlers/lightwood_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/lightwood_handler/requirements.txt
@@ -1,6 +1,1 @@
-lightwood==23.11.1.0
-lightwood[audio]==23.11.1.0
-lightwood[extra_ts]==23.11.1.0
-lightwood[extra]==23.11.1.0
-lightwood[image]==23.11.1.0
-lightwood[xai]==23.11.1.0
+lightwood==23.12.4.0

--- a/mindsdb/integrations/handlers/lightwood_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/lightwood_handler/requirements.txt
@@ -1,1 +1,1 @@
-lightwood==23.12.4.0
+lightwood==23.11.1.0


### PR DESCRIPTION
## Description

This avoids packages like `qiskit` blocking the handler installation in macOS. This one in particular and `image` are experimental and not meant to be supported in MindsDB (yet). There are others, like `extra` and `extra_ts` which we may want to offer in the future.

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)



