### PR TITLE
Feat add new handler to update Shopify orders

### DIFF
--- a/mindsdb/integrations/handlers/shopify_handler/README.md
+++ b/mindsdb/integrations/handlers/shopify_handler/README.md
@@ -72,6 +72,7 @@ Watch this video on creating a Shopify access token [here](https://www.youtube.c
     - [x] Support WHERE
     - [x] Support ORDER BY
     - [x] Support column selection
+  - [x] Support UPDATE
   - [x] Support DELETE
 - [x] Shopify Customer Reviews Table for a given Store
   - [x] Support SELECT
@@ -107,7 +108,8 @@ Watch this video on creating a Shopify access token [here](https://www.youtube.c
 ## TODO
 
 - [ ] Support UPDATE and DELETE for Customers table
-- [ ] Support INSERT, UPDATE and DELETE for Product and Orders tables
+- [ ] Support INSERT, UPDATE and DELETE for Product
+- [ ] Support INSERT For Orders tables
 - [ ] Shopify Payments table
 - [ ] Shopify Inventory table
 - [ ] Shopify Discounts table
@@ -213,4 +215,11 @@ For `customers` table, DELETE is supported too. You can delete the customers as 
 ~~~~sql
 DELETE FROM shopify_datasource.customers
 WHERE verified_email = false;
+~~~~
+
+For `Orders` table, UPDATE is supported. You can update the orders as follows:
+~~~~sql
+UPDATE shopify_datasource.orders
+SET email="abc@your_domain.com"
+WHERE id=5632671580477;
 ~~~~

--- a/mindsdb/integrations/handlers/shopify_handler/shopify_tables.py
+++ b/mindsdb/integrations/handlers/shopify_handler/shopify_tables.py
@@ -415,7 +415,6 @@ class OrdersTable(APITable):
         ValueError
             If the query contains an unsupported condition
         """
-        print(f"**************************************{query}********")
         update_statement_parser = UPDATEQueryParser(query)
         values_to_update, where_conditions = update_statement_parser.parse_query()
         orders_df = pd.json_normalize(self.get_orders())

--- a/mindsdb/integrations/handlers/shopify_handler/shopify_tables.py
+++ b/mindsdb/integrations/handlers/shopify_handler/shopify_tables.py
@@ -397,7 +397,37 @@ class OrdersTable(APITable):
         orders_df = select_statement_executor.execute_query()
 
         return orders_df
-    
+
+    def update(self, query: ast.Update) -> None:
+        """Updates data in the Shopify "PUT /orders" API endpoint.
+
+        Parameters
+        ----------
+        query : ast.Update
+           Given SQL UPDATE query
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        ValueError
+            If the query contains an unsupported condition
+        """
+        print(f"**************************************{query}********")
+        update_statement_parser = UPDATEQueryParser(query)
+        values_to_update, where_conditions = update_statement_parser.parse_query()
+        orders_df = pd.json_normalize(self.get_orders())
+
+        update_statement_executor = UPDATEQueryExecutor(
+            orders_df,
+            where_conditions
+        )
+        orders_df = update_statement_executor.execute_query()
+        orders_ids = orders_df['id'].tolist()
+        self.update_orders(orders_ids, values_to_update)
+
     def delete(self, query: ast.Delete) -> None:
         """Deletes data from the Shopify "DELETE /orders" API endpoint.
 
@@ -429,7 +459,18 @@ class OrdersTable(APITable):
 
         order_ids = orders_df['id'].tolist()
         self.delete_orders(order_ids)
-        
+
+    def update_orders(self, order_ids: List[int], values_to_update: Dict[Text, Any]) -> None:
+        api_session = self.handler.connect()
+        shopify.ShopifyResource.activate_session(api_session)
+
+        for order_id in order_ids:
+            order = shopify.Order.find(order_id)
+            for key, value in values_to_update.items():
+                setattr(order, key, value)
+            order.save()
+            logger.info(f'Order {order_id} updated')
+
     def delete_orders(self, order_ids: List[int]) -> None:
         api_session = self.handler.connect()
         shopify.ShopifyResource.activate_session(api_session)


### PR DESCRIPTION
## Description

This a new feature for the Shopify Handler. Under this feature, users can update the data for Shopify's Order Table.

Fixes #7846

## Type of change

(Please delete options that are not relevant)

- [x] ⚡ New feature (non-breaking change which adds functionality)
- [x] 📄 This change requires a documentation update

## Verification Process
* Set up mindsdb  on your local as a [documented here](https://docs.mindsdb.com/setup/self-hosted/pip/macos)
* Get your shophify Access key and your shop name URL
* Write the command to create a shophify database as mentioned [here](https://github.com/mindsdb/mindsdb/tree/staging/mindsdb/integrations/handlers/shopify_handler#example-usage)
* Now write a simple update SQL query to test the changes

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [x] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.


https://github.com/mindsdb/mindsdb/assets/52901608/6cb5e079-7ead-4c28-b26b-4022c8fdad9e


