### PR TITLE
Fix checking frontend version

### DIFF
--- a/mindsdb/api/http/initialize.py
+++ b/mindsdb/api/http/initialize.py
@@ -168,7 +168,8 @@ def initialize_static():
         if last_gui_version_lv is False:
             return False
 
-        if current_gui_version_lv is not None:
+        # ignore versions like '23.9.2.2'
+        if current_gui_version_lv is not None and len(current_gui_version_lv.version) < 3:
             if current_gui_version_lv >= last_gui_version_lv:
                 return True
         logger.debug("Updating gui..")


### PR DESCRIPTION
## Description

Changes:
- Ignore frontend versions like '23.9.2.2'

Version 23.9.2.2 was downloaded some time ago and since that time local version stopped to update (because 23.9.2.2 is greater than any next version)
https://mindsdb-web-builds.s3.amazonaws.com/compatible-config.json


Fixes #issue_number

## Type of change


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



