### PR TITLE
Minor Fixes to LangChain and Rag

### DIFF
--- a/mindsdb/integrations/handlers/langchain_handler/langchain_handler.py
+++ b/mindsdb/integrations/handlers/langchain_handler/langchain_handler.py
@@ -387,7 +387,7 @@ class LangChainHandler(BaseMLEngine):
         except TimeoutError:
             completions.append("I'm sorry! I couldn't come up with a response in time. Please try again.")
         # Can't use ThreadPoolExecutor as context manager since we need wait=False.
-        executor.shutdown(wait=False, cancel_futures=True)
+        executor.shutdown(wait=False)
 
         # add null completion for empty prompts
         for i in sorted(empty_prompt_ids):

--- a/mindsdb/integrations/handlers/rag_handler/settings.py
+++ b/mindsdb/integrations/handlers/rag_handler/settings.py
@@ -216,7 +216,7 @@ class OpenAIParameters(LLMParameters):
     """Model parameters for the LLM API interface"""
 
     openai_api_key: str
-    model_id: str = Field(default="text-davinci-003", title="model name")
+    model_id: str = Field(default="gpt-3.5-turbo-instruct", title="model name")
     n: int = Field(default=1, title="number of responses to return")
 
     @validator("model_id", allow_reuse=True)


### PR DESCRIPTION
## Description

This PR makes a couple of minor fixes to bugs I encountered in the RAG and LangChain handlers in the process of setting up a Chat Bot (with a Knowledge Base skill) via MS Teams.

The summary of the fixes are as follows,

1. The `shutdown()` method of the `Executor` does not seem to accept an argument called `cancel_futures`, which has been removed.
2. The OpenAI settings for the RAG handler was using the depreciated `text-davinci-003` model, which has been changed. @dusvyat Is this the best model to use here?

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



