### PR TITLE
fix openai handler `api_base` argument

### DIFF
--- a/mindsdb/integrations/handlers/openai_handler/openai_handler.py
+++ b/mindsdb/integrations/handlers/openai_handler/openai_handler.py
@@ -122,6 +122,7 @@ class OpenAIHandler(BaseMLEngine):
                 "api_key",
                 "openai_api_key",
                 "api_organization",
+                "api_base"
             }
         )
 
@@ -653,7 +654,7 @@ class OpenAIHandler(BaseMLEngine):
         completion_col = using_args.get('completion_column', 'completion')
         
         api_key = get_api_key('openai', args, self.engine_storage)
-        api_base = using_args.get('api_base', os.environ['OPENAI_API_BASE'])
+        api_base = using_args.get('api_base', os.environ.get('OPENAI_API_BASE', OPENAI_API_BASE))
         org = using_args.get('api_organization')
         client = self._get_client(api_key=api_key, base_url=api_base, org=org)
 


### PR DESCRIPTION
## Description

Finetune was blocked because of:
 - if `api_base` not in args, and `OPENAI_API_BASE` not in env, then key error raised
 - `api_base` can not be in args because it is not in white list

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



