### PR TITLE
Remove mssql as default handler

### DIFF
--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -65,7 +65,7 @@ target "cloud" {
   inherits = ["_common"]
   tags = get_tags("cloud")
   args = {
-    EXTRAS = ".[lightwood,huggingface,statsforecast-extra,neuralforecast-extra,timegpt,surrealdb,youtube,ignite,gmail,pgvector] darts datasetsforecast"
+    EXTRAS = ".[lightwood,huggingface,statsforecast-extra,neuralforecast-extra,timegpt,surrealdb,mssql,youtube,ignite,gmail,pgvector] darts datasetsforecast"
   }
 }
 

--- a/mindsdb/integrations/handlers/mssql_handler/README.md
+++ b/mindsdb/integrations/handlers/mssql_handler/README.md
@@ -18,9 +18,21 @@ The required arguments to establish a connection are as follows:
 * `user` is the database user.
 * `password` is the database password.
 
-If you installed MindsDB locally via pip, you need to install all handler dependencies manually. To do so, go to the handler's folder (mindsdb/integrations/handlers/mssql_handler) and run this command:   `pip install -r requirements.txt`.
 
 ## Installation
+
+To install this handler, run `pip install mindsdb[mssql]`. Or if you are dealing with the git repository, `pip install .[mssql]`.
+
+### Install on Apple Silicon
+
+Installation on Apple Silicon is more complicated and requires libraries for building the `pymssql` library. For Apple Silicon we'd recommend using one of our [docker containers](https://hub.docker.com/r/mindsdb/mindsdb). If you want to install via pip anyway, the following instructions may help:
+```
+brew install freetds openssl
+echo 'export LDFLAGS="-L/opt/homebrew/opt/freetds/lib -L/opt/homebrew/opt/openssl@3/lib"' >> ~/.zshrc
+echo 'export CFLAGS="-I/opt/homebrew/opt/freetds/include"' >> ~/.zshrc
+echo 'export CPPFLAGS="-I/opt/homebrew/opt/openssl@3/include"' >> ~/.zshrc
+source ~/.zshrc
+``` 
 
 We are going to first install Microsoft SQL Server locally using docker, please follow along:
 ```

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ DEFAULT_PIP_EXTRAS = [
     'langchain',            # required for mindsdb/interfaces/skills/skill_tool used by some handlers
     'langchain_embedding',  # required for mindsdb/interfaces/skills/skill_tool used by some handlers
     'postgres',
-    'mssql',
     'mysql',
     'mariadb',
     'scylla',


### PR DESCRIPTION
## Description

Fixes installs on macos. Installing pymssql on macos requires building the package and takes some setting up on macos.
Updates docs for installing and adds mssql back into the cloud docker images

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



