### PR TITLE
removed chatbot ui docs

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -312,7 +312,6 @@
           "group": "Chatbots with Agents",
           "pages": [
             "sql/tutorials/chatbots_agents",
-            "sql/tutorials/llm-chatbot-ui",
             "sql/tutorials/create-chatbot"
           ]
         },


### PR DESCRIPTION
## Description

as the chatbot icon from mindsdb editor will be temp disabled, the corresponding doc page is removed for now

Fixes #issue_number

## Type of change

- [ ] 📄 This change is a documentation update
