### PR TITLE
Added credentials_json Parameter for YouTube

### DIFF
--- a/mindsdb/integrations/handlers/utilities/auth_utilities/google/google_oauth_utilities.py
+++ b/mindsdb/integrations/handlers/utilities/auth_utilities/google/google_oauth_utilities.py
@@ -18,17 +18,18 @@ logger = log.getLogger(__name__)
 
 
 class GoogleOAuth2Manager:
-    def __init__(self, handler_stroage: str, scopes: list, credentials_file: str = None, credentials_url: str = None, code: str = None):
+    def __init__(self, handler_stroage: str, scopes: list, credentials_file: str = None, credentials_url: str = None, credentials_json: str = None, code: str = None):
         self.handler_storage = handler_stroage
         self.scopes = scopes
         self.credentials_file = credentials_file
         self.credentials_url = credentials_url
+        self.credentials_json = credentials_json
         self.code = code
 
     def get_oauth2_credentials(self):
         creds = None
 
-        if self.credentials_file or self.credentials_url:
+        if self.credentials_file or self.credentials_url or self.credentials_json:
             # get the current directory and checks tokens & creds
             curr_dir = self.handler_storage.folder_get('config')
 
@@ -76,6 +77,13 @@ class GoogleOAuth2Manager:
         if self.credentials_file and os.path.isfile(self.credentials_file):
             copyfile(self.credentials_file, secret_file)
             return True
+        
+        # if credentials_json is set, attempt to write the file
+        if self.credentials_json:
+            with open(secret_file, 'w') as creds:
+                json.dump(self.credentials_json, creds)
+            return True
+
         return False
     
     def _execute_google_auth_flow(self, secret_file, scopes, code=None):

--- a/mindsdb/integrations/handlers/youtube_handler/youtube_handler.py
+++ b/mindsdb/integrations/handlers/youtube_handler/youtube_handler.py
@@ -51,6 +51,7 @@ class YoutubeHandler(APIHandler):
 
         self.credentials_url = self.connection_data.get('credentials_url', None)
         self.credentials_file = self.connection_data.get('credentials_file', None)
+        self.credentials_json = self.connection_data.get('credentials_json', None)
         if self.connection_data.get('credentials'):
             self.credentials_file = self.connection_data.pop('credentials')
         if not self.credentials_file and not self.credentials_url:
@@ -86,7 +87,7 @@ class YoutubeHandler(APIHandler):
         if self.is_connected is True:
             return self.connection
         
-        google_oauth2_manager = GoogleOAuth2Manager(self.handler_storage, self.scopes, self.credentials_file, self.credentials_url, self.connection_data.get('code'))
+        google_oauth2_manager = GoogleOAuth2Manager(self.handler_storage, self.scopes, self.credentials_file, self.credentials_url, self.credentials_json, self.connection_data.get('code'))
         creds = google_oauth2_manager.get_oauth2_credentials()
 
         youtube = build(


### PR DESCRIPTION
## Description

This PR adds the `credentials_json` parameter to the YouTube handler. The reason for including this is because currently, when initializing the integration through the form and the credentials file is uploaded directly, there is no mechanism in place to handler the authentication. With the inclusion of this parameter, the content of the file can be read when the file is uploaded to the front-end and sent across to the handler.

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [X] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



