### PR TITLE
[fix] #6821 - deprecate normal completion mode for OpenAI handler

### DIFF
--- a/mindsdb/integrations/handlers/openai_handler/openai_handler.py
+++ b/mindsdb/integrations/handlers/openai_handler/openai_handler.py
@@ -43,10 +43,9 @@ class OpenAIHandler(BaseMLEngine):
         self.default_model = 'gpt-3.5-turbo'
         self.default_image_model = 'dall-e-2'
         self.default_mode = (
-            'default'  # can also be 'conversational' or 'conversational-full'
+            'conversational'  # can also be 'conversational-full'
         )
         self.supported_modes = [
-            'default',
             'conversational',
             'conversational-full',
             'image',
@@ -56,7 +55,7 @@ class OpenAIHandler(BaseMLEngine):
         self.max_batch_size = 20
         self.default_max_tokens = 100
         self.chat_completion_models = CHAT_MODELS
-        self.supported_ft_models = FINETUNING_MODELS # base models compatible with finetuning
+        self.supported_ft_models = FINETUNING_MODELS  # base models compatible with finetuning
 
     @staticmethod
     def create_validation(target, args=None, **kwargs):
@@ -271,7 +270,7 @@ class OpenAIHandler(BaseMLEngine):
             }
 
             if (
-                args.get('mode', self.default_mode) != 'default'
+                args.get('mode', self.default_mode) in ('conversational', 'conversational-full')
                 and model_name not in self.chat_completion_models
             ):
                 raise Exception(
@@ -494,15 +493,6 @@ class OpenAIHandler(BaseMLEngine):
                     kwargs['messages'] = truncate_msgs_for_token_limit(
                         kwargs['messages'], kwargs['model'], api_args['max_tokens']
                     )
-                    pkwargs = {**kwargs, **api_args}
-
-                    before_openai_query(kwargs)
-                    resp = _tidy(client.chat.completions.create(**pkwargs))
-                    _log_api_call(pkwargs, resp)
-
-                    completions.extend(resp)
-                elif mode == 'default':
-                    kwargs['messages'] = [initial_prompt] + [kwargs['messages'][-1]]
                     pkwargs = {**kwargs, **api_args}
 
                     before_openai_query(kwargs)


### PR DESCRIPTION
## Description

This PR deprecates the normal completion mode for OpenAI handler. Default mode now is `conversational` which uses the `ChatCompletion` endpoint.

Fixes #6821

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



