### PR TITLE
Adding url to connection_args ordered dict.

### DIFF
--- a/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
+++ b/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
@@ -251,25 +251,25 @@ connection_args = OrderedDict(
     user={
         'type': ARG_TYPE.STR,
         'description': 'The user name used to authenticate with the MySQL server.',
-        'required': True,
+        'required': False,
         'label': 'User'
-    },
+        },
     password={
         'type': ARG_TYPE.PWD,
         'description': 'The password to authenticate the user with the MySQL server.',
-        'required': True,
+        'required': False,
         'label': 'Password'
     },
     database={
         'type': ARG_TYPE.STR,
         'description': 'The database name to use when connecting with the MySQL server.',
-        'required': True,
+        'required': False,
         'label': 'Database'
     },
     host={
         'type': ARG_TYPE.STR,
         'description': 'The host name or IP address of the MySQL server. NOTE: use \'127.0.0.1\' instead of \'localhost\' to connect to local server.',
-        'required': True,
+        'required': False,
         'label': 'Host'
     },
     port={
@@ -302,6 +302,12 @@ connection_args = OrderedDict(
         'required': False,
         'label': 'ssl_key',
     }
+    url={
+        'type': ARG_TYPE.PATH,
+        'description': 'The URL for connecting to the server.  The username and password can be provided here OR in the other appropriate fields. Either the server, port, and database MUST be provided OR this field must be provided.',
+        'required': False,
+        'label': 'url',
+        }
 )
 
 connection_args_example = OrderedDict(


### PR DESCRIPTION
This was an oversight in a previous PR.

As far as I can tell this only affects the generated API documentation.  

## Description

Please include a summary of the change and the issue it solves. 

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [X] Necessary documentation updates are either made or tracked in issues.
- [X] Relevant unit and integration tests are updated or added.



