### PR TITLE
Better error handling if exception can't be pickled

### DIFF
--- a/mindsdb/integrations/libs/ml_exec_base.py
+++ b/mindsdb/integrations/libs/ml_exec_base.py
@@ -41,7 +41,7 @@ from mindsdb.utilities.functions import mark_process
 import mindsdb.utilities.profiler as profiler
 from mindsdb.utilities.ml_task_queue.producer import MLTaskProducer
 from mindsdb.utilities.ml_task_queue.const import ML_TASK_TYPE
-from mindsdb.integrations.libs.process_cache import process_cache, empty_callback
+from mindsdb.integrations.libs.process_cache import process_cache, empty_callback, MLProcessException
 
 try:
     import torch.multiprocessing as mp
@@ -420,6 +420,8 @@ class BaseMLEngineExec:
         except (ImportError, ModuleNotFoundError):
             raise
         except Exception as e:
+            if type(e) is MLProcessException:
+                e = e.base_exception
             msg = str(e).strip()
             if msg == '':
                 msg = e.__class__.__name__

--- a/mindsdb/integrations/libs/process_cache.py
+++ b/mindsdb/integrations/libs/process_cache.py
@@ -42,7 +42,7 @@ def empty_callback(_task):
 class MLProcessException(Exception):
     """Wrapper for exception to safely send it back to the main process.
 
-    If exception is can not be pickled (pickle.loads(pickle.dumps(e))) then it may lead to termination of the ML process.
+    If exception can not be pickled (pickle.loads(pickle.dumps(e))) then it may lead to termination of the ML process.
     Also in this case, the error sent to the user will not be relevant. This wrapper should prevent it.
     """
     base_exception_bytes: bytes = None


### PR DESCRIPTION
## Description

If exception can not be pickled (pickle.loads(pickle.dumps(e))) then it may lead to termination of the ML process.
Also in this case, the error sent to the user will not be relevant. This wrapper should prevent it.

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [v] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



