### PR TITLE
Add custom container-name in example code

### DIFF
--- a/docs/setup/self-hosted/docker.mdx
+++ b/docs/setup/self-hosted/docker.mdx
@@ -83,12 +83,12 @@ Here is how to install the dependencies in the Docker container:
 
 1. Run the MindsDB Docker container:
     ```bash
-    docker run -d -p 47334:47334 -p 47335:47335 mindsdb/mindsdb
+    docker run -d -p 47334:47334 -p 47335:47335 --name my_container mindsdb/mindsdb
     ```
 
 2. Start an interactive shell in the container:
     ```bash
-    docker exec -it container-name sh
+    docker exec -it my_container sh
     ```
 
 3. Install the dependencies:
@@ -107,7 +107,7 @@ Here is how to install the dependencies in the Docker container:
 
 5. Restart the container:
     ```bash
-    docker restart container-name
+    docker restart my_container
     ```
 
 ## Configuration Options


### PR DESCRIPTION
Current code is not directly copy-pasteable as-is because "container-name" throws

Error response from daemon: No such container: container-name

Given that the docs are written for complete newbies, it's not clear that "container-name" needs to be replaced with the container name randomly generated by docker run. Instead of instructing the user to find the container name (e.g. with docker ps) it's probably best practice just to set a container name explicitly. Adding that change here with --name

## Description

Please include a summary of the change and the issue it solves. 

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



