### PR TITLE
Аix getting api-key for openai finetune

### DIFF
--- a/mindsdb/integrations/handlers/openai_handler/openai_handler.py
+++ b/mindsdb/integrations/handlers/openai_handler/openai_handler.py
@@ -649,11 +649,13 @@ class OpenAIHandler(BaseMLEngine):
         """  # noqa
 
         args = args if args else {}
+
+        api_key = get_api_key('openai', args, self.engine_storage)
+
         using_args = args.pop('using') if 'using' in args else {}
         prompt_col = using_args.get('prompt_column', 'prompt')
         completion_col = using_args.get('completion_column', 'completion')
         
-        api_key = get_api_key('openai', args, self.engine_storage)
         api_base = using_args.get('api_base', os.environ.get('OPENAI_API_BASE', OPENAI_API_BASE))
         org = using_args.get('api_organization')
         client = self._get_client(api_key=api_key, base_url=api_base, org=org)

--- a/mindsdb/integrations/utilities/handler_utils.py
+++ b/mindsdb/integrations/utilities/handler_utils.py
@@ -33,6 +33,8 @@ def get_api_key(
     # 1
     if "api_key" in create_args:
         return create_args["api_key"]
+    if "using" in create_args and "api_key" in create_args["using"]:
+        return create_args["using"]["api_key"]
     # 2
     connection_args = engine_storage.get_connection_args()
     if "api_key" in connection_args:


### PR DESCRIPTION
## Description

There is no possible to specify api-key when do openai finetune. If put key into `using`, then it ignored.

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



