### PR TITLE
Stored MS Teams Redirect URI in Handler Storage

### DIFF
--- a/mindsdb/integrations/handlers/utilities/auth_utilities/microsoft/ms_graph_api_auth_utilities.py
+++ b/mindsdb/integrations/handlers/utilities/auth_utilities/microsoft/ms_graph_api_auth_utilities.py
@@ -20,9 +20,14 @@ class MSGraphAPIAuthManager:
         self.tenant_id = tenant_id
         self.code = code
 
-        self.redirect_uri = request.headers['ORIGIN'] + '/verify-auth'
-        if '127.0.0.1' in self.redirect_uri:
-            self.redirect_uri = self.redirect_uri.replace('127.0.0.1', 'localhost')
+        if self.handler_storage.json_get('args'):
+            self.redirect_uri = self.handler_storage.json_get('args').get('redirect_uri')
+        else:
+            self.redirect_uri = request.headers['ORIGIN'] + '/verify-auth'
+            if '127.0.0.1' in self.redirect_uri:
+                self.redirect_uri = self.redirect_uri.replace('127.0.0.1', 'localhost')
+
+            self.handler_storage.json_set('args', {'redirect_uri': self.redirect_uri})
 
     def get_access_token(self):
         try:
@@ -69,10 +74,6 @@ class MSGraphAPIAuthManager:
 
             return response
         else:
-            redirect_uri = request.headers['ORIGIN'] + '/verify-auth'
-            if '127.0.0.1' in redirect_uri:
-                self.redirect_uri = redirect_uri.replace('127.0.0.1', 'localhost')
-
             auth_url = msal_app.get_authorization_request_url(
                 scopes=self.scopes,
                 redirect_uri=self.redirect_uri,

--- a/mindsdb/integrations/handlers/utilities/auth_utilities/microsoft/ms_graph_api_auth_utilities.py
+++ b/mindsdb/integrations/handlers/utilities/auth_utilities/microsoft/ms_graph_api_auth_utilities.py
@@ -20,8 +20,11 @@ class MSGraphAPIAuthManager:
         self.tenant_id = tenant_id
         self.code = code
 
+        # get the redirect uri from handler storage if it exists
         if self.handler_storage.json_get('args'):
             self.redirect_uri = self.handler_storage.json_get('args').get('redirect_uri')
+        # otherwise, get it from the request headers
+        # this is done because when the chatbot task runs, it doesn't have access to the request headers because it does not come through a request
         else:
             self.redirect_uri = request.headers['ORIGIN'] + '/verify-auth'
             if '127.0.0.1' in self.redirect_uri:


### PR DESCRIPTION
## Description

This PR updates the logic for the MS Teams authentication process to generate a redirect URI only on the first time that the connection initialized. At this point the redirect URI will be stored in handler storage and subsequent attempts at initializing the same connection will access it from this storage.

This update was required because as the chat bot task runs on a separate thread and does not come through a request, it does not have access to the request headers used to generate the redirect URI.

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [x]   Verification Steps: This change needs to be validated by creating a MS Teams chat bot.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [X] Necessary documentation updates are either made or tracked in issues - no updates required.
- [X] Relevant unit and integration tests are updated or added -  no updates required.



