### PR TITLE
[Docs] update mongo doc: replace `insert`->`insertOne`, `predictors`->`models`

### DIFF
--- a/docs/sdks/mongo/jobs/insertOne.mdx
+++ b/docs/sdks/mongo/jobs/insertOne.mdx
@@ -5,14 +5,14 @@ sidebarTitle: Create a Job
 
 ## Description
 
-The `db.jobs.insert()` function creates and schedules a job.
+The `db.jobs.insertOne()` function creates and schedules a job.
 
 ## Syntax
 
 Here is the syntax:
 
 ```
-db.jobs.insert({
+db.jobs.insertOne({
     'name': 'job2',
     'query': "select * from models"
 })
@@ -21,7 +21,7 @@ db.jobs.insert({
 And here is a more complex example:
 
 ```
-db.jobs.insert({
+db.jobs.insertOne({
     'name': 'job1',
     'schedule_str': 'every day',
     'start_at': '2023-03-30',    

--- a/docs/sdks/mongo/models/finetune.mdx
+++ b/docs/sdks/mongo/models/finetune.mdx
@@ -5,12 +5,12 @@ sidebarTitle: Finetune a Model
 
 ## Description
 
-The `db.models.insert({"name": "model_name","action": "finetune"})` function is used finetune a model.
+The `db.models.insertOne({"name": "model_name","action": "finetune"})` function is used finetune a model.
 
 ## Syntax
 
 Here is the syntax:
 
 ```sql
-db.models.insert({"name": "model_name","action": "finetune"})
+db.models.insertOne({"name": "model_name","action": "finetune"})
 ```

--- a/docs/sdks/mongo/models/retrain.mdx
+++ b/docs/sdks/mongo/models/retrain.mdx
@@ -5,12 +5,12 @@ sidebarTitle: Retrain a Model
 
 ## Description
 
-The `db.models.insert({"name": "model_name","action": "retrain"})` function is used retrain a model.
+The `db.models.insertOne({"name": "model_name","action": "retrain"})` function is used retrain a model.
 
 ## Syntax
 
 Here is the syntax:
 
 ```sql
-db.models.insert({"name": "model_name","action": "retrain"})
+db.models.insertOne({"name": "model_name","action": "retrain"})
 ```

--- a/docs/sdks/mongo/mongo.mdx
+++ b/docs/sdks/mongo/mongo.mdx
@@ -6,9 +6,9 @@ Note: This is work in progress, please join our slack channel if you have any qu
 
 ### Train new model
 
-To train a new model, you will need to `insert()` a new document inside the mindsdb.models collection.
+To train a new model, you will need to `insertOne()` a new document inside the mindsdb.models collection.
 
-The object sent to the `insert()` for training the new model should contain:
+The object sent to the `insertOne()` for training the new model should contain:
 
 - name (string) -- The name of the model.
 - predict (string) -- The feature you want to predict. To predict multiple features, include a list of features.
@@ -20,7 +20,7 @@ The object sent to the `insert()` for training the new model should contain:
 - training_options (dict) -- Optional value that contains additional training parameters. To train timeseries model you need to provide `training_options`.
 
 ```javascript
-db.predictors.insert({
+db.models.insertOne({
     'name': str,
     'predict': str | list of fields,
     'connection': str,  # optional
@@ -36,7 +36,7 @@ db.predictors.insert({
 For the timeseries model:
 
 ```
-db.predictors.insert({
+db.models.insertOne({
     'name': str,
     'predict': str | list of fields,
     'connection': str,  # optional
@@ -63,7 +63,7 @@ db.predictors.insert({
 The following example shows you how to train a new model from a mongo client. The collection used for training the model is the [Telcom Customer Churn](https://www.kaggle.com/blastchar/telco-customer-churn) dataset.
 
 ```sql
-db.predictors.insert({
+db.models.insertOne({
     'name': 'churn',
     'predict': 'Churn',
     'select_data_query':{
@@ -83,7 +83,7 @@ This `INSERT` query will train a new model called `churn` that predicts the cust
 To check that the training finished successfully, you can `find()` the model status inside mindsdb.models collection e.g.:
 
 ```javascript
-db.predictors.find();
+db.models.find();
 ```
 
 ![Training model status](/assets/predictors/mongo/mongo-status.gif)
@@ -93,10 +93,10 @@ You have successfully trained a new model from a mongo shell. The next step is t
 
 #### Delete model
 
-To delete the model run `remove` function on predictors collection and send the name of the model to delete as:
+To delete the model run `remove` function on models collection and send the name of the model to delete as:
 
 ```javascript
-db.predictors.remove({ name: "model_name" });
+db.models.remove({ name: "model_name" });
 ```
 
 ## Query the model from MongoDB API

--- a/mindsdb/api/mongo/README.md
+++ b/mindsdb/api/mongo/README.md
@@ -105,7 +105,7 @@ db.house_sales.find({
 Append data to collection:
 
 ```
-db.house_sales.insert({
+db.house_sales.insertOne({
     'real_price': 10000
 })
 ```
@@ -131,7 +131,7 @@ From mongo:
 // working with mindsdb database
 use mindsdb
 
-db.predictors.insert(
+db.models.insertOne(
 {
      "name": "sales_model",
      "predict": "sale_price",
@@ -153,7 +153,7 @@ db.predictors.insert(
 Retrain predictor: 
 The same syntax as create model, but using "action": "retrain"
 ```
-db.models.insert({
+db.models.insertOne({
      "name": "sales_model",
      "action": "retrain",
 })
@@ -162,7 +162,7 @@ db.models.insert({
 Finetune predictor:
 The same syntax as create model, but using "action": "finetune"
 ```
-db.models.insert({
+db.models.insertOne({
      "name": "sales_model",
      "action": "finetune",
 })
@@ -186,13 +186,13 @@ You can unnest it using aggregate mongo query:
 - $unwind - is doing unnesting
 - $project - is moving keys to top level
 
-## List of predictors from mongo:
+## List of models from mongo:
 ```
-// all predictors
-db.predictors.find({})
+// all models
+db.models.find({})
 
 // filter by name
-db.predictors.find({'name': "sales_model"})
+db.models.find({'name': "sales_model"})
 ```
 
 
@@ -307,9 +307,9 @@ db.sales_model.stats({'scale':'ensemble'})
 ```
 
 
-## Delete predictor 
+## Delete models 
 ```
-db.predictors.deleteOne({'name': "sales_model"})
+db.models.deleteOne({'name': "sales_model"})
 ```
 
 ## ML Engines
@@ -342,7 +342,7 @@ db.ml_engines.deleteOne({"name": "openai_2"})
 
 **Create**
 ```
-db.jobs.insert({
+db.jobs.insertOne({
     'name': 'job1',
     'schedule_str': 'every day',
     'start_at': '2023-03-30',    
@@ -372,7 +372,7 @@ in case of mongo syntax it will be converted to sql
 
 One more example:
 ```
-db.jobs.insert({
+db.jobs.insertOne({
     'name': 'job2',
     'query': "select * from models"
 })


### PR DESCRIPTION
## Description

`.insert` is replaced to `.insertOne`
`predictors` replaced to `models`

Close #7214

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



