### PR TITLE
Improve error message if model in 'error' status

### DIFF
--- a/mindsdb/api/http/namespaces/handlers.py
+++ b/mindsdb/api/http/namespaces/handlers.py
@@ -56,7 +56,7 @@ class InstallDependencies(Resource):
     def post(self, handler_name):
         handler_import_status = ca.integration_controller.get_handlers_import_status()
         if handler_name not in handler_import_status:
-            return f'Unkown handler: {handler_name}', 400
+            return f'Unknown handler: {handler_name}', 400
 
         if handler_import_status[handler_name].get('import', {}).get('success', False) is True:
             return 'Installed', 200

--- a/mindsdb/utilities/exception.py
+++ b/mindsdb/utilities/exception.py
@@ -7,7 +7,7 @@ class BaseEntityException(Exception):
     """
     def __init__(self, message: str, entity_name: str = None) -> None:
         self.message = message
-        self.entity_name = entity_name or 'unkown'
+        self.entity_name = entity_name or 'unknown'
 
     def __str__(self) -> str:
         return f'{self.message}: {self.entity_name}'

--- a/mindsdb/utilities/log_controller.py
+++ b/mindsdb/utilities/log_controller.py
@@ -6,7 +6,7 @@ def fmt_log_record(log_record):
     return {
         'log_from': 'mindsdb',
         'level': log_record.log_type,
-        'context': 'unkown',
+        'context': 'unknown',
         'text': log_record.payload,
         'created_at': str(log_record.created_at).split('.')[0]
     }

--- a/tests/unit/test_project_structure.py
+++ b/tests/unit/test_project_structure.py
@@ -755,12 +755,13 @@ class TestProjectStructure(BaseExecutorDummyML):
             {'a': 2, 'b': 'b'},
         ])
         self.set_handler(data_handler, name='pg', tables={'tasks': df})
+        self.save_file('tasks', df)
 
         # -- create model --
         self.run_sql(
             '''
                 CREATE model task_model
-                from pg (select * from tasks)
+                from files (select * from tasks)
                 PREDICT a
                 using engine='dummy_ml'
             '''


### PR DESCRIPTION
## Description

If use a model in 'error' status, then error message will be like
```
The model 'model_name' cannot be used as it is currently in 'error' status.
For detailed information about the error, please execute the following command:

    select error from information_schema.models where name = 'model_name';
```
instead of
```
Can't select from cryptocurrency_forecast_model in project: unkown
```

Also fixed typo `unkown`->`unknown`

Close #8826

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



