### PR TITLE
Fix: JOIN model with empty dataframe

### DIFF
--- a/mindsdb/api/executor/sql_query/result_set.py
+++ b/mindsdb/api/executor/sql_query/result_set.py
@@ -52,6 +52,9 @@ class ResultSet:
 
         return f'{self.__class__.__name__}({self.length()} rows, cols: {col_names})\n {data}'
 
+    def __len__(self) -> int:
+        return len(self._records)
+
     # --- converters ---
 
     def from_df(self, df, database, table_name, table_alias=None):

--- a/tests/integration_tests/flows/test_ts_predictions.py
+++ b/tests/integration_tests/flows/test_ts_predictions.py
@@ -90,6 +90,16 @@ class TestHTTP(HTTPHelperMixin):
         assert len([x for x in data if x['group'] == 'a']) == 3
         assert data[0]['date'] == (datetime.date.today() + datetime.timedelta(days=30))
 
+    def test_gt_latest_date_empty_join(self):
+        sql = '''
+            select p.date, p.group, p.value
+            from mindsdb.testv as t join mindsdb.tstest as p
+            where t.date > LATEST and t.group = 'wrong'
+        '''
+        resp = self.sql_via_http(sql, RESPONSE_TYPE.TABLE)
+        data = to_dicts(resp['data'])
+        assert len(data) == 0
+
     def test_eq_latest_date(self):
         sql = '''
             select p.date, p.group, p.value


### PR DESCRIPTION
## Description

Reason of issue: if join model and  empty dataframe, then info about columns is loosed. That follow to error.

Close #8842

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



