### PR TITLE
Don't pickle exception, wrap it

### DIFF
--- a/mindsdb/integrations/libs/process_cache.py
+++ b/mindsdb/integrations/libs/process_cache.py
@@ -1,6 +1,5 @@
 import sys
 import time
-import pickle
 import threading
 from typing import Optional, Callable
 from concurrent.futures import ProcessPoolExecutor, Future

--- a/mindsdb/integrations/libs/process_cache.py
+++ b/mindsdb/integrations/libs/process_cache.py
@@ -49,11 +49,11 @@ class MLProcessException(Exception):
 
     def __init__(self, base_exception: Exception, message: str = None) -> None:
         super().__init__(message)
-        self.base_exception_bytes = pickle.dumps(base_exception)
+        self.message = f'{base_exception.__class__.__name__}: {base_exception}'
 
     @property
     def base_exception(self) -> Exception:
-        return pickle.loads(self.base_exception_bytes)
+        return RuntimeError(self.message)
 
 
 class WarmProcess:


### PR DESCRIPTION
## Description

Continue of #8729

Not every exception can be unpickled, sometimes it can't create instance of exception. Fix is to wrap it in RuntimeException 

How it works:
https://www.loom.com/share/08a74119e8054ea2b8557d27c2b3ce82

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



