### PR TITLE
Fix warning about flask JSONEncoder deprecation

### DIFF
--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -14,7 +14,6 @@ import asyncio
 import secrets
 import traceback
 import threading
-from textwrap import dedent
 from packaging import version
 
 from mindsdb.__about__ import __version__ as mindsdb_version
@@ -209,10 +208,8 @@ if __name__ == '__main__':
         import_meta = handler_meta.get("import", {})
         if import_meta.get("success", False) is not True:
             logger.info(
-                dedent(
-                    """Some handlers cannot be imported. You can check list of available handlers by execute command in sql editor:
-                    select * from information_schema.handlers;"""
-                )
+                """Some handlers cannot be imported. You can check list of available handlers by execute command in sql editor:
+select * from information_schema.handlers;"""
             )
             break
     # @TODO Backwards compatibility for tests, remove later

--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -210,10 +210,8 @@ if __name__ == '__main__':
         if import_meta.get("success", False) is not True:
             logger.info(
                 dedent(
-                    """
-                Some handlers cannot be imported. You can check list of available handlers by execute command in sql editor:
-                    select * from information_schema.handlers;
-            """
+                    """Some handlers cannot be imported. You can check list of available handlers by execute command in sql editor:
+                    select * from information_schema.handlers;"""
                 )
             )
             break

--- a/mindsdb/api/mongo/utilities/mongodb_query.py
+++ b/mindsdb/api/mongo/utilities/mongodb_query.py
@@ -1,10 +1,9 @@
 import datetime as dt
-from json import JSONEncoder
-
+import json
 from bson import ObjectId
 
 
-class MongoJSONEncoder(JSONEncoder):
+class MongoJSONEncoder(json.JSONEncoder):
 
     def default(self, obj):
         if isinstance(obj, dt.datetime):

--- a/mindsdb/utilities/json_encoder.py
+++ b/mindsdb/utilities/json_encoder.py
@@ -1,11 +1,11 @@
 from datetime import datetime, date, timedelta
 from decimal import Decimal
 import numpy as np
-from flask.json import JSONEncoder
 import pandas as pd
+import json
 
 
-class CustomJSONEncoder(JSONEncoder):
+class CustomJSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, np.ndarray):
             return obj.tolist()


### PR DESCRIPTION
Fixes this warning when running MindsDB:
`/mindsdb/mindsdb/__main__.py:145: DeprecationWarning: 'JSONEncoder' is deprecated and will be removed in Flask 2.3. Use 'Flask.json' to provide an alternate JSON implementation instead.`