### PR TITLE
Mark `files` handler as permanent

### DIFF
--- a/mindsdb/integrations/handlers/file_handler/__init__.py
+++ b/mindsdb/integrations/handlers/file_handler/__init__.py
@@ -8,6 +8,8 @@ title = 'File'
 name = 'files'
 type = HANDLER_TYPE.DATA
 
+permanent = True
+
 __all__ = [
     'Handler', 'version', 'name', 'type', 'title'
 ]

--- a/mindsdb/interfaces/database/database.py
+++ b/mindsdb/interfaces/database/database.py
@@ -57,7 +57,7 @@ class DatabaseController:
                 'id': x.id,
                 'engine': None,
                 'visible': True,
-                'deletable': True
+                'deletable': x.name.lower() != 'mindsdb'
             })
         for key, value in integrations.items():
             db_type = value.get('type', 'data')
@@ -70,7 +70,7 @@ class DatabaseController:
                     'class_type': value.get('class_type'),
                     'connection_data': value.get('connection_data'),
                     'visible': True,
-                    'deletable': True
+                    'deletable': value.get('permanent', False) is False
                 })
 
         if filter_type is not None:

--- a/mindsdb/interfaces/database/integrations.py
+++ b/mindsdb/interfaces/database/integrations.py
@@ -322,6 +322,7 @@ class IntegrationController:
             'type': integration_type,
             'class_type': class_type,
             'engine': integration_record.engine,
+            'permanent': getattr(integration_module, 'permanent', False),
             'date_last_update': deepcopy(integration_record.updated_at),
             'connection_data': data
         }


### PR DESCRIPTION
## Description

 - Mark `files` handler as permanent, therefore it can not be deleted
 - Mark `mindsdb` project as not deletable

Fixes #8878

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



