### PR TITLE
Add auth flag in the config example

### DIFF
--- a/docs/setup/custom-config.mdx
+++ b/docs/setup/custom-config.mdx
@@ -51,6 +51,7 @@ First, you should prepare a `config.json` file based on the following template; 
         "autoupdate": true
     },
     "auth":{
+        "http_auth_enabled": False,
         "username": "mindsdb",
         "password": "123"
     },


### PR DESCRIPTION
## Description

This PR adds the `http_auth_enabled` flag in the default config.json example. This is needed for enabling the authentication and was missing from the example


## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [X] 📄 This change is a documentation update

