### PR TITLE
Fix supported python versions for pip installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -185,5 +185,5 @@ setup(
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.8,<=3.10",
 )


### PR DESCRIPTION
## Description

Won't allow pip installs on python versions we don't support (3.11+)


## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)



