### PR TITLE
Updated the Broken Dependencies for the BigQuery Handler

### DIFF
--- a/mindsdb/integrations/handlers/bigquery_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/bigquery_handler/requirements.txt
@@ -1,2 +1,2 @@
-google-cloud-bigquery
+google-cloud-bigquery[pandas]
 sqlalchemy-bigquery


### PR DESCRIPTION
## Description

The BigQuery handler is not usable at the moment, due to a missing dependency as shown below,

![Screenshot from 2024-03-12 11-00-41](https://github.com/mindsdb/mindsdb/assets/49385643/113eadfc-ce12-4cf2-868c-c048a9409ab3)

This PR adds the missing dependency in a robust manner as mentioned [here](https://stackoverflow.com/questions/72511979/valueerror-install-dbtypes-to-use-this-function).

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added - N/A



