### PR TITLE
Upgrade to latest ClickHouse sqlalchemy

### DIFF
--- a/mindsdb/integrations/handlers/clickhouse_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/clickhouse_handler/requirements.txt
@@ -1,1 +1,1 @@
-clickhouse-sqlalchemy @ git+https://github.com/StpMax/clickhouse-sqlalchemy@5eadc4f
+clickhouse-sqlalchemy>=0.3.1


### PR DESCRIPTION
## Description

This PR upgrades the ClickHouse dependency to the latest version that supports SqlAlchemy 2 and removes the forked repo as a dependency.

Fixes #8926 

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Additional Media:
![Screenshot from 2024-03-18 13-50-09](https://github.com/mindsdb/mindsdb/assets/7192539/02316161-672d-4eb8-a532-f4edce526415)




## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



