### PR TITLE
simplify adding metadata to vectordb

### DIFF
--- a/mindsdb/integrations/handlers/chromadb_handler/tests/test_chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/tests/test_chromadb_handler.py
@@ -145,7 +145,21 @@ class TestChromaDBHandler(BaseExecutorTest):
                 ],  # different dimensions
             }
         )
-        self.set_handler(postgres_handler_mock, "pg", tables={"df": df, "df2": df2})
+
+        df3 = pd.DataFrame(
+            {
+                "id": ["id1", "id2", "id3"],
+                "content": ["this is a test", "this is a test", "this is a test"],
+                "test": ["test1", "test2", "test3"],
+                "embeddings": [
+                    [1.0, 2.0, 3.0],
+                    [1.0, 2.0, 3.0],
+                    [1.0, 2.0, 3.0],
+                ],
+            }
+        )
+
+        self.set_handler(postgres_handler_mock, "pg", tables={"df": df, "df2": df2, "df3": df3})
         num_record = df.shape[0]
 
         # create a table
@@ -208,6 +222,25 @@ class TestChromaDBHandler(BaseExecutorTest):
         """
         ret = self.run_sql(sql)
         assert ret.shape[0] == num_record + 3  # only one unique record was added
+
+        # insert into a table with a select statement, passing in metadata as extra named column e.g. test
+
+        sql = """
+            INSERT INTO chroma_test.test_table (
+            SELECT
+                content,embeddings, test
+            FROM
+                pg.df3
+                )
+        """
+        self.run_sql(sql)
+
+        # check if the data is inserted
+        sql = """
+            SELECT * FROM chroma_test.test_table
+        """
+        ret = self.run_sql(sql)
+        assert ret.shape[0] == num_record + 3  # three unique records were added
 
         # insert into a table with a select statement, but wrong columns
         with pytest.raises(Exception):


### PR DESCRIPTION
## Description

simplify insert with vectordb, extra columns which aren't in schema will be assumed to be part of metadata

e.g.

```
insert into my_vectordb(
select 
  id, 
  body as content,  
  /* all other columns go to metadata */ 
    mail_id, to_field, from_field, subject, subject, datetime
from email_datasource.emails)
```

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



