### PR TITLE
removing redundant package lists and sentence-transformers library

### DIFF
--- a/mindsdb/integrations/handlers/rag_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/rag_handler/requirements.txt
@@ -5,3 +5,5 @@ html2text
 writerai~=1.1.0
 pydantic
 langchain-community  # for Writer LLM integration
+sentence-transformers # needed for HuggingFaceEmbeddings from langchain-community
+

--- a/mindsdb/integrations/handlers/rag_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/rag_handler/requirements.txt
@@ -2,9 +2,6 @@
 faiss-cpu
 openai==1.6.1
 html2text
-sentence-transformers
 writerai~=1.1.0
 pydantic
-sentence-transformers
-faiss-cpu
 langchain-community  # for Writer LLM integration

--- a/mindsdb/integrations/handlers/rag_handler/settings.py
+++ b/mindsdb/integrations/handlers/rag_handler/settings.py
@@ -175,6 +175,7 @@ class PersistedVectorStoreLoader:
                 folder_path=self.config.persist_directory,
                 embeddings=self.config.embeddings_model,
                 index_name=self.config.collection_name,
+                allow_dangerous_deserialization=True
             )
 
         else:

--- a/tests/unit/ml_handlers/test_rag.py
+++ b/tests/unit/ml_handlers/test_rag.py
@@ -293,7 +293,7 @@ class TestRAG(BaseExecutorTest):
              writer_api_key='{WRITER_API_KEY}',
              writer_org_id='{WRITER_ORG_ID}',
              vector_store_folder_name='rag_writer_qa_test_multi_url',
-             input_columnn='question'
+             input_column='question'
         """
         )
 

--- a/tests/unit/ml_handlers/test_rag.py
+++ b/tests/unit/ml_handlers/test_rag.py
@@ -179,7 +179,8 @@ class TestRAG(BaseExecutorTest):
              engine='rag',
              llm_type='openai',
              openai_api_key='{OPENAI_API_KEY}',
-             vector_store_folder_name='rag_openai_qa_test'
+             vector_store_folder_name='rag_openai_qa_test',
+             input_column='question'
         """
         )
         self.wait_predictor("proj", "test_rag_openai_qa")
@@ -207,7 +208,8 @@ class TestRAG(BaseExecutorTest):
              llm_type='openai',
              openai_api_key='{OPENAI_API_KEY}',
              vector_store_folder_name='rag_openai_qa_test_batch',
-             embeddings_batch_size={embeddings_batch_size}
+             embeddings_batch_size={embeddings_batch_size},
+             input_column='question'
         """
         )
 
@@ -235,7 +237,8 @@ class TestRAG(BaseExecutorTest):
              vector_store_name='faiss',
              writer_api_key='{WRITER_API_KEY}',
              writer_org_id='{WRITER_ORG_ID}',
-             vector_store_folder_name='rag_writer_qa_test'
+             vector_store_folder_name='rag_writer_qa_test',
+             input_column='question'
         """
         )
         self.wait_predictor("proj", "test_rag_writer_qa")
@@ -261,7 +264,8 @@ class TestRAG(BaseExecutorTest):
              vector_store_name='faiss',
              writer_api_key='{WRITER_API_KEY}',
              writer_org_id='{WRITER_ORG_ID}',
-             vector_store_folder_name='rag_writer_qa_test_single_url'
+             vector_store_folder_name='rag_writer_qa_test_single_url',
+             input_column='question'
         """
         )
         self.wait_predictor("proj", "test_rag_writer_qa_single_url")
@@ -288,7 +292,8 @@ class TestRAG(BaseExecutorTest):
              url_column_name='url',
              writer_api_key='{WRITER_API_KEY}',
              writer_org_id='{WRITER_ORG_ID}',
-             vector_store_folder_name='rag_writer_qa_test_multi_url'
+             vector_store_folder_name='rag_writer_qa_test_multi_url',
+             input_columnn='question'
         """
         )
 


### PR DESCRIPTION
## Description

Removes the dependency: hugging face `sentence_transformer` package, that requires installation of `torch` and `cudnn`. This simplifies install and streamlines use of LLM endpoints.

## Type of change

(Please delete options that are not relevant)

- [x ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [x ]   Verification Steps:
 - Instantiated a RAG model using writer. No errors were thrown.

## Checklist:

- [ x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ x] I have appropriately commented on my code, especially in complex areas.
- [ x] Necessary documentation updates are either made or tracked in issues.
- [ x] Relevant unit and integration tests are updated or added.



