### PR TITLE
Sets the 'success' Attribute of /<handler_name>/install Endpoint to False Upon Installation Failure

### DIFF
--- a/mindsdb/integrations/utilities/install.py
+++ b/mindsdb/integrations/utilities/install.py
@@ -29,6 +29,8 @@ def install_dependencies(dependencies):
                 output = output + '\n'
             output = output + 'Errors: ' + errs.decode()
         result['error_message'] = output
-
-    result['success'] = True
+        result['success'] = False
+    else:
+        result['success'] = True
+        
     return result

--- a/mindsdb/integrations/utilities/install.py
+++ b/mindsdb/integrations/utilities/install.py
@@ -32,5 +32,5 @@ def install_dependencies(dependencies):
         result['success'] = False
     else:
         result['success'] = True
-        
+
     return result


### PR DESCRIPTION
## Description

This PR fixes the issue where when the installation of dependencies fail for a particular integration, the /<handler_name>/install endpoint succeeds.

Fixes https://github.com/mindsdb/mindsdb/issues/8976

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas - N/A
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added.



