### PR TITLE
Adding functionality for multi-column ingestion into vector databases and skills

### DIFF
--- a/mindsdb/integrations/handlers/langchain_embedding_handler/langchain_embedding_handler.py
+++ b/mindsdb/integrations/handlers/langchain_embedding_handler/langchain_embedding_handler.py
@@ -161,7 +161,7 @@ class LangchainEmbeddingHandler(BaseMLEngine):
         embeddings = model.embed_documents(df_texts.tolist())
 
         # create a new dataframe with the embeddings
-        df_embeddings = df.copy().assign(**{target: embeddings})
+        df_embeddings = df.copy().assign(**{'embedding_context': df_texts, target: embeddings})
 
         return df_embeddings
 

--- a/mindsdb/integrations/libs/vectordatabase_handler.py
+++ b/mindsdb/integrations/libs/vectordatabase_handler.py
@@ -35,6 +35,7 @@ class TableField(Enum):
 
     ID = "id"
     CONTENT = "content"
+    CONTEXT = "embedding_context"
     EMBEDDINGS = "embeddings"
     METADATA = "metadata"
     SEARCH_VECTOR = "search_vector"
@@ -139,7 +140,7 @@ class VectorStoreHandler(BaseHandler):
         return set(columns).issubset(allowed_columns)
 
     def _is_condition_allowed(self, condition: FilterCondition) -> bool:
-        allowed_field_values = set([field.value for field in TableField])
+        allowed_field_values = set([field['name'] for field in self.SCHEMA])
         if condition.column in allowed_field_values:
             return True
         else:

--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -126,6 +126,12 @@ class KnowledgeBaseTable:
         df_emb = self._df_to_embeddings(df)
         df = pd.concat([df, df_emb], axis=1)
 
+        # drop original 'content' column and rename model's 'embedding_context' column to 'content'
+        df = df.drop(TableField.CONTENT.value, axis='columns')
+        df = df.rename(
+            columns={TableField.CONTEXT.value: TableField.CONTENT.value}
+        )
+
         # send to vector db
         db_handler = self._get_vector_db()
         db_handler.do_upsert(self._kb.vector_database_table, df)
@@ -185,7 +191,7 @@ class KnowledgeBaseTable:
             if target != TableField.EMBEDDINGS.value:
                 # adapt output for vectordb
                 df_out = df_out.rename(columns={target: TableField.EMBEDDINGS.value})
-            df_out = df_out[[TableField.EMBEDDINGS.value]]
+            df_out = df_out[[TableField.CONTEXT.value, TableField.EMBEDDINGS.value]]
 
         return df_out
 


### PR DESCRIPTION
## Description

Current vector database and knowledge base implementation does not allow for multi-column insertion, even though the `langchain_embeddings` handler does support multi-column embedding. The `langchain_embeddings` handler concatentates the row entries as context for the embedding, but does not return this concatenation. Therefore, the actual context provided to the embedding model remains hidden. This PR explicitly returns the embedding context as the `embedding_context` column. 

The knowledge base insert statement is modified to handle the protected `embedding_context` column.

`embedding_context` is registered as a protected column name for the vector database integration. 

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ x] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

Tested locally on most up-to-date staging branch.

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



