### PR TITLE
create prometheus dir if it doesnt exist

### DIFF
--- a/.github/workflows/test_on_deploy.yml
+++ b/.github/workflows/test_on_deploy.yml
@@ -52,8 +52,6 @@ jobs:
 
         if [ "$RUNNER_OS" == "Linux" ]; then
 
-          mkdir prometheus_metrics
-
           pytest -vx tests/integration_tests/flows/test_ml_task_queue.py
 
           # MySQL API

--- a/docker/mindsdb.Dockerfile
+++ b/docker/mindsdb.Dockerfile
@@ -9,9 +9,6 @@ RUN --mount=target=/var/lib/apt,type=cache,sharing=locked \
     && apt-get install -y freetds-dev  # freetds required to build pymssql for mssql_handler
 
 WORKDIR /mindsdb
-# Have to make sure we have a clean metrics dir.
-RUN mkdir prometheus_metrics
-
 
 # Copy just requirements and install them to cache the layer
 # This won't include any of the default handlers, but it should still speed things up
@@ -44,7 +41,6 @@ RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements/requi
 COPY docker/mindsdb_config.release.json /root/mindsdb_config.json
 
 ENV PYTHONUNBUFFERED=1
-ENV PROMETHEUS_MULTIPROC_DIR="./prometheus_metrics"
 
 EXPOSE 47334/tcp
 EXPOSE 47335/tcp
@@ -67,7 +63,6 @@ COPY --link --from=extras /usr/local/lib/python3.10/site-packages /usr/local/lib
 COPY docker/mindsdb_config.release.json /root/mindsdb_config.json
 
 ENV PYTHONUNBUFFERED=1
-ENV PROMETHEUS_MULTIPROC_DIR="./prometheus_metrics"
 
 EXPOSE 47334/tcp
 EXPOSE 47335/tcp

--- a/mindsdb/metrics/server.py
+++ b/mindsdb/metrics/server.py
@@ -12,7 +12,7 @@ logger = log.getLogger(__name__)
 def init_metrics(app: Flask):
     prometheus_dir = os.environ.get('PROMETHEUS_MULTIPROC_DIR', None)
     if prometheus_dir is None:
-        logger.warning('PROMETHEUS_MULTIPROC_DIR environment variable is not set and is needed for metrics server.')
+        logger.info("PROMETHEUS_MULTIPROC_DIR environment variable is not set. Metrics server won't be started.")
         return
     elif not os.path.isdir(prometheus_dir):
         os.makedirs(prometheus_dir)

--- a/mindsdb/metrics/server.py
+++ b/mindsdb/metrics/server.py
@@ -10,9 +10,12 @@ logger = log.getLogger(__name__)
 
 
 def init_metrics(app: Flask):
-    if os.environ.get('PROMETHEUS_MULTIPROC_DIR', None) is None:
+    prometheus_dir = os.environ.get('PROMETHEUS_MULTIPROC_DIR', None)
+    if prometheus_dir is None:
         logger.warning('PROMETHEUS_MULTIPROC_DIR environment variable is not set and is needed for metrics server.')
         return
+    elif not os.path.isdir(prometheus_dir):
+        os.makedirs(prometheus_dir)
     # See: https://prometheus.github.io/client_python/multiprocess/
     registry = CollectorRegistry()
     multiprocess.MultiProcessCollector(registry)


### PR DESCRIPTION
- Create prometheus dir if `PROMETHEUS_MULTIPROC_DIR` is set, but the dir doesnt exist
- Remove `PROMETHEUS_MULTIPROC_DIR` from the dockerfile as the average user won't use prometheus
- Make log message `info` as it is not an issue for normal users.
- Remove `mkdir prometheus_metrics` from test script