### PR TITLE
Fixed Column Structure of chat_messages Table

### DIFF
--- a/mindsdb/integrations/handlers/ms_teams_handler/ms_teams_tables.py
+++ b/mindsdb/integrations/handlers/ms_teams_handler/ms_teams_tables.py
@@ -220,32 +220,38 @@ class ChatMessagesTable(APITable):
 
         # if both chat_id and message_id are given, get the message with that id from the API
         if message_id and chat_id:
-            chat_message = api_client.get_chat_message(chat_id, message_id)
-            # add the missing eventDetail attribute to the chat message
-            chat_message['eventDetail'] = {
-                '@odata.type': None, 
-                'visibleHistoryStartDateTime': None, 
-                'members': None, 
-                'initiator': {
-                    'application': None, 
-                    'device': None, 
-                    'user': {
-                        '@odata.type': None, 
-                        'id': None,
-                        'displayName': None,
-                        'userIdentityType': None,
-                        'tenantId': None
-                    }
-                }
-            }
-
-            return [chat_message]
+            chat_messages = [api_client.get_chat_message(chat_id, message_id)]
         # if only the chat_id is given, get all the messages from that chat
         elif chat_id:
-            return api_client.get_chat_messages(chat_id)
+            chat_messages = api_client.get_chat_messages(chat_id)
         # if no parameters are given or only the message_id is given, get all the messages from all the chats
         else:
-            return api_client.get_all_chat_messages()
+            chat_messages = api_client.get_all_chat_messages()
+
+        # define the empty eventDetail attribute that is missing from the API response
+        eventDetail = {
+            '@odata.type': None, 
+            'visibleHistoryStartDateTime': None, 
+            'members': None, 
+            'initiator': {
+                'application': None, 
+                'device': None, 
+                'user': {
+                    '@odata.type': None, 
+                    'id': None,
+                    'displayName': None,
+                    'userIdentityType': None,
+                    'tenantId': None
+                }
+            }
+        }
+
+        # add the missing eventDetail attribute to the chat messages if it is missing
+        for chat_message in chat_messages:
+            if chat_message.get("eventDetail") is None:
+                chat_message['eventDetail'] = eventDetail
+
+        return chat_messages
 
     def insert(self, query: ast.Insert) -> None:
         """

--- a/mindsdb/integrations/handlers/ms_teams_handler/ms_teams_tables.py
+++ b/mindsdb/integrations/handlers/ms_teams_handler/ms_teams_tables.py
@@ -228,29 +228,6 @@ class ChatMessagesTable(APITable):
         else:
             chat_messages = api_client.get_all_chat_messages()
 
-        # define the empty eventDetail attribute that is missing from the API response
-        eventDetail = {
-            '@odata.type': None, 
-            'visibleHistoryStartDateTime': None, 
-            'members': None, 
-            'initiator': {
-                'application': None, 
-                'device': None, 
-                'user': {
-                    '@odata.type': None, 
-                    'id': None,
-                    'displayName': None,
-                    'userIdentityType': None,
-                    'tenantId': None
-                }
-            }
-        }
-
-        # add the missing eventDetail attribute to the chat messages if it is missing
-        for chat_message in chat_messages:
-            if chat_message.get("eventDetail") is None:
-                chat_message['eventDetail'] = eventDetail
-
         return chat_messages
 
     def insert(self, query: ast.Insert) -> None:

--- a/mindsdb/integrations/handlers/ms_teams_handler/settings.py
+++ b/mindsdb/integrations/handlers/ms_teams_handler/settings.py
@@ -87,17 +87,7 @@ class MSTeamsHandlerConfig(BaseSettings):
         "from_user_userIdentityType",
         "from_user_tenantId",
         "body_contentType",
-        "body_content",
-        "eventDetail_@odata.type",
-        "eventDetail_visibleHistoryStartDateTime",
-        "eventDetail_members",
-        "eventDetail_initiator_application",
-        "eventDetail_initiator_device",
-        "eventDetail_initiator_user_@odata.type",
-        "eventDetail_initiator_user_id",
-        "eventDetail_initiator_user_displayName",
-        "eventDetail_initiator_user_userIdentityType",
-        "eventDetail_initiator_user_tenantId",
+        "body_content"
     ]
 
     CHANNELS_TABLE_COLUMNS: List = [


### PR DESCRIPTION
## Description

This PR fixes running `SELECT` statements on the `chat_messages` table by removing the dependency on the `eventDetails` attribute.

Fixes https://github.com/mindsdb/mindsdb/issues/9014

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [X]   Test Location: https://github.com/mindsdb/mindsdb/blob/bugfix/ms_teams_event_details/tests/handler_tests/test_ms_teams_handler.py
 - [X]   Verification Steps: Run the test module indicated above.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A.
- [X] Relevant unit and integration tests are updated or added.



