### PR TITLE
Fix delete from table in database

### DIFF
--- a/mindsdb/api/executor/command_executor.py
+++ b/mindsdb/api/executor/command_executor.py
@@ -80,7 +80,6 @@ from mindsdb.api.mysql.mysql_proxy.libs.constants.mysql import (
 from .exceptions import (
     ExecutorException,
     BadDbError,
-    BadTableError,
     NotSupportedYet,
     WrongArgumentError,
     TableNotExistError,
@@ -611,13 +610,6 @@ class ExecuteCommands:
         elif type(statement) is Delete:
             if statement.table.parts[-1].lower() == "models_versions":
                 return self.answer_delete_model_version(statement, database_name)
-            if (
-                database_name != "mindsdb"
-                and statement.table.parts[0] != "mindsdb"
-            ):
-                raise BadTableError(
-                    "Only 'DELETE' from database 'mindsdb' is possible at this moment"
-                )
 
             SQLQuery(statement, session=self.session, execute=True, database=database_name)
             return ExecuteAnswer(ANSWER_TYPE.OK)

--- a/tests/unit/test_project_structure.py
+++ b/tests/unit/test_project_structure.py
@@ -921,6 +921,14 @@ class TestProjectStructure(BaseExecutorDummyML):
 
             self.run_sql(f'show {item}')
 
+    def test_delete_from_table(self):
+        df1 = pd.DataFrame([
+            {'a': 1}
+        ])
+        self.set_data('tbl1', df1)
+
+        self.run_sql('delete from tbl1 where a=1', database='dummy_data')
+
 
 class TestJobs(BaseExecutorDummyML):
 


### PR DESCRIPTION
## Description

Fix delete from table of active database:
```sql
use my_db;

delete from my_table where a=1
```

Also related to https://github.com/mindsdb/mindsdb_sql/pull/369

Fixes #8029

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



