### PR TITLE
Added Check for Import Errors When Running CREATE MODEL Statement

### DIFF
--- a/mindsdb/integrations/libs/ml_handler_process/learn_process.py
+++ b/mindsdb/integrations/libs/ml_handler_process/learn_process.py
@@ -82,6 +82,7 @@ def learn_process(data_integration_ref: dict, problem_definition: dict, fetch_da
 
             module = importlib.import_module(module_path)
 
+            # check if module is imported successfully and raise exception if not
             if module.import_error is not None:
                 raise module.import_error
 

--- a/mindsdb/integrations/libs/ml_handler_process/learn_process.py
+++ b/mindsdb/integrations/libs/ml_handler_process/learn_process.py
@@ -82,6 +82,9 @@ def learn_process(data_integration_ref: dict, problem_definition: dict, fetch_da
 
             module = importlib.import_module(module_path)
 
+            if module.import_error is not None:
+                raise module.import_error
+
             handlerStorage = HandlerStorage(integration_id)
             modelStorage = ModelStorage(model_id)
             modelStorage.fileStorage.push()     # FIXME


### PR DESCRIPTION
## Description

This PR adds a check for import errors when running CREATE MODEL statements and raises the relevant error. This is to avoid the `TypeError: 'NoneType' object is not callable` error being logged when running such statement typically fail.

Fixes https://github.com/mindsdb/mindsdb/issues/9018

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

With this fix, the errors raised are now more precise and informative as shown below,

![image](https://github.com/mindsdb/mindsdb/assets/49385643/84ea30b5-ce44-41a5-a424-21404a082b40)

Note: I have introduced this error to the RAG handler temporarily for demonstration purposes.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A.
- [ ] Relevant unit and integration tests are updated or added.



