### PR TITLE
Fixed Installation of Dependencies for Integrations That Refer to Other requirements.txt Files

### DIFF
--- a/mindsdb/integrations/utilities/install.py
+++ b/mindsdb/integrations/utilities/install.py
@@ -9,9 +9,19 @@ def install_dependencies(dependencies):
         'success': False,
         'error_message': None
     }
+
+    split_dependencies = []
+    for dependency in dependencies:
+        # check if the dependency is a path to a requirements file
+        if dependency.startswith('-r'):
+            # split the string into '-r' and the path
+            split_dependencies.extend(dependency.split(' '))
+        else:
+            split_dependencies.append(dependency)
+
     try:
         sp = subprocess.Popen(
-            [sys.executable, '-m', 'pip', 'install', *dependencies],
+            [sys.executable, '-m', 'pip', 'install', *split_dependencies],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         )


### PR DESCRIPTION
## Description

This PR fixes the installation of dependencies for integrations that refer to the `requirements.txt` file of another integration.

Fixes https://github.com/mindsdb/mindsdb/issues/9021

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

Installation of dependencies now run successfully (as opposed to the failures that have been displayed in the issue),
![image](https://github.com/mindsdb/mindsdb/assets/49385643/71455e76-ed73-4ed2-9db5-6696dcdf5dca)

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A.
- [ ] Relevant unit and integration tests are updated or added.



