### PR TITLE
Make alembic use mindsdb log level

### DIFF
--- a/mindsdb/utilities/log.py
+++ b/mindsdb/utilities/log.py
@@ -56,7 +56,7 @@ def configure_logging():
                 "level": mindsdb_level,
             },
             "alembic": {
-                "level": logging.DEBUG,
+                "level": mindsdb_level,
             },
         },
     )


### PR DESCRIPTION
Alembic is currently set to output debug logs which doubles up on alembic output. We can use the mindsdb log level and `info` log output will still list migrations being run.

Before:
<img width="959" alt="image" src="https://github.com/mindsdb/mindsdb/assets/895845/21433f05-8b7b-42f9-982b-dba10b7c529f">


After:
![image](https://github.com/mindsdb/mindsdb/assets/895845/869a24ad-ff24-4563-9539-4b294be73fb3)

Fixes #8488
