### PR TITLE
Fixed the Initializer for the EventStoreDB Integrations

### DIFF
--- a/mindsdb/integrations/handlers/eventstoredb_handler/__init__.py
+++ b/mindsdb/integrations/handlers/eventstoredb_handler/__init__.py
@@ -1,7 +1,14 @@
 from mindsdb.integrations.libs.const import HANDLER_TYPE
 
-from .eventstoredb_handler import EventStoreDB as Handler
-from .__about__ import __version__ as version
+from .__about__ import __version__ as version, __description__ as description
+
+try:
+    from .eventstoredb_handler import EventStoreDB as Handler
+
+    import_error = None
+except Exception as e:
+    Handler = None
+    import_error = e
 
 title = 'EventStoreDB'
 name = 'eventstoredb'
@@ -9,5 +16,12 @@ type = HANDLER_TYPE.DATA
 icon_path = 'icon.svg'
 
 __all__ = [
-    'Handler', 'version', 'name', 'type', 'title', 'icon_path'
+    'Handler',
+    'version',
+    'name',
+    'type',
+    'title',
+    'description',
+    'import_error',
+    'icon_path'
 ]


### PR DESCRIPTION
## Description

This PR fixes the `__init__` for the EventStoreDB handler by including error handling and some missing attributes. The lack of error handling is the reason this integration is not visible in the 'Manage Integrations' page as mentioned in the issue given below.

Fixes https://github.com/mindsdb/mindsdb_private/issues/468

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added - N/A



