### PR TITLE
Fixed Installation of Dependencies for Integrations That Refer to requirements.txt Files (Docker-supported)

### DIFF
--- a/mindsdb/integrations/utilities/install.py
+++ b/mindsdb/integrations/utilities/install.py
@@ -52,7 +52,6 @@ def install_dependencies(dependencies):
                 output = output + '\n'
             output = output + 'Errors: ' + errs.decode()
         result['error_message'] = output
-        result['success'] = False
     else:
         result['success'] = True
 

--- a/mindsdb/integrations/utilities/install.py
+++ b/mindsdb/integrations/utilities/install.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import subprocess
 
@@ -10,12 +11,24 @@ def install_dependencies(dependencies):
         'error_message': None
     }
 
+    # get the path to this script
+    script_path = os.path.dirname(os.path.realpath(__file__))
     split_dependencies = []
     for dependency in dependencies:
         # check if the dependency is a path to a requirements file
         if dependency.startswith('-r'):
             # split the string into '-r' and the path
-            split_dependencies.extend(dependency.split(' '))
+            r_flag, req_path = dependency.split(' ')
+            # create the absolute path to the requirements file
+            abs_req_path = os.path.abspath(os.path.join(script_path, req_path.replace('mindsdb/integrations', '..')))
+
+            # check if the file exists
+            if os.path.exists(abs_req_path):
+                split_dependencies.append(r_flag)
+                split_dependencies.append(abs_req_path)
+            else:
+                raise FileNotFoundError(f"Requirements file not found: {req_path}")
+
         else:
             split_dependencies.append(dependency)
 


### PR DESCRIPTION
## Description

This PR fixes the installation of dependencies for integrations that refer to the requirements.txt file of another integration. The fix that was made [here](https://github.com/mindsdb/mindsdb/pull/9022) does not work when running via Docker, it only works locally. The reason for that is when building our Docker image, MindsDB is installed as a package and as such the absolute path of the requirements file needs to be accessed when installations are made.

Fixes https://github.com/mindsdb/mindsdb/issues/9021
Fixes https://github.com/mindsdb/mindsdb_private/issues/493
Fixes https://github.com/mindsdb/mindsdb_private/issues/492

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

Given below are screenshots of successfully installing dependencies for integrations (D0lt and Rockset) that refer to `requirements.txt` files of other integrations via Docker. This container was built locally using the changes that were made here. The install operation of the 'Manage Integrations' page uses the fixed code in order to install dependencies.

![Screenshot from 2024-04-05 14-11-56](https://github.com/mindsdb/mindsdb/assets/49385643/740dde7d-d0fd-4087-84d3-ec0a4c0889f4)

![Screenshot from 2024-04-05 14-11-39](https://github.com/mindsdb/mindsdb/assets/49385643/b88c580a-3ffd-450a-8199-b42ba623e7da)

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added.



