### PR TITLE
Fixed Installation of Dependencies When requirements.txt Files Contain Comments

### DIFF
--- a/mindsdb/integrations/utilities/install.py
+++ b/mindsdb/integrations/utilities/install.py
@@ -15,6 +15,10 @@ def install_dependencies(dependencies):
     script_path = os.path.dirname(os.path.realpath(__file__))
     split_dependencies = []
     for dependency in dependencies:
+        # ignore standalone comments
+        if dependency.startswith('#'):
+            continue
+        
         # check if the dependency is a path to a requirements file
         if dependency.startswith('-r'):
             # split the string into '-r' and the path

--- a/mindsdb/integrations/utilities/install.py
+++ b/mindsdb/integrations/utilities/install.py
@@ -18,7 +18,11 @@ def install_dependencies(dependencies):
         # ignore standalone comments
         if dependency.startswith('#'):
             continue
-        
+
+        # remove inline comments
+        if '#' in dependency:
+            dependency = dependency.split('#')[0].strip()
+
         # check if the dependency is a path to a requirements file
         if dependency.startswith('-r'):
             # split the string into '-r' and the path


### PR DESCRIPTION
## Description

This PR fixes the installation of dependencies for integrations that refer to `requirements.txt` files that contain comments. A good example is the RAG handler as illustrated in the issue given below.

Note that both standalone comments and inline comments have been handled in this fix.

Fixes https://github.com/mindsdb/mindsdb_private/issues/487

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

Given below are screenshots of successfully installing dependencies for the RAG intgration via Docker. This container was built locally using the changes that were made here. The install operation of the 'Manage Integrations' page uses the fixed code in order to install dependencies.

![image](https://github.com/mindsdb/mindsdb/assets/49385643/a9ab10fc-9fd1-47db-ba42-4d1c26dbbafe)

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added.



