### PR TITLE
bump litellm version

### DIFF
--- a/mindsdb/integrations/handlers/langchain_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/langchain_handler/requirements.txt
@@ -4,5 +4,5 @@ tiktoken >= 0.3.0
 anthropic==0.3.5
 langchain-experimental  # Tools
 langfuse  # Tracing
-litellm==1.23.2
+litellm==1.35.0
 -r mindsdb/integrations/handlers/openai_handler/requirements.txt

--- a/mindsdb/integrations/handlers/litellm_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/litellm_handler/requirements.txt
@@ -1,1 +1,1 @@
-litellm
+litellm==1.35.0


### PR DESCRIPTION
## Description

This PR bumps the LiteLLM version to 1.35.0 to address a security issue.
- https://github.com/advisories/GHSA-46cm-pfwv-cgf8


## Type of change


- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [X] Necessary documentation updates are either made or tracked in issues.
- [X] Relevant unit and integration tests are updated or added.



