### PR TITLE
Allow 'sql' skill name instead of just 'text_to_sql' for Agents

### DIFF
--- a/mindsdb/interfaces/skills/skill_tool.py
+++ b/mindsdb/interfaces/skills/skill_tool.py
@@ -111,7 +111,7 @@ class SkillToolController:
             dict with keys: name, description, func
         """
 
-        if skill.type == 'text_to_sql':
+        if skill.type == 'text_to_sql' or skill.type == 'sql':
             return self._make_text_to_sql_tools(skill)
         elif skill.type == 'knowledge_base':
             return self._make_knowledge_base_tools(skill)


### PR DESCRIPTION
## Description

This simplifies skill creation by changing the name from `text_to_sql` to simply `sql`. Related to this PR: https://github.com/mindsdb/mindsdb_python_sdk/pull/96

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


