### PR TITLE
Remove prometheus dir from dockerfile

### DIFF
--- a/docker/mindsdb.Dockerfile
+++ b/docker/mindsdb.Dockerfile
@@ -41,9 +41,8 @@ RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements/requi
 COPY docker/mindsdb_config.release.json /root/mindsdb_config.json
 
 
-ENV PYTHONUNBUFFERED=1
+ENV PYTHONUNBUFFERED 1
 ENV MINDSDB_DOCKER_ENV 1
-ENV PROMETHEUS_MULTIPROC_DIR="./prometheus_metrics"
 
 EXPOSE 47334/tcp
 EXPOSE 47335/tcp
@@ -65,9 +64,8 @@ RUN --mount=target=/var/lib/apt,type=cache,sharing=locked \
 COPY --link --from=extras /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
 COPY docker/mindsdb_config.release.json /root/mindsdb_config.json
 
-ENV PYTHONUNBUFFERED=1
+ENV PYTHONUNBUFFERED 1
 ENV MINDSDB_DOCKER_ENV 1
-ENV PROMETHEUS_MULTIPROC_DIR="./prometheus_metrics"
 
 EXPOSE 47334/tcp
 EXPOSE 47335/tcp


### PR DESCRIPTION
The average user won't need to run prometheus metrics so I don't think it should be enabled by default.

The removed env-var is still set in our deployments where we want metrics to be active.