### PR TITLE
Fix  REST API Endpoints URL

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -11,7 +11,7 @@ info:
     name: GNU General Public License v3.0
     url: 'https://github.com/mindsdb/mindsdb/blob/staging/LICENSE'
 servers:
-  - url: 'http://127.0.0.1:47334/v1/api'
+  - url: 'http://127.0.0.1:47334/'
     description: MindsDB local deployments
 components:
   schemas:


### PR DESCRIPTION
## Description

This PR removes obsolete `v1/api` from the REST API Endpoints URL.

Fixes #9107 

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [X] 📄 This change is a documentation update
