### PR TITLE
Update Avaiability of handlers

### DIFF
--- a/default_handlers.txt
+++ b/default_handlers.txt
@@ -15,3 +15,4 @@ statsforecast
 timegpt
 binance
 twitter
+mindsdb_inference

--- a/default_handlers.txt
+++ b/default_handlers.txt
@@ -4,7 +4,7 @@ mysql
 mariadb
 scylla
 cassandra
-# clickhouse
+clickhouse
 # snowflake
 slack
 sqlite

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -91,7 +91,7 @@ target "images" {
       },
       {
         name = "cloud"
-        extras = ".[lightwood,huggingface,statsforecast-extra,neuralforecast-extra,timegpt,surrealdb,mssql,youtube,ignite,gmail,pgvector,llama_index,writer,rag,github,snowflake,clickhouse,couchbase,twelve_labs,bigquery] darts datasetsforecast"
+        extras = ".[lightwood,huggingface,statsforecast-extra,neuralforecast-extra,timegpt,mssql,youtube,gmail,pgvector,llama_index,writer,rag,github,snowflake,clickhouse,twelve_labs,bigquery] darts datasetsforecast"
         target = ""
       },
     ]


### PR DESCRIPTION
## Description

This PR adds mindsdb_inference and clickhouse to default handlers. ClickHouse was removed due to dependencies issues, which are now resolved.
Also, surreal, ignite, and couchbase are removed from the cloud until we verify them.


## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update



