### PR TITLE
Mongo shell: describe model error shows right command

### DIFF
--- a/docs/sdks/mongo/models/describe.mdx
+++ b/docs/sdks/mongo/models/describe.mdx
@@ -3,12 +3,12 @@ title: Describe a Model
 sidebarTitle: Describe a Model
 ---
 
-The `stats()` method is used to display the attributes of an existing model. It accepts the `{scale: "attribute"}` object as an argument.
+The `describe` command is used to display the attributes of an existing model. It accepts the name of the model and describe attribute separated by '.' as an argument.
 
-Here is how to call the `stats()` method:
+Here is how to call the `describe` command:
 
-```sql
-db.predictor_name.stats({scale: "attribute"});
+```javascript
+db.runCommand({describe: "predictor_name.attribute"})
 ```
 
 Where:
@@ -16,21 +16,21 @@ Where:
 | Name                   | Description                                                                                                                                   |
 | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `predictor_name`       | The name of the predictor whose statistics you want to see.                                                                                   |
-| `{scale: "attribute"}` | The argument of the `stats()` method defines the type of statistics (`{scale: "features"}`, or `{scale: "model"}`, or `{scale: "ensemble"}`). |
+| `attribute` | The argument of the `describe` command defines the type of statistics (`features`, or `model`, or `ensemble`). |
 
-## The `stats()` Method with the `{scale: "features"}` Parameter
+## The `describe` Command with the `features` Parameter
 
 ### Description
 
-The `db.predictor_name.stats({scale: "features"})` method is used to display the
+The `db.runCommand({describe: "predictor_name.features"})` command is used to display the
 way the model encoded the data before training.
 
 ### Syntax
 
 Here is the syntax:
 
-```sql
-db.predictor_name.stats({scale: "features"});
+```javascript
+db.runCommand({describe: "predictor_name.features"})
 ```
 
 On execution, we get:
@@ -61,8 +61,8 @@ Where:
 
 Let's describe the `home_rentals_model` model.
 
-```sql
-db.home_rentals_model.stats({scale: "features"});
+```javascript
+db.runCommand({describe: "home_rentals_model.features"})
 ```
 
 On execution, we get:
@@ -123,11 +123,11 @@ On execution, we get:
 }
 ```
 
-## The `stats()` Method with the `{scale: "model"}` Parameter
+## The `describe` Command with the `model` Parameter
 
 ### Description
 
-The `db.predictor_name.stats({scale: "model"})` method is used to display the
+The `db.runCommand({describe: "predictor_name.model"})` method is used to display the
 performance of the candidate models.
 
 ### Syntax
@@ -135,7 +135,7 @@ performance of the candidate models.
 Here is the syntax:
 
 ```sql
-db.predictor_name.stats({scale: "model"});
+db.runCommand({describe: "predictor_name.model"})
 ```
 
 On execution, we get:
@@ -166,8 +166,8 @@ Where:
 
 Let's see the output for the `home_rentals_model` model.
 
-```sql
-db.home_rentals_model.stats({scale: "model"});
+```javascript
+db.runCommand({describe: "home_rentals_model.model"})
 ```
 
 On execution, we get:
@@ -198,11 +198,11 @@ On execution, we get:
 }
 ```
 
-## The `stats()` Method with the `{scale: "ensemble"}` Parameter
+## The `describe` Command with the `ensemble` Parameter
 
 ### Description
 
-The `db.predictor_name.stats({scale: "ensemble"})` method is used to display the
+The `db.runCommand({describe: "predictor_name.ensemble"})` command is used to display the
 parameters used to select the best candidate model.
 
 ### Syntax
@@ -210,7 +210,7 @@ parameters used to select the best candidate model.
 Here is the syntax:
 
 ```sql
-db.predictor_name.stats({scale: "ensemble"});
+db.runCommand({describe: "predictor_name.ensemble"})
 ```
 
 On execution, we get:

--- a/mindsdb/api/mongo/README.md
+++ b/mindsdb/api/mongo/README.md
@@ -301,11 +301,10 @@ https://docs.mindsdb.com/sql/api/describe/
 
 How to call it from mongo
 ```
-db.sales_model.stats({'scale':'features'})
-db.sales_model.stats({'scale':'model'})
-db.sales_model.stats({'scale':'ensemble'})
+db.runCommand({describe: "sales_model.features"})
+db.runCommand({describe: "sales_model.ensemble"})
+db.runCommand({describe: "sales_model.model"})
 ```
-
 
 ## Delete models 
 ```

--- a/mindsdb/api/mongo/responders/__init__.py
+++ b/mindsdb/api/mongo/responders/__init__.py
@@ -26,6 +26,7 @@ from .list_databases import responder as responder_list_databases
 from .find import responder as responder_find
 from .insert import responder as responder_insert
 from .delete import responder as responder_delete
+from .describe import responder as responder_describe
 
 from .sasl_start import responder as sasl_start
 from .sasl_continue import responder as sasl_continue
@@ -63,6 +64,7 @@ responders = [
     responder_find,
     responder_insert,
     responder_delete,
+    responder_describe,
     # auth
     sasl_start,
     sasl_continue,

--- a/mindsdb/api/mongo/responders/aggregate.py
+++ b/mindsdb/api/mongo/responders/aggregate.py
@@ -68,9 +68,9 @@ class Responce(Responder):
             data = run_sql_command(request_env, ast_query)
 
         elif '$collStats' in first_step:
-            raise NotImplementedError(
+            raise ValueError(
                 "To describe model use:"
-                " db.runCommand( { collStats: 'model_name', scale: 'describe_type'})"
+                " db.runCommand({describe: 'model_name.attribute'})"
             )
 
         else:

--- a/mindsdb/api/mongo/responders/aggregate.py
+++ b/mindsdb/api/mongo/responders/aggregate.py
@@ -61,9 +61,20 @@ class Responce(Responder):
         db = query['$db']
         collection = query['aggregate']
 
-        ast_query = aggregate_to_ast(query, request_env.get('database', 'mindsdb'))
+        first_step = query['pipeline'][0]
+        if '$match' in first_step:
+            ast_query = aggregate_to_ast(query, request_env.get('database', 'mindsdb'))
 
-        data = run_sql_command(request_env, ast_query)
+            data = run_sql_command(request_env, ast_query)
+
+        elif '$collStats' in first_step:
+            raise NotImplementedError(
+                "To describe model use:"
+                " db.runCommand( { collStats: 'model_name', scale: 'describe_type'})"
+            )
+
+        else:
+            raise NotImplementedError
 
         cursor = {
             'id': Int64(0),

--- a/mindsdb/api/mongo/responders/describe.py
+++ b/mindsdb/api/mongo/responders/describe.py
@@ -1,0 +1,24 @@
+from mindsdb_sql.parser.ast import Describe, Identifier
+
+from mindsdb.api.mongo.classes import Responder
+import mindsdb.api.mongo.functions as helpers
+from mindsdb.api.mongo.classes.query_sql import run_sql_command
+
+
+class Responce(Responder):
+    when = {'describe': helpers.is_true}
+
+    def result(self, query, request_env, mindsdb_env, session):
+        db = query['$db']
+        model = query['describe']
+
+        ast_query = Describe(Identifier(model))
+
+        data = run_sql_command(request_env, ast_query)
+        res = {'data': data, 'ns': f"{db}.{model}"}
+
+        return res
+
+
+responder = Responce()
+

--- a/mindsdb/api/mongo/responders/describe.py
+++ b/mindsdb/api/mongo/responders/describe.py
@@ -21,4 +21,3 @@ class Responce(Responder):
 
 
 responder = Responce()
-


### PR DESCRIPTION
## Description

When 'stat' function is used in [mongo shell](https://www.mongodb.com/docs/mongodb-shell/install/):
```python
> db.home_rentals_model.stats({'scale': 'features'})
```
It calls aggregate command on server with params:
```json
{  
  "aggregate": "home_rentals_model", 
  "pipeline": [
     { "$collStats":
        {"storageStats":
           {"scale": 1}
        }
     }
  ]
}
```
And this payload doesn't have info about type of description (in our case 'features')

In this PR error message to user is changed to show right command to get call describe:
In our example it is:
```javascript
db.runCommand({describe: "home_rentals_model.attribute"})
```



Fixes #7389

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



