### PR TITLE
Drop `semaphor` table

### DIFF
--- a/mindsdb/interfaces/storage/db.py
+++ b/mindsdb/interfaces/storage/db.py
@@ -124,21 +124,6 @@ class Json(types.TypeDecorator):
         return json.loads(value) if value is not None else None
 
 
-class Semaphor(Base):
-    __tablename__ = "semaphor"
-
-    id = Column(Integer, primary_key=True)
-    updated_at = Column(
-        DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now
-    )
-    created_at = Column(DateTime, default=datetime.datetime.now)
-    entity_type = Column("entity_type", String)
-    entity_id = Column("entity_id", Integer)
-    action = Column(String)
-    company_id = Column(Integer)
-    __table_args__ = (UniqueConstraint("entity_type", "entity_id", name="uniq_const"),)
-
-
 class PREDICTOR_STATUS:
     __slots__ = ()
     COMPLETE = "complete"

--- a/mindsdb/migrations/versions/2024-04-25_2958416fbe75_drop_semaphor.py
+++ b/mindsdb/migrations/versions/2024-04-25_2958416fbe75_drop_semaphor.py
@@ -1,0 +1,36 @@
+"""drop-semaphor
+
+Revision ID: 2958416fbe75
+Revises: 9461892bd889
+Create Date: 2024-04-25 18:30:54.051212
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import mindsdb.interfaces.storage.db  # noqa
+
+
+# revision identifiers, used by Alembic.
+revision = '2958416fbe75'
+down_revision = '9461892bd889'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_table('semaphor')
+
+
+def downgrade():
+    op.create_table(
+        'semaphor',
+        sa.Column('id', sa.INTEGER(), nullable=False),
+        sa.Column('updated_at', sa.DATETIME(), nullable=True),
+        sa.Column('created_at', sa.DATETIME(), nullable=True),
+        sa.Column('entity_type', sa.VARCHAR(), nullable=True),
+        sa.Column('entity_id', sa.INTEGER(), nullable=True),
+        sa.Column('action', sa.VARCHAR(), nullable=True),
+        sa.Column('company_id', sa.INTEGER(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('entity_type', 'entity_id', name='uniq_const')
+    )


### PR DESCRIPTION
## Description

The `semaphore` table has not been used for a long time and can be safely dropped.

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



