### PR TITLE
Chromadb: sync handler storage on rw operations

### DIFF
--- a/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
@@ -103,13 +103,16 @@ class ChromaDBHandler(VectorStoreHandler):
                 port=client_config["chroma_server_http_port"],
             )
 
+    def _sync(self):
+        # if handler storage is used: sync on every change write operation
+        if self.persist_directory:
+            self.handler_storage.folder_sync(self.persist_directory)
+
     def __del__(self):
         """Close the database connection."""
 
         if self.is_connected is True:
-            if self.persist_directory:
-                # sync folder to handler storage
-                self.handler_storage.folder_sync(self.persist_directory)
+            self._sync()
 
             self.disconnect()
 
@@ -341,6 +344,7 @@ class ChromaDBHandler(VectorStoreHandler):
             embeddings=data[TableField.EMBEDDINGS.value],
             metadatas=data.get(TableField.METADATA.value),
         )
+        self._sync()
 
     def upsert(self, table_name: str, data: pd.DataFrame):
         return self.insert(table_name, data)
@@ -368,6 +372,7 @@ class ChromaDBHandler(VectorStoreHandler):
             embeddings=data[TableField.EMBEDDINGS.value],
             metadatas=data.get(TableField.METADATA.value),
         )
+        self._sync()
 
     def delete(
         self, table_name: str, conditions: List[FilterCondition] = None
@@ -384,12 +389,14 @@ class ChromaDBHandler(VectorStoreHandler):
             raise Exception("Delete query must have at least one condition!")
         collection = self._client.get_collection(table_name)
         collection.delete(ids=id_filters, where=filters)
+        self._sync()
 
     def create_table(self, table_name: str, if_not_exists=True):
         """
         Create a collection with the given name in the ChromaDB database.
         """
         self._client.create_collection(table_name, get_or_create=if_not_exists)
+        self._sync()
 
     def drop_table(self, table_name: str, if_exists=True):
         """
@@ -397,6 +404,7 @@ class ChromaDBHandler(VectorStoreHandler):
         """
         try:
             self._client.delete_collection(table_name)
+            self._sync()
         except ValueError:
             if if_exists:
                 return


### PR DESCRIPTION
## Description

In come cases update handler storage is not copied from 'content' to 'storage' folder. It leads to error in knowledge base, for example:
- Collection default_collection does not exist


Fixes #9023

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



