### PR TITLE
Moved the File Splitter Imports to the Function They are Used in

### DIFF
--- a/mindsdb/api/http/namespaces/knowledge_bases.py
+++ b/mindsdb/api/http/namespaces/knowledge_bases.py
@@ -12,7 +12,6 @@ from mindsdb.api.http.utils import http_error
 from mindsdb.metrics.metrics import api_endpoint_metrics
 from mindsdb.integrations.handlers.langchain_embedding_handler import construct_model_from_args
 from mindsdb.integrations.handlers.web_handler.urlcrawl_helpers import get_all_websites
-from mindsdb.integrations.utilities.rag.splitters.file_splitter import FileSplitter, FileSplitterConfig
 from mindsdb.interfaces.database.projects import ProjectController
 from mindsdb.interfaces.file.file_controller import FileController
 from mindsdb.integrations.utilities.rag.loaders.file_loader import FileLoader
@@ -29,6 +28,8 @@ _DEFAULT_MARKDOWN_HEADERS_TO_SPLIT_ON = [
 
 
 def _insert_file_into_knowledge_base(table: KnowledgeBaseTable, file_name: str, embeddings_provider: str):
+    from mindsdb.integrations.utilities.rag.splitters.file_splitter import FileSplitter, FileSplitterConfig
+    
     file_controller = FileController()
     splitter = FileSplitter(FileSplitterConfig(embeddings=construct_model_from_args({'class': embeddings_provider})))
     file_path = file_controller.get_file_path(file_name)

--- a/mindsdb/api/http/namespaces/knowledge_bases.py
+++ b/mindsdb/api/http/namespaces/knowledge_bases.py
@@ -28,6 +28,7 @@ _DEFAULT_MARKDOWN_HEADERS_TO_SPLIT_ON = [
 
 
 def _insert_file_into_knowledge_base(table: KnowledgeBaseTable, file_name: str, embeddings_provider: str):
+    # import here to prevent the need to set OPENAI_API_KEY
     from mindsdb.integrations.utilities.rag.splitters.file_splitter import FileSplitter, FileSplitterConfig
     
     file_controller = FileController()

--- a/mindsdb/api/http/namespaces/knowledge_bases.py
+++ b/mindsdb/api/http/namespaces/knowledge_bases.py
@@ -30,7 +30,7 @@ _DEFAULT_MARKDOWN_HEADERS_TO_SPLIT_ON = [
 def _insert_file_into_knowledge_base(table: KnowledgeBaseTable, file_name: str, embeddings_provider: str):
     # import here to prevent the need to set OPENAI_API_KEY
     from mindsdb.integrations.utilities.rag.splitters.file_splitter import FileSplitter, FileSplitterConfig
-    
+
     file_controller = FileController()
     splitter = FileSplitter(FileSplitterConfig(embeddings=construct_model_from_args({'class': embeddings_provider})))
     file_path = file_controller.get_file_path(file_name)


### PR DESCRIPTION
## Description

This PR moves the imports of the file splitter classes (`FileSplitter`, `FileSplitterConfig`) in the module where the API endpoints for Knowledge Bases are defined, to within the function which actually uses them.

Fixes https://github.com/mindsdb/mindsdb/issues/9161

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added.



