### PR TITLE
Model column map

### DIFF
--- a/mindsdb/api/executor/sql_query/steps/apply_predictor_step.py
+++ b/mindsdb/api/executor/sql_query/steps/apply_predictor_step.py
@@ -125,6 +125,19 @@ class ApplyPredictorStepCall(ApplyPredictorBaseCall):
 
         params = step.params or {}
 
+        # handle columns mapping to model
+        if step.columns_map is not None:
+            # columns_map = {str: Identifier}
+            for model_col, table_col in step.columns_map.items():
+                if len(table_col.parts) != 2:
+                    continue
+                table_name, col_name = table_col.parts
+                data_cols = data.find_columns(col_name, table_alias=table_name)
+                if len(data_cols) == 0:
+                    continue
+                # rename first found column
+                data_cols[0].alias = model_col
+
         for table in data.get_tables()[:1]:  # add  __mindsdb_row_id only for first table
             row_id_col = Column(
                 name='__mindsdb_row_id',

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -17,7 +17,7 @@ redis >=5.0.0, < 6.0.0
 walrus==0.9.3
 flask-compress >= 1.0.0
 appdirs >= 1.0.0
-mindsdb-sql ~= 0.14.0
+mindsdb-sql ~= 0.15.0
 pydantic >= 1.8.2
 mindsdb-evaluator >= 0.0.7, < 0.1.0
 checksumdir >= 1.2.0

--- a/tests/unit/dummy_ml_handler/dummy_ml_handler.py
+++ b/tests/unit/dummy_ml_handler/dummy_ml_handler.py
@@ -20,15 +20,22 @@ class DummyHandler(BaseMLEngine):
         df['predictor_id'] = self.model_storage.predictor_id
         df['row_id'] = self.model_storage.predictor_id * 100 + df.reset_index().index
 
+        output_columns = ['predicted', 'predictor_id', 'row_id', 'engine_args']
+
         if 'engine_args' in df.columns:
             # could exist from previous model
             df = df.drop('engine_args', axis=1)
             print(1)
         args = self.engine_storage.json_get('engine_args')
 
+        # check input
+        if 'input' in df.columns:
+            df['output'] = df['input']
+            output_columns.append('output')
+
         df.insert(len(df.columns), 'engine_args', [args] * len(df))
 
-        return df[['predicted', 'predictor_id', 'row_id', 'engine_args']]
+        return df[output_columns]
 
     def _get_model_verison(self):
         return self.model_storage._get_model_record(

--- a/tests/unit/test_project_structure.py
+++ b/tests/unit/test_project_structure.py
@@ -1116,6 +1116,34 @@ class TestJobs(BaseExecutorDummyML):
         ret = self.run_sql('select * from models where name="pred"')
         assert len(ret) == 1
 
+    def test_model_column_maping(self):
+        df = pd.DataFrame([
+            {'a': 10, 'c': 30},
+            {'a': 20, 'c': 40},
+        ])
+        self.set_data('tbl', df)
+
+        self.run_sql(
+            '''
+                CREATE model mindsdb.pred
+                PREDICT p
+                using engine='dummy_ml',
+                join_learn_process=true
+            '''
+        )
+        ret = self.run_sql('''
+            select * from dummy_data.tbl t
+            join pred m on m.input = t.a
+        ''')
+        assert ret['output'][0] == 10
+
+        # without aliases
+        ret = self.run_sql('''
+            select * from dummy_data.tbl
+            join pred on pred.input = tbl.c
+        ''')
+        assert ret['output'][0] == 30
+
     def test_schema(self, scheduler):
 
         # --- create objects + describe ---


### PR DESCRIPTION
## Description

Mapping columns to model in joins

In this example
```sql
select * from db.table1 t
join my_model m on t.a = m.x
```

If table1 has:
```
a | b | c 
---------
1 | 2 | 3 
```

Column 'a' will be renamed to 'x' and my_model will receive input:
```
x | b | c 
---------
1 | 2 | 3 
```


Fixes #4576
Dependent on https://github.com/mindsdb/mindsdb_sql/pull/375

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



