### PR TITLE
MindsDB Inference - Fixed Validation of API Keys on Model/Engine Creation

### DIFF
--- a/mindsdb/integrations/handlers/mindsdb_inference/mindsdb_inference_handler.py
+++ b/mindsdb/integrations/handlers/mindsdb_inference/mindsdb_inference_handler.py
@@ -47,10 +47,31 @@ class MindsDBInferenceHandler(OpenAIHandler):
                 raise Exception('Invalid api key')
             raise Exception(f'Something went wrong: {e}')
 
+    def create_engine(self, connection_args):
+        """
+        Validate the MindsDB Inference API credentials on engine creation.
+
+        Args:
+            connection_args (dict): Connection arguments.
+
+        Raises:
+            Exception: If the handler is not configured with valid API credentials.
+
+        Returns:
+            None
+        """
+        connection_args = {k.lower(): v for k, v in connection_args.items()}
+        api_key = connection_args.get('mindsdb_inference_api_key')
+        if api_key is not None:
+            org = connection_args.get('api_organization')
+            api_base = connection_args.get('api_base') or os.environ.get('MINDSDB_INFERENCE_BASE', mindsdb_inference_handler_config.BASE_URL)
+            client = self._get_client(api_key=api_key, base_url=api_base, org=org)
+            MindsDBInferenceHandler._check_client_connection(client)
+
     @staticmethod
     def create_validation(target, args=None, **kwargs):
         """
-        Validate the MindsDB Inference engine handler.
+        Validate the MindsDB Inference API credentials on model creation.
 
         Args:
             target (str): Target column, not required for LLMs.
@@ -58,7 +79,7 @@ class MindsDBInferenceHandler(OpenAIHandler):
             kwargs (dict): Handler keyword arguments.
 
         Raises:
-            AuthenticationError: If the handler is not properly configured.
+            Exception: If the handler is not configured with valid API credentials.
 
         Returns:
             None

--- a/tests/unit/ml_handlers/test_mindsdb_inference.py
+++ b/tests/unit/ml_handlers/test_mindsdb_inference.py
@@ -1,7 +1,6 @@
 import pandas
 import unittest
 from collections import OrderedDict
-from openai import AuthenticationError
 from unittest.mock import patch, MagicMock
 
 from mindsdb.integrations.handlers.mindsdb_inference.mindsdb_inference_handler import MindsDBInferenceHandler
@@ -42,7 +41,7 @@ class TestMindsDBInference(unittest.TestCase):
         Test if model creation raises an exception with an invalid API key.
         """
 
-        with self.assertRaises(AuthenticationError):
+        with self.assertRaises(Exception):
             self.handler.create_validation('target', args={"using": {}}, handler_storage=self.mock_engine_storage)
 
     @patch('mindsdb.integrations.handlers.openai_handler.openai_handler.OpenAI')


### PR DESCRIPTION
## Description

This PR updates the MindsDB Inference handler to validate API keys on engine/model creation.

Note: The logic applied the OpenAI handler for this validation does not work with the inference API because the LiteLLM Proxy does not implement the `/models/{model_name}` endpoint, which is called `models.retrieve()`.

Fixes https://github.com/mindsdb/mindsdb/issues/9160

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [X]   Test Location: `tests/unit/ml_handlers/test_mindsdb_inference.py` for unit tests and `mindsdb/integrations/handlers/mindsdb_inference/tests/test_mindsdb_inference_handler.py` for integration tests.
 - [X]   Verification Steps: Run the above test modules (for integration tests, a valid API key will need to be set to the `MDB_TEST_MDB_INFERENCE_API_KEY` env variable).

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

API keys will now be validated on engine/model creation and exceptions will be raised if they are invalid as shown below,

On engine creation:
![image](https://github.com/mindsdb/mindsdb/assets/49385643/87dc2b80-2818-4089-ad37-1c76d00c2ab8)

On model creation:
![image](https://github.com/mindsdb/mindsdb/assets/49385643/acd22e95-682e-4284-a323-40daf53da8b7)

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [X] Necessary documentation updates are either made or tracked in issues.
- [X] Relevant unit and integration tests are updated or added.