### PR TITLE
Improve caching of docker builds

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-TEST
+
 # Understanding the Diverse Licensing Structure of MindsDB's Repo
 
 1. MindsDB Core: The MindsDB Core component specifically uses the Elastic License 2.0. This is a distinct license that applies to this particular part of the project.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-
+TEST
 # Understanding the Diverse Licensing Structure of MindsDB's Repo
 
 1. MindsDB Core: The MindsDB Core component specifically uses the Elastic License 2.0. This is a distinct license that applies to this particular part of the project.

--- a/docker/mindsdb.Dockerfile
+++ b/docker/mindsdb.Dockerfile
@@ -1,7 +1,7 @@
 # This first stage produces a file structure with ONLY files required to run `pip install .`
 # We want to do this because we have a lot of dependencies which take a long time to install
 # So we avoid invalidating the cache of `pip install .` at all costs by ignoring every other file
-FROM python:3.10
+FROM python:3.10 as deps
 WORKDIR /mindsdb
 
 # Copy everything to begin with
@@ -31,7 +31,7 @@ RUN --mount=target=/var/lib/apt,type=cache,sharing=locked \
     && apt-get install -y freetds-dev  # freetds required to build pymssql on arm64 for mssql_handler. Can be removed when we are on python3.11+
 
 # Copy the requirements files, setup.py etc from above
-COPY --from=0 /mindsdb .
+COPY --from=deps /mindsdb .
 # Install all requirements for mindsdb and all the default handlers
 RUN --mount=type=cache,target=/root/.cache/pip pip install "."
 # Install extras on top of the bare mindsdb

--- a/docker/mindsdb.Dockerfile
+++ b/docker/mindsdb.Dockerfile
@@ -1,34 +1,55 @@
-# Bare mindsdb with no extras is built as a separate stage for caching
+# This first stage produces a file structure with ONLY files required to run `pip install .`
+# We want to do this because we have a lot of dependencies which take a long time to install
+# So we avoid invalidating the cache of `pip install .` at all costs by ignoring every other file
+FROM python:3.10
+WORKDIR /mindsdb
+
+# Copy everything to begin with
+COPY . .
+# Find every FILE that is not a requirements file and delete it
+RUN find ./ -type f -not -name "requirements*.txt" -print | xargs rm -f
+# Find every empty directory and delete them
+RUN find ./ -type d -empty -delete
+# Copy setup.py and everything else used by setup.py
+COPY setup.py default_handlers.txt README.md ./
+COPY mindsdb/__about__.py mindsdb/
+
+
+
+
+# This stage copies the structure left from the previous stage and runs `pip install .`
+# This long-running step should be cached in most cases (unless a requirements file or setup.py etc is changed)
 FROM python:3.10 as build
+WORKDIR /mindsdb
+
 # "rm ... docker-clean" stops docker from removing packages from our cache
 # https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#example-cache-apt-packages
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 RUN --mount=target=/var/lib/apt,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     apt update && apt-get upgrade -y \
-    && apt-get install -y freetds-dev  # freetds required to build pymssql for mssql_handler
+    && apt-get install -y freetds-dev  # freetds required to build pymssql on arm64 for mssql_handler. Can be removed when we are on python3.11+
 
-WORKDIR /mindsdb
+# Copy the requirements files, setup.py etc from above
+COPY --from=0 /mindsdb .
+# Install all requirements for mindsdb and all the default handlers
+RUN --mount=type=cache,target=/root/.cache/pip pip install "."
+# Install extras on top of the bare mindsdb
+RUN --mount=type=cache,target=/root/.cache/pip if [ -n "$EXTRAS" ]; then pip install $EXTRAS; fi
 
-# Copy just requirements and install them to cache the layer
-# This won't include any of the default handlers, but it should still speed things up
-COPY requirements/requirements.txt /mindsdb/requirements/requirements.txt
-RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements/requirements.txt
-
-
-# Now copy the rest of the code and install it
-COPY . /mindsdb
+# Copy all of the mindsdb code over finally
+COPY . .
+# Install the "mindsdb" package now that we have the code for it
 RUN --mount=type=cache,target=/root/.cache/pip pip install "."
 
 
-# Install extras on top of the bare mindsdb
-FROM build as extras
-ARG EXTRAS
-RUN --mount=type=cache,target=/root/.cache/pip if [ -n "$EXTRAS" ]; then pip install $EXTRAS; fi
 
 
-# For use in docker-compose
-FROM extras as dev
+# Same as build image, but with dev dependencies installed.
+# This image is used in our docker-compose
+FROM build as dev
+WORKDIR /mindsdb
+
 # "rm ... docker-clean" stops docker from removing packages from our cache
 # https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#example-cache-apt-packages
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
@@ -51,8 +72,13 @@ EXPOSE 47336/tcp
 ENTRYPOINT [ "sh", "-c", "python -m mindsdb --config=/root/mindsdb_config.json --api=http,mysql,mongodb" ]
 
 
-# Copy installed pip packages and install only what we need
+
+
+# This is the final image for most use-cases
+# Copies the installed pip packages from `build` and installs only what we need
 FROM python:3.10-slim
+WORKDIR /mindsdb
+
 # "rm ... docker-clean" stops docker from removing packages from our cache
 # https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#example-cache-apt-packages
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
@@ -61,7 +87,7 @@ RUN --mount=target=/var/lib/apt,type=cache,sharing=locked \
     apt update && apt-get upgrade -y \
     && apt-get install -y libmagic1 libpq5 freetds-bin
 
-COPY --link --from=extras /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
+COPY --link --from=build /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
 COPY docker/mindsdb_config.release.json /root/mindsdb_config.json
 
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
This change makes a large portion of the docker build time (pip installing all our requirements) be able to be cached more often.

Cache misses were happening when almost any file changed in the repo, and most requirements would have to be installed again without being cached.

In this PR we instead:
- create a layer containing *only* the files required to run `pip install .` (requirements files, `setup.py` etc).
- Copy files from this layer and run `pip install .` and `pip install .[<extras>]` (this will now only miss if a requirements file or `setup.py` etc have changed)
- *Now* copy the whole repo into the container and run `pip install .` again - this will only install MindsDB itself
- Continue with the build as before