### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.2"
 services:
 
   mindsdb:
-    image: mindsdb/mindsdb:dev
+    image: mindsdb/mindsdb:devel
     # If you want to build the image instead:
     # build:
     #   context: .


### PR DESCRIPTION
## Description

This PR updates the docker-compose file to use the `devel` tag instead of `dev` which was depricated.

Fixes #https://github.com/mindsdb/mindsdb/issues/9208

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update





