### PR TITLE
Upgrade Werkzeug to 2.3.8

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 packaging
-werkzeug==2.2.2
+werkzeug==2.3.8
 pandas >=2.0.0, <2.1.0
 flask-restx >= 1.0.1, < 2.0.0
 flask == 2.2.2


### PR DESCRIPTION
## Description

This PR upgrades Werkzeug to 2.3.8 version to fix https://github.com/mindsdb/mindsdb/security/dependabot/87. Note, we can't upgrade to the latest v3 due to required changes in Flask, then in Flask restx which is still not fully compatible https://github.com/python-restx/flask-restx?tab=readme-ov-file#on-flask-compatibility.

Fixes #https://github.com/mindsdb/mindsdb/security/dependabot/87

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update



