### PR TITLE
Fixed Auth Mechanism for ScyllaDB/Cassandra

### DIFF
--- a/docs/integrations/data-integrations/scylladb.mdx
+++ b/docs/integrations/data-integrations/scylladb.mdx
@@ -20,15 +20,15 @@ Before proceeding, ensure the following prerequisites are met:
 The ScyllaDB handler for MindsDB was developed using the scylla-driver library for Python.
 The required arguments to establish a connection are as follows:
 
-* `host`: Host name or IP address of ScyllaDB.
-* `port`: Connection port.
-* `user`: Authentication username.
-* `password`: Authentication password.
-* `keyspace`: The specific keyspace (top-level container for tables) to connect to.
-* `protocol_version`: Optional. Defaults to 4.
-* `secure_connect_bundle`: Optional. Needed only for connections to DataStax Astra.
+- `host`: Host name or IP address of ScyllaDB.
+- `port`: Connection port.
+- `user`: Authentication username. Optional; required only if authentication is enabled.
+- `password`: Authentication password. Optional; required only if authentication is enabled.
+- `keyspace`: The specific keyspace (top-level container for tables) to connect to.
+- `protocol_version`: Optional. Defaults to 4.
+- `secure_connect_bundle`: Optional. Needed only for connections to DataStax Astra.
 
-## Usage 
+## Usage
 
 To set up a connection between MindsDB and a Scylla server, utilize the following SQL syntax:
 
@@ -44,8 +44,11 @@ WITH
     "keyspace": "test_data"
   };
 ```
+
 <Tip>
-The protocol version is set to 4 by default. Should you wish to modify it, simply include "protocol_version": 5 within the PARAMETERS dictionary in the query above.
+  The protocol version is set to 4 by default. Should you wish to modify it,
+  simply include "protocol_version": 5 within the PARAMETERS dictionary in the
+  query above.
 </Tip>
 
 With the connection established, you can execute queries on your keyspace as demonstrated below:

--- a/mindsdb/integrations/handlers/cassandra_handler/README.md
+++ b/mindsdb/integrations/handlers/cassandra_handler/README.md
@@ -12,12 +12,12 @@ ScyllaDB is API-compatible with Apache Cassandra so this handler just extends th
 
 The required arguments to establish a connection are:
 
-* `host`: the host name or IP address of the Cassandra 
-* `port`: the port to use when connecting 
-* `user`: the user to authenticate 
-* `password`: the password to authenticate the user
-* `keyspace`: the keyspace to connect to(top level container for tables)
-* `protocol_version`: not required, default to 4
+- `host`: the host name or IP address of the Cassandra
+- `port`: the port to use when connecting
+- `user`: the user to authenticate. Optional; required only if authentication is enabled.
+- `password`: the password to authenticate the user. Optional; required only if authentication is enabled.
+- `keyspace`: the keyspace to connect to(top level container for tables)
+- `protocol_version`: not required, default to 4
 
 ## Usage
 

--- a/mindsdb/integrations/handlers/scylla_handler/README.md
+++ b/mindsdb/integrations/handlers/scylla_handler/README.md
@@ -11,13 +11,13 @@ ScyllaDB is an open-source distributed NoSQL wide-column data store. It was purp
 The ScyllaDB handler for MindsDB was developed using the scylla-driver library for Python.
 Connection Parameters:
 
-* host: Host name or IP address of ScyllaDB.
-* port: Connection port.
-* user: Authentication username.
-* password: Authentication password.
-* keyspace: The specific keyspace (top-level container for tables) to connect to.
-* protocol_version: Optional. Defaults to 4.
-* secure_connect_bundle: Optional. Needed only for connections to DataStax Astra.
+- host: Host name or IP address of ScyllaDB.
+- port: Connection port
+- user: Authentication username. Optional; required only if authentication is enabled.
+- password: Authentication password. Optional; required only if authentication is enabled.
+- keyspace: The specific keyspace (top-level container for tables) to connect to.
+- protocol_version: Optional. Defaults to 4.
+- secure_connect_bundle: Optional. Needed only for connections to DataStax Astra.
 
 ## Usage Guide
 
@@ -31,10 +31,11 @@ PARAMETERS={
   "user":"user@mindsdb.com",
   "password": "pass",
   "host": "127.0.0.1",
-  "port": "9042",
+  "port": 9042,
   "keyspace": "test_data"
 };
 ```
+
 > ℹ️ Tip: The protocol version is set to 4 by default. Should you wish to modify it, simply include "protocol_version": 5 within the PARAMETERS dictionary in the query above.
 
 ## Querying the Keyspace:

--- a/mindsdb/integrations/handlers/scylla_handler/scylla_handler.py
+++ b/mindsdb/integrations/handlers/scylla_handler/scylla_handler.py
@@ -71,9 +71,14 @@ class ScyllaHandler(DatabaseHandler):
         if self.is_connected is True:
             return self.session
 
-        auth_provider = PlainTextAuthProvider(
-            username=self.connection_args['user'], password=self.connection_args['password']
-        )
+        auth_provider = None
+        if any(key in self.connection_args for key in ('user', 'password')):
+            if all(key in self.connection_args for key in ('user', 'password')):
+                auth_provider = PlainTextAuthProvider(
+                    username=self.connection_args['user'], password=self.connection_args['password']
+                )
+            else:
+                raise ValueError("If authentication is required, both 'user' and 'password' must be provided!") 
 
         connection_props = {
             'auth_provider': auth_provider


### PR DESCRIPTION
## Description

This PR fixes the auth mechanism for the ScyllaDB handler (and as a result, the Cassandra handler) to enforce it only if the parameters are provided.

Fixes https://github.com/mindsdb/mindsdb/issues/9215

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

![image](https://github.com/mindsdb/mindsdb/assets/49385643/01b95012-44fa-4fcb-8b34-c009b12a5a27)

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [X] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.