### PR TITLE
Fixed Pydantic Import for field_validator in RAG and Writer

### DIFF
--- a/mindsdb/integrations/handlers/rag_handler/settings.py
+++ b/mindsdb/integrations/handlers/rag_handler/settings.py
@@ -15,7 +15,7 @@ from langchain.embeddings.huggingface import HuggingFaceEmbeddings
 from langchain_community.llms import Writer
 from langchain_community.document_loaders import DataFrameLoader
 from langchain_community.vectorstores import FAISS, Chroma, VectorStore
-from pydantic import BaseModel, Extra, Field, validator
+from pydantic import BaseModel, Extra, Field, field_validator
 
 from mindsdb.integrations.handlers.chromadb_handler.chromadb_handler import get_chromadb
 from mindsdb.integrations.handlers.rag_handler.exceptions import (

--- a/mindsdb/integrations/handlers/writer_handler/settings.py
+++ b/mindsdb/integrations/handlers/writer_handler/settings.py
@@ -1,7 +1,7 @@
 from typing import List, Union
 
 from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
-from pydantic import BaseModel, Extra, validator
+from pydantic import BaseModel, Extra, field_validator
 
 from mindsdb.integrations.handlers.rag_handler.settings import (
     DEFAULT_EMBEDDINGS_MODEL,


### PR DESCRIPTION
## Description

This PR corrects the import of the field_validator of Pydantic in the RAG and Writer handlers.

Fixes https://github.com/mindsdb/mindsdb/issues/9242

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added - N/A



