### PR TITLE
Fixed the Snowflake get_tables() Method

### DIFF
--- a/mindsdb/integrations/handlers/snowflake_handler/snowflake_handler.py
+++ b/mindsdb/integrations/handlers/snowflake_handler/snowflake_handler.py
@@ -176,23 +176,13 @@ class SnowflakeHandler(DatabaseHandler):
             Response: A response object containing the list of tables and views, formatted as per the `Response` class.
         """
 
-        query = "SHOW TABLES;"
-        result_tables = self.native_query(query)
-        if result_tables.resp_type == RESPONSE_TYPE.TABLE:
-            result_tables.data_frame = result_tables.data_frame.rename(columns={'name': 'table_name'})[['table_name']]
-        elif result_tables.resp_type == RESPONSE_TYPE.OK:
-            result_tables.data_frame = DataFrame(columns=['table_name'])
-
-        query = "SHOW VIEWS;"
-        result_views = self.native_query(query)
-        if result_views.resp_type == RESPONSE_TYPE.TABLE:
-            result_views.data_frame = result_views.data_frame.rename(columns={'name': 'table_name'})[['table_name']]
-        elif result_views.resp_type == RESPONSE_TYPE.OK:
-            result_views.data_frame = DataFrame(columns=['table_name'])
-
-        result = Response(RESPONSE_TYPE.TABLE)
-        result.data_frame = concat([result_tables.data_frame, result_views.data_frame], ignore_index=True)
-        return result
+        query = """
+            SELECT TABLE_NAME, TABLE_SCHEMA, TABLE_TYPE
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_TYPE IN ('BASE TABLE', 'VIEW')
+            AND TABLE_SCHEMA <> 'INFORMATION_SCHEMA'
+        """
+        return self.native_query(query)
 
     def get_columns(self, table_name) -> Response:
         """


### PR DESCRIPTION
## Description

This PR fixes the query used in the `get_tables()` method used in the Snowflake integration.

Fixes https://github.com/mindsdb/mindsdb/issues/9294

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [X]   Test Location: `tests/unit/handlers/test_snowflake.py` for unit tests and `mindsdb/integrations/handlers/snowflake_handler/tests/test_snowflake_handler.py` for integration tests.
 - [X]   Verification Steps: Run the above test modules (for integration tests, a Snowflake account will be required).

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [X] Relevant unit and integration tests are updated or added.



