### PR TITLE
Added Job to Trigger a Release of the Docker Desktop Extension

### DIFF
--- a/.github/workflows/build_deploy_prod.yml
+++ b/.github/workflows/build_deploy_prod.yml
@@ -135,7 +135,7 @@ jobs:
           github_token: ${{ secrets.DD_EXT_REPO_DISPATCH_PAT_TOKEN }}
           workflow_file_name: bump-mindsdb-version.yml
           ref: main
-          client_payload: '{"version": "${{ env.CI_REF_NAME }}"}'
+          client_payload: '{"version": "${{ env.CI_REF_NAME_SLUG }}"}'
 
   run_tests:
     name: Run Post-Deploy Tests

--- a/.github/workflows/build_deploy_prod.yml
+++ b/.github/workflows/build_deploy_prod.yml
@@ -4,8 +4,8 @@ on:
   release:
     types: [published]
     paths-ignore:
-      - 'docs/**'
-      - 'README.md'
+      - "docs/**"
+      - "README.md"
 
 # Cancel any existing runs of this workflow on the same branch/pr
 # We always want to build/deploy/test a new commit over an older one
@@ -18,38 +18,38 @@ jobs:
     runs-on: mdb-dev
     if: github.actor != 'mindsdbadmin'
     steps:
-    - uses: actions/checkout@v4
-    # Get clean environment variables via https://github.com/marketplace/actions/github-environment-variables-action
-    - uses: FranzDiebold/github-env-vars-action@v2
-    - name: Set up Python
-      uses: actions/setup-python@v5.1.0
-      with:
-        python-version: ${{ vars.CI_PYTHON_VERSION }}
-    - name: Check Version
-      run: |
-        PYTHONPATH=./ python tests/scripts/check_version.py ${{ env.CI_REF_NAME }} ${{ github.event.release.prerelease }}
+      - uses: actions/checkout@v4
+      # Get clean environment variables via https://github.com/marketplace/actions/github-environment-variables-action
+      - uses: FranzDiebold/github-env-vars-action@v2
+      - name: Set up Python
+        uses: actions/setup-python@v5.1.0
+        with:
+          python-version: ${{ vars.CI_PYTHON_VERSION }}
+      - name: Check Version
+        run: |
+          PYTHONPATH=./ python tests/scripts/check_version.py ${{ env.CI_REF_NAME }} ${{ github.event.release.prerelease }}
 
   deploy_to_pypi:
     runs-on: mdb-dev
     needs: check-version
     if: github.actor != 'mindsdbadmin'
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5.1.0
-      with:
-        python-version: ${{ vars.CI_PYTHON_VERSION }}
-    - name: Install dependencies
-      run: |
-        pip install -r requirements/requirements-dev.txt
-    - name: Build and publish
-      env:
-        TWINE_USERNAME:  __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        # This uses the version string from __about__.py, which we checked matches the git tag above
-        python setup.py sdist
-        twine upload dist/*
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5.1.0
+        with:
+          python-version: ${{ vars.CI_PYTHON_VERSION }}
+      - name: Install dependencies
+        run: |
+          pip install -r requirements/requirements-dev.txt
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          # This uses the version string from __about__.py, which we checked matches the git tag above
+          python setup.py sdist
+          twine upload dist/*
 
   docker_build:
     # Build our docker images based on our bake file
@@ -114,6 +114,28 @@ jobs:
           ref: main
           client_payload: '{"image-tag-prefix": "${{ env.CI_REF_NAME }}", "deploy-env": "prod"}'
 
+  trigger_dd_extension_release:
+    # Trigger private repo to deploy to prod env
+    runs-on: mdb-dev
+    needs: docker_build
+    if: github.actor != 'mindsdbadmin'
+    environment:
+      name: prod
+    # We only want to run one deploy job for an env at a time
+    # Don't cancel in progress jobs because it may be for a different PR
+    concurrency:
+      group: deploy-prod
+      cancel-in-progress: false
+    steps:
+      - uses: FranzDiebold/github-env-vars-action@v2
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: mindsdb
+          repo: mindsdb-docker-extension
+          github_token: ${{ secrets.DD_EXT_REPO_DISPATCH_PAT_TOKEN }}
+          workflow_file_name: bump-mindsdb-version.yml
+          ref: main
+          client_payload: '{"version": "${{ env.CI_REF_NAME }}"}'
 
   run_tests:
     name: Run Post-Deploy Tests

--- a/.github/workflows/build_deploy_prod.yml
+++ b/.github/workflows/build_deploy_prod.yml
@@ -121,18 +121,13 @@ jobs:
     if: github.actor != 'mindsdbadmin'
     environment:
       name: prod
-    # We only want to run one deploy job for an env at a time
-    # Don't cancel in progress jobs because it may be for a different PR
-    concurrency:
-      group: deploy-prod
-      cancel-in-progress: false
     steps:
       - uses: FranzDiebold/github-env-vars-action@v2
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: mindsdb
           repo: mindsdb-docker-extension
-          github_token: ${{ secrets.DD_EXT_REPO_DISPATCH_PAT_TOKEN }}
+          github_token: ${{ secrets.REPO_DISPATCH_PAT_TOKEN }}
           workflow_file_name: bump-mindsdb-version.yml
           ref: main
           client_payload: '{"version": "${{ env.CI_REF_NAME_SLUG }}"}'


### PR DESCRIPTION
## Description

This PR adds a job to the production workflow that deploys MindsDB artifacts to trigger a new release of the Docker Desktop extension. This is done by triggering [this workflow](https://github.com/mindsdb/mindsdb-docker-extension/blob/main/.github/workflows/bump-mindsdb-version.yml) setup in the repository for the extension.

Fixes https://github.com/mindsdb/mindsdb-docker-extension/issues/6
Fixes https://github.com/mindsdb/mindsdb_private/issues/575

## Type of change

- [X] ⚡ New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB - N/A
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added - N/A