### PR TITLE
Updated the SQLAlchemy Dependency for Redshift to Use Fork

### DIFF
--- a/docs/integrations/data-integrations/amazon-redshift.mdx
+++ b/docs/integrations/data-integrations/amazon-redshift.mdx
@@ -3,35 +3,36 @@ title: Amazon Redshift
 sidebarTitle: Amazon Redshift
 ---
 
-This is the implementation of the Redshift data handler for MindsDB.
-
-[Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/mgmt/welcome.html) is a fully managed, petabyte-scale data warehouse service in the cloud. You can start with just a few hundred gigabytes of data and scale to a petabyte or more, enabling you to use your data to acquire new insights for your business and customers.
+This documentation describes the integration of MindsDB with [Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/mgmt/welcome.html), a fully managed, petabyte-scale data warehouse service in the cloud. You can start with just a few hundred gigabytes of data and scale to a petabyte or more, enabling you to use your data to acquire new insights for your business and customers.
 
 ## Prerequisites
 
 Before proceeding, ensure the following prerequisites are met:
 
 1. Install MindsDB locally via [Docker](/setup/self-hosted/docker) or [Docker Desktop](/setup/self-hosted/docker-desktop).
-2. To connect Amazon Redshift to MindsDB, install the required dependencies following [this instruction](/setup/self-hosted/docker#install-dependencies).
-3. Install or ensure access to Amazon Redshift.
+2. To connect Redshift to MindsDB, install the required dependencies following [this instruction](/setup/self-hosted/docker#install-dependencies).
 
-## Implementation
+<Tip>
+Please note that, if you are using Docker to run MindsDB, before installing the dependencies for this integration as per the instructions given above, it is currently necessary to install Git in the container. To do this, run the following commands:
 
-This handler is implemented using the `redshift_connector` library that is provided by Amazon Web Services.
+Start an interactive shell in the container:
+```bash
+docker exec -it mindsdb_container sh
+```
+If you haven't specified a name when spinning up the MindsDB container with `docker run`, you can find it by running `docker ps`.
 
-The required arguments to establish a connection are as follows:
+Install Git:
+```bash
+apt-get -y update
+apt-get -y install git
+``` 
 
-* `host` is the host name or IP address of the Redshift cluster.
-* `port` is the port to use when connecting with the Redshift cluster.
-* `database` is the database name to use when connecting with the Redshift cluster.
-* `user` is the username to authenticate the user with the Redshift cluster.
-* `password` is the password to authenticate the user with the Redshift cluster.
+The need to perform this step will be removed in future versions of MindsDB.
+</Tip>
 
-## Usage
+## Connection
 
-Before attempting to connect the Redshift database to MindsDB, ensure that it accepts incoming connections. Here is a [guide](https://aws.amazon.com/premiumsupport/knowledge-center/cannot-connect-redshift-cluster) for troubleshooting Redshift database connections.
-
-To connect to the Redshift database in MindsDB using this handler, use the following syntax:
+Establish a connection to your Redshift database from MindsDB by executing the following SQL command:
 
 ```sql
 CREATE DATABASE redshift_datasource
@@ -46,9 +47,36 @@ WITH
   };
 ```
 
-Once this connection has been established, you can query your table as follows:
+Required connection parameters include the following:
+
+* `host`: The host name or IP address of the Redshift cluster.
+* `port`: The port to use when connecting with the Redshift cluster.
+* `database`: The database name to use when connecting with the Redshift cluster.
+* `user`: The username to authenticate the user with the Redshift cluster.
+* `password`: The password to authenticate the user with the Redshift cluster.
+
+## Usage
+
+Retrieve data from a specified table by providing the integration name, schema, and table name:
 
 ```sql
 SELECT *
-FROM redshift_datasource.example_tbl;
+FROM redshift_datasource.schema_name.table_name
+LIMIT 10;
 ```
+
+Run Amazon Redshift SQL queries directly on the connected Redshift database:
+
+```sql
+SELECT * FROM redshift_datasource (
+
+    --Native Query Goes Here
+    WITH VENUECOPY AS (SELECT * FROM VENUE)
+      SELECT * FROM VENUECOPY ORDER BY 1 LIMIT 10;
+
+);
+```
+
+<Note>
+The above examples utilize `redshift_datasource` as the datasource name, which is defined in the `CREATE DATABASE` command.
+</Note>

--- a/mindsdb/integrations/handlers/redshift_handler/README.md
+++ b/mindsdb/integrations/handlers/redshift_handler/README.md
@@ -1,41 +1,82 @@
-# Redshift Handler
+---
+title: Amazon Redshift
+sidebarTitle: Amazon Redshift
+---
 
-This is the implementation of the Redshift handler for MindsDB.
+This documentation describes the integration of MindsDB with [Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/mgmt/welcome.html), a fully managed, petabyte-scale data warehouse service in the cloud. You can start with just a few hundred gigabytes of data and scale to a petabyte or more, enabling you to use your data to acquire new insights for your business and customers.
 
-## Redshift
-Amazon Redshift is a fully managed, petabyte-scale data warehouse service in the cloud. You can start with just a few hundred gigabytes of data and scale to a petabyte or more. This enables you to use your data to acquire new insights for your business and customers.
-https://docs.aws.amazon.com/redshift/latest/mgmt/welcome.html
+## Prerequisites
 
-## Implementation
-This handler was implemented using the `redshift_connector` library that is provided by Amazon Web Services.
+Before proceeding, ensure the following prerequisites are met:
 
-The required arguments to establish a connection are,
-* `host`: the host name or IP address of the Redshift cluster
-* `port`: the port to use when connecting with the Redshift cluster
-* `database`: the database name to use when connecting with the Redshift cluster
-* `user`: the user to authenticate the user with the Redshift cluster
-* `password`: the password to authenticate the user with the Redshift cluster
+1. Install MindsDB locally via [Docker](/setup/self-hosted/docker) or [Docker Desktop](/setup/self-hosted/docker-desktop).
+2. To connect Redshift to MindsDB, install the required dependencies following [this instruction](/setup/self-hosted/docker#install-dependencies).
 
-## Usage
-Before attempting to connect to a Redshift cluster using MindsDB, ensure that it accepts incoming connections. The following can be used as a guideline to accomplish this,
-<br>
-https://aws.amazon.com/premiumsupport/knowledge-center/cannot-connect-redshift-cluster/
+<Tip>
+Please note that, if you are using Docker to run MindsDB, before installing the dependencies for this integration as per the instructions given above, it is currently necessary to install Git in the container. To do this, run the following commands:
 
-In order to make use of this handler and connect to a Redshift cluster in MindsDB, the following syntax can be used,
-~~~~sql
+Start an interactive shell in the container:
+```bash
+docker exec -it mindsdb_container sh
+```
+If you haven't specified a name when spinning up the MindsDB container with `docker run`, you can find it by running `docker ps`.
+
+Install Git:
+```bash
+apt-get -y update
+apt-get -y install git
+``` 
+
+The need to perform this step will be removed in future versions of MindsDB.
+</Tip>
+
+## Connection
+
+Establish a connection to your Redshift database from MindsDB by executing the following SQL command:
+
+```sql
 CREATE DATABASE redshift_datasource
 WITH
-engine='redshift',
-parameters={
+  engine = 'redshift',
+  parameters = {
     "host": "examplecluster.abc123xyz789.us-west-1.redshift.amazonaws.com",
     "port": 5439,
     "database": "example_db",
     "user": "awsuser",
     "password": "my_password"
-};
-~~~~
+  };
+```
 
-Now, you can use this established connection to query your database as follows,
-~~~~sql
-SELECT * FROM redshift_datasource.example_tbl
-~~~~
+Required connection parameters include the following:
+
+* `host`: The host name or IP address of the Redshift cluster.
+* `port`: The port to use when connecting with the Redshift cluster.
+* `database`: The database name to use when connecting with the Redshift cluster.
+* `user`: The username to authenticate the user with the Redshift cluster.
+* `password`: The password to authenticate the user with the Redshift cluster.
+
+## Usage
+
+Retrieve data from a specified table by providing the integration name, schema, and table name:
+
+```sql
+SELECT *
+FROM redshift_datasource.schema_name.table_name
+LIMIT 10;
+```
+
+Run Amazon Redshift SQL queries directly on the connected Redshift database:
+
+```sql
+SELECT * FROM redshift_datasource (
+
+    --Native Query Goes Here
+    WITH VENUECOPY AS (SELECT * FROM VENUE)
+      SELECT * FROM VENUECOPY ORDER BY 1 LIMIT 10;
+
+);
+```
+
+<Note>
+The above examples utilize `redshift_datasource` as the datasource name, which is defined in the `CREATE DATABASE` command.
+</Note>

--- a/mindsdb/integrations/handlers/redshift_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/redshift_handler/requirements.txt
@@ -1,2 +1,2 @@
 redshift_connector
-sqlalchemy-redshift
+sqlalchemy-redshift @ git+https://github.com/aquarium-ai/sqlalchemy-redshift


### PR DESCRIPTION
## Description

This PR updates sqlalchemy-redshift dependency required by the Amazon Redshift integration to use this [fork](https://github.com/aquarium-ai/sqlalchemy-redshift).

With this, the installation of dependencies complete successfully,
![Screenshot from 2024-06-11 16-19-34](https://github.com/mindsdb/mindsdb/assets/49385643/33fc966e-f4e0-4abf-a8e1-0aeae220a198)

A tip has also been added to the documentation page and the README for the integration stating that Git needs to be installed in the container prior to installing these dependencies when using Docker to run MindsDB. The doc and the README were also put into the correct layout.

Partially fixes https://github.com/mindsdb/mindsdb/issues/9321

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB - N/A
- [ ] I have appropriately commented on my code, especially in complex areas - N/A
- [X] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.