### PR TITLE
Dependencies: Migrate from `crate[sqlalchemy]` to `sqlalchemy-cratedb`

### DIFF
--- a/mindsdb/integrations/handlers/crate_handler/crate_handler.py
+++ b/mindsdb/integrations/handlers/crate_handler/crate_handler.py
@@ -15,7 +15,7 @@ from mindsdb.integrations.libs.const import HANDLER_CONNECTION_ARG_TYPE as ARG_T
 
 import pandas as pd
 from crate import client as db
-from crate.client.sqlalchemy.dialect import CrateDialect
+from sqlalchemy_cratedb import dialect
 
 logger = log.getLogger(__name__)
 
@@ -148,7 +148,7 @@ class CrateHandler(DatabaseHandler):
             HandlerResponse
         """
 
-        renderer = SqlalchemyRender(CrateDialect)
+        renderer = SqlalchemyRender(dialect)
         query_str = renderer.get_string(query, with_failback=True)
         return self.native_query(query_str)
 

--- a/mindsdb/integrations/handlers/crate_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/crate_handler/requirements.txt
@@ -1,1 +1,2 @@
-crate[sqlalchemy]
+crate
+sqlalchemy-cratedb


### PR DESCRIPTION
## About
The [CrateDB SQLAlchemy dialect](https://github.com/crate-workbench/sqlalchemy-cratedb) needs more love, so it was separated from the [DBAPI HTTP driver](https://github.com/crate/crate-python). This patch intends to accompany the migration.

## Details
The new canonical package for the SQLAlchemy CrateDB dialect on PyPI is:

> https://pypi.org/project/sqlalchemy-cratedb/

/cc @hammerhead, @hlcianfagna, @surister
