### PR TITLE
[FIX] - Download correct GUI version

### DIFF
--- a/mindsdb/api/http/initialize.py
+++ b/mindsdb/api/http/initialize.py
@@ -173,7 +173,7 @@ def initialize_static():
 
         # ignore versions like '23.9.2.2'
         if current_gui_version_lv is not None and len(current_gui_version_lv.version) < 3:
-            if current_gui_version_lv >= last_gui_version_lv:
+            if current_gui_version_lv == last_gui_version_lv:
                 return True
         logger.debug("Updating gui..")
         success = update_static(last_gui_version_lv)


### PR DESCRIPTION
## Description

The issue involves the GUI version download for MindsDB when using Docker or self-hosted setups. Currently, MindsDB always downloads the latest GUI version, regardless of the installed MindsDB version. This mismatch causes confusion about which GUI version is compatible with the installed MindsDB version.

**Expected Behavior with Changes:**

- Download the correct GUI version based on the [compatible-json](https://mindsdb-web-builds.s3.amazonaws.com/compatible-config.json) file.
- Retain the same GUI version if no update is needed.


## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



