### PR TITLE
added aws marketplace as installtion option in docs

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -267,6 +267,7 @@
           "pages": [
             "setup/self-hosted/docker",
             "setup/self-hosted/docker-desktop",
+            "setup/cloud/aws-marketplace",
             {
               "group": "Configuration",
               "pages": [

--- a/docs/setup/cloud/aws-marketplace.mdx
+++ b/docs/setup/cloud/aws-marketplace.mdx
@@ -1,0 +1,10 @@
+---
+title: MindsDB at AWS Marketplace
+sidebarTitle: AWS Marketplace
+---
+
+MindsDB offers a streamlined setup process in cloud environments using its AWS Marketplace image.
+
+<Info>
+Explore the MindsDB AWS Marketplace image [here](https://aws.amazon.com/marketplace/seller-profile?id=03a65520-86ca-4ab8-a394-c11eb54573a9).
+</Info>


### PR DESCRIPTION
## Description

added aws marketplace as installtion option in docs

![image](https://github.com/mindsdb/mindsdb/assets/109554435/307345c1-1106-46f9-8e7b-ae4a43db2a1f)

Fixes #issue_number

## Type of change

- [ ] 📄 This change is a documentation update
