### PR TITLE
DOCS-9379: Indexing Error for the Installation Section on Docs Website

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -261,7 +261,17 @@
           "pages": [
             "setup/self-hosted/docker",
             "setup/self-hosted/docker-desktop",
+            {
+              "group": "PIP",
+              "pages": [
+                "setup/self-hosted/pip/linux",
+                "setup/self-hosted/pip/macos",
+                "setup/self-hosted/pip/source",
+                "setup/self-hosted/pip/windows"
+              ]
+            },
             "setup/cloud/aws-marketplace",
+            "setup/community-deploys-mindsdb",
             {
               "group": "Configuration",
               "pages": [

--- a/docs/setup/community-deploys-mindsdb.mdx
+++ b/docs/setup/community-deploys-mindsdb.mdx
@@ -1,6 +1,6 @@
 ---
-title: Deploying MindsDB in any cloud
-sidebarTitle: Other clouds
+title: Deploying MindsDB in any Cloud
+sidebarTitle: Other Clouds
 ---
 
 Check out the articles and video guides created by our community:

--- a/docs/setup/self-hosted/pip/linux.mdx
+++ b/docs/setup/self-hosted/pip/linux.mdx
@@ -1,6 +1,6 @@
 ---
-title: Setup for Linux via pip
-sidebarTitle: pip on Linux
+title: Setup for Linux via PIP
+sidebarTitle: PIP on Linux
 ---
 
 <iframe

--- a/docs/setup/self-hosted/pip/macos.mdx
+++ b/docs/setup/self-hosted/pip/macos.mdx
@@ -1,6 +1,6 @@
 ---
-title: Setup for MacOS via pip
-sidebarTitle: pip on MacOS
+title: Setup for MacOS via PIP
+sidebarTitle: PIP on MacOS
 ---
 
 <Tip>

--- a/docs/setup/self-hosted/pip/source.mdx
+++ b/docs/setup/self-hosted/pip/source.mdx
@@ -1,6 +1,6 @@
 ---
-title: Setup for Source Code via pip
-sidebarTitle: pip from Source
+title: Setup for Source Code via PIP
+sidebarTitle: PIP from Source
 ---
 
 This section describes how to deploy MindsDB from the source code. It is the preferred way to use MindsDB if you want to contribute to our code or debug MindsDB.

--- a/docs/setup/self-hosted/pip/windows.mdx
+++ b/docs/setup/self-hosted/pip/windows.mdx
@@ -1,6 +1,6 @@
 ---
-title: Setup for Windows via pip
-sidebarTitle: pip on Windows
+title: Setup for Windows via PIP
+sidebarTitle: PIP on Windows
 ---
 
 <Tip>


### PR DESCRIPTION
## Description

This PR updates the `mint.json` file inside the docs folder to add some missing installation documentation sections.

The list of the missing doc pages includes the following.

- PIP Section
     - PIP on Linux
     - PIP on MacOS
     - PIP on Source
     - PIP on Windows
- Other Clouds

Fixes #9379 

## Type of change

- [x] 📄 This change requires a documentation website update.

## Verification Process

To ensure the changes are working as expected:

- Pull these changes to the local system.
- Run the docs website locally using `mintlify dev`.
- Check the Installation section on the Sidebar panel to find the updated indexing of missing pages.

## Additional Media:

**Updated Docs Site Screenshot:**

![Correct Indexing](https://github.com/mindsdb/mindsdb/assets/47860497/3f113ed8-5d5a-4497-bae2-6840299b5242)

- [x] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] This PR abides by the Contributing Guidelines of MindsDB.


