### PR TITLE
[ENH] Migrate OpenAI's json_struct mode to use prompt template

### DIFF
--- a/docs/use-cases/data_enrichment/json-from-text.mdx
+++ b/docs/use-cases/data_enrichment/json-from-text.mdx
@@ -81,7 +81,7 @@ Let's create an OpenAI model.
             'location': 'location',
             'nob': 'number of bathrooms'
         },
-        input_text = 'sentence';
+        prompt_template = '{{sentence}}';
     ```
     </Tab>
 
@@ -96,7 +96,7 @@ Let's create an OpenAI model.
         predict: 'json',
         training_options: {
             engine: 'openai',
-            input_text: 'sentence',
+            prompt_template: '{{sentence}}',
             json_struct: {
                 'rental_price': 'rental price',
                 'location': 'location',
@@ -112,7 +112,7 @@ We pass three parameters as follows:
 
 1. The `engine` parameter ensures we use the OpenAI engine.
 2. The `json_struct` parameter stores a predefined JSON structure used for the output.
-3. The `input_text` parameter contains the name of the column that stores input text.
+3. The `prompt_template` parameter contains the instruction passed to the model that may include variables such as `{{sentence}}`.
 
 Now we can query the model, passing the input text stored in the `sentence` column.
 

--- a/tests/unit/ml_handlers/test_openai.py
+++ b/tests/unit/ml_handlers/test_openai.py
@@ -41,7 +41,7 @@ class TestOpenAI(unittest.TestCase):
         Test if model creation raises an exception without required parameters.
         """
 
-        with self.assertRaisesRegex(Exception, "One of `question_column`, `prompt_template` or `json_struct` is required for this engine."):
+        with self.assertRaisesRegex(Exception, "One of `question_column`, `prompt_template` or `prompt` is required for this engine."):
             self.handler.create_validation('target', args={"using": {}}, handler_storage=self.mock_engine_storage)
 
     def test_create_validation_with_invalid_parameter_combinations_raises_exception(self):


### PR DESCRIPTION
## Description

Deprecate `input_text` keyword argument in favor of `prompt_template` when using `json_struct` mode, both for UX streamlining and also to enable multi-column support.

Example queries change from this:

```
CREATE MODEL mindsdb.nlp_model
PREDICT json
USING
    engine = 'openai_engine',
    json_struct = {
        'rental_price': 'rental price',
        'location': 'location',
        'nob': 'number of bathrooms'
    },
    input_text = 'sentence';

SELECT json
FROM mindsdb.nlp_model
WHERE sentence = 'Amazing 3 bedroom apartment located at the heart of Manhattan, has one full bathrooms and one toilet room for just 3000 a month.';
```

To this:

```
CREATE MODEL mindsdb.nlp_model
PREDICT json
USING
    engine = 'openai_engine',
    json_struct = {
        'rental_price': 'rental price',
        'location': 'location',
        'nob': 'number of bathrooms'
    },
    prompt_template = '{{sentence}}';

SELECT json
FROM mindsdb.nlp_model
WHERE sentence = 'Amazing 3 bedroom apartment located at the heart of Manhattan, has one full bathrooms and one toilet room for just 3000 a month.';
```

![image](https://github.com/mindsdb/mindsdb/assets/12536303/94e262aa-c771-433b-9ea1-fe7f9654ecb8)


## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)
- [x] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] 📄 This change requires a documentation update

@martyna-mindsdb feel free to directly change docs on this PR if that's helpful.

Tagging @torrmal for visibility at his request.

## Verification Process

To ensure the changes are working as expected:

 - [x]   Test Location: manual test.
 - [x]   Verification Steps: follow this example from our [docs](https://docs.mindsdb.com/use-cases/data_enrichment/json-from-text).

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



