### PR TITLE
Support querying columns from connected database

### DIFF
--- a/mindsdb/api/executor/datahub/datanodes/integration_datanode.py
+++ b/mindsdb/api/executor/datahub/datanodes/integration_datanode.py
@@ -53,6 +53,21 @@ class IntegrationDataNode(DataNode):
         return True
 
     def get_table_columns(self, tableName):
+        response = self.integration_handler.get_columns(tableName)
+        if response.type == RESPONSE_TYPE.TABLE:
+            df = response.data_frame
+            col_name = None
+            # looking for specific column names
+            for col in ('Field', 'column_name', 'column'):
+                if col in df.columns:
+                    col_name = col
+                    break
+            # if not found - pick first one
+            if col_name is None:
+                col_name = df.columns[0]
+
+            return list(df[col_name])
+
         return []
 
     def drop_table(self, name: Identifier, if_exists=False):

--- a/tests/unit/executor_test_base.py
+++ b/tests/unit/executor_test_base.py
@@ -303,15 +303,7 @@ class BaseExecutorTest(BaseUnitTest):
                 )
 
             return handler_response(
-                pd.DataFrame(
-                    [
-                        {
-                            "table_schema": "public",
-                            "table_name": "table1",
-                            "table_type": "BASE TABLE",
-                        }
-                    ]
-                )
+                pd.DataFrame(tables_ar)
             )
 
         mock_handler().get_tables.side_effect = get_tables_f

--- a/tests/unit/test_project_structure.py
+++ b/tests/unit/test_project_structure.py
@@ -955,6 +955,16 @@ class TestProjectStructure(BaseExecutorDummyML):
 
         self.run_sql('delete from tbl1 where a=1', database='dummy_data')
 
+    @patch('mindsdb.integrations.handlers.postgres_handler.Handler')
+    def test_select_columns(self, data_handler):
+        df = pd.DataFrame([[1, 'x'], [2, 'y']], columns=['aa', 'bb'])
+
+        self.set_handler(data_handler, name='pg', tables={'tbl1': df})
+
+        ret = self.run_sql("SELECT * FROM information_schema.columns WHERE table_schema='pg'")
+
+        assert list(ret['COLUMN_NAME']) == ['aa', 'bb']
+
 
 class TestJobs(BaseExecutorDummyML):
 


### PR DESCRIPTION
## Description

If remote database or other project exists in query filter for `information_schema.columns` table:
```sql
SELECT * FROM information_schema.columns
WHERE table_schema='example_db';  -- or table_schema in ('example_db', 'project1')
```
Mindsdb queries columns from connected database (using get_tables, get_columns handler methods)

Why don't query all databases by default: fetching columns from every tables could take a lot of time. For me example_db returns it for 10 sec.

![image](https://github.com/mindsdb/mindsdb/assets/8502631/7bafdc02-0012-4067-aaed-05e047c5dc2b)


## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



