### PR TITLE
Update build_deploy_prod.yml

### DIFF
--- a/.github/workflows/build_deploy_prod.yml
+++ b/.github/workflows/build_deploy_prod.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements/requirements-dev.txt
+          pip install importlib_metadata==7.2.1
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__


### PR DESCRIPTION
## Description

This PR fixes the [PyPI build key error](https://github.com/mindsdb/mindsdb/actions/runs/9668768606/job/26673895010#step:5:2216). For now, as a workaround, we use a specific `importlib-metadata version`; for ref, see this [twine issue.](https://github.com/pypa/twine/issues/977#issuecomment-2189800841)
