### PR TITLE
Updated Dependencies to Make the HuggingFace Integration Usable

### DIFF
--- a/mindsdb/integrations/handlers/huggingface_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/huggingface_handler/requirements.txt
@@ -1,5 +1,5 @@
 transformers >= 4.34.0, < 5.0.0
-datasets
+datasets==2.16.1
 evaluate
 torch
 nltk

--- a/mindsdb/integrations/handlers/huggingface_handler/requirements_cpu.txt
+++ b/mindsdb/integrations/handlers/huggingface_handler/requirements_cpu.txt
@@ -1,5 +1,5 @@
 transformers >= 4.34.0, < 5.0.0
-datasets
+datasets==2.16.1
 evaluate
 nltk
 huggingface-hub


### PR DESCRIPTION
## Description

This PR fixes the dependencies for the HuggingFace handler and makes it usable by pinning the `datasets` package to 2.16.1. The issue mentioned below seems to be a result of using an incompatible version of `datasets` with `pyarrow`.

The newly pinned version of the package works with `pyarrow=11.0.0`, which is a dependency for our BYOM handler (the BYOM handler is one of our default handlers, so this version of `pyarrow` comes pre-installed).

Fixes https://github.com/mindsdb/mindsdb/issues/9056

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

![image](https://github.com/mindsdb/mindsdb/assets/49385643/5aec85f9-d513-44a6-a02f-3a68451c55fb)

![image](https://github.com/mindsdb/mindsdb/assets/49385643/08996e38-3030-4b3c-8fe9-3b0c78dc34d2)

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB - N/A
- [ ] I have appropriately commented on my code, especially in complex areas - N/A
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added.



