### PR TITLE
Fix case sensitive `drop database`

### DIFF
--- a/mindsdb/api/http/namespaces/tree.py
+++ b/mindsdb/api/http/namespaces/tree.py
@@ -31,6 +31,7 @@ class GetLeaf(Resource):
     @ns_conf.doc('get_tree_leaf')
     @api_endpoint_metrics('GET', '/tree/database')
     def get(self, db_name):
+        db_name = db_name.lower()
         databases = ca.database_controller.get_dict()
         if db_name not in databases:
             return http_error(

--- a/mindsdb/interfaces/database/database.py
+++ b/mindsdb/interfaces/database/database.py
@@ -81,7 +81,7 @@ class DatabaseController:
     def get_dict(self, filter_type: Optional[str] = None):
         return OrderedDict(
             (
-                x['name'],
+                x['name'].lower(),
                 {
                     'type': x['type'],
                     'engine': x['engine'],

--- a/mindsdb/interfaces/database/database.py
+++ b/mindsdb/interfaces/database/database.py
@@ -18,6 +18,7 @@ class DatabaseController:
 
     def delete(self, name: str):
         databases = self.get_dict()
+        name = name.lower()
         if name not in databases:
             raise EntityNotExistsError('Database does not exists', name)
         db_type = databases[name]['type']

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -551,10 +551,14 @@ class Test(BaseExecutorMockPredictor):
     @patch('mindsdb.integrations.handlers.postgres_handler.Handler')
     def test_drop_database(self, mock_handler):
         from mindsdb.utilities.exception import EntityNotExistsError
-        self.set_handler(mock_handler, name='pg', tables={})
 
-        # remove existing
+        # remove existing (check different cases)
+        self.set_handler(mock_handler, name='pg', tables={})
         self.execute("drop database pg")
+        self.set_handler(mock_handler, name='PG', tables={})
+        self.execute("drop database pg")
+        self.set_handler(mock_handler, name='pg', tables={})
+        self.execute("drop database Pg")
 
         # try one more time
         with pytest.raises(EntityNotExistsError):
@@ -1263,6 +1267,10 @@ class TestIfExistsIfNotExists(BaseExecutorMockPredictor):
 
         # create the same project with if not exists doesn't throw an error
         self.execute('CREATE PROJECT IF NOT EXISTS another_test_project')
+
+        self.execute('DROP PROJECT another_test_project')
+        self.execute('CREATE PROJECT ANOTHER_test_project')
+        self.execute('DROP PROJECT another_TEST_project')
 
     def test_database_integration(self):
         from mindsdb.utilities.exception import EntityExistsError, EntityNotExistsError


### PR DESCRIPTION
## Description

`drop database` was case sensitive:
```sql
CREATE DATABASE POSTGRES WITH ENGINE = 'postgres' ...;
DROP DATABASE postgres; -- error
```

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



