### PR TITLE
Fix: wrap list into Tuple for proper rendering

### DIFF
--- a/mindsdb/integrations/utilities/sql_utils.py
+++ b/mindsdb/integrations/utilities/sql_utils.py
@@ -176,6 +176,8 @@ def filter_dataframe(df: pd.DataFrame, conditions: list):
     where_query = None
     for op, arg1, arg2 in conditions:
 
+        if isinstance(arg2, (tuple, list)):
+            arg2 = ast.Tuple(arg2)
         item = ast.BinaryOperation(op=op, args=[ast.Identifier(arg1), ast.Constant(arg2)])
         if where_query is None:
             where_query = item


### PR DESCRIPTION
## Description

Fixes error in shopify handler with query having IN:
```sql
select * from orders
where total_price in (168, 59148, 25);
```
It wasn't properly rendered for executing in duckdb 

Fixes #issue_number

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



