### PR TITLE
ensure for loop range is performed on integer and not a float

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/data_types/mysql_packet.py
+++ b/mindsdb/api/mysql/mysql_proxy/data_types/mysql_packet.py
@@ -143,7 +143,7 @@ class Packet:
         ret = []
         body_len = len(body_string)
         mod = body_len % MAX_PACKET_SIZE
-        num_packets = body_len / MAX_PACKET_SIZE + (1 if mod > 0 else 0)
+        num_packets = body_len // MAX_PACKET_SIZE + (1 if mod > 0 else 0)
 
         for i in range(num_packets):
             left_limit = i * MAX_PACKET_SIZE


### PR DESCRIPTION
## Description

divides with integer output instead of float so that performing a for loop in range will not throw an error.

Fixes #issue_number #9426

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



