### PR TITLE
Fixed the Link to Minds Endpoint Handler

### DIFF
--- a/docs/integrations/ai-engines/minds_endpoint.mdx
+++ b/docs/integrations/ai-engines/minds_endpoint.mdx
@@ -15,7 +15,7 @@ Before proceeding, ensure the following prerequisites are met:
 
 ## Setup
 
-Create an AI engine from the [Minds Endpoint handler](https://github.com/mindsdb/mindsdb/tree/main/mindsdb/integrations/handlers/minds_endpoint).
+Create an AI engine from the [Minds Endpoint handler](https://github.com/mindsdb/mindsdb/tree/main/mindsdb/integrations/handlers/minds_endpoint_handler).
 
 ```sql
 CREATE ML_ENGINE minds_endpoint_engine


### PR DESCRIPTION
## Description

This PR fixes the link to the Minds Endpoint handler in the documentation.

Fixes https://github.com/mindsdb/mindsdb/issues/9459

## Type of change

- [X] 📄 This change is a documentation update