### PR TITLE
[fix] StatsForecast: Enable 'season_length' as setteable parameter

### DIFF
--- a/mindsdb/integrations/handlers/statsforecast_handler/statsforecast_handler.py
+++ b/mindsdb/integrations/handlers/statsforecast_handler/statsforecast_handler.py
@@ -54,7 +54,7 @@ def get_season_length(frequency):
 
 def get_insample_cv_results(model_args, df):
     """Gets insample cross validation results"""
-    season_length = get_season_length(model_args["frequency"])
+    season_length = get_season_length(model_args["frequency"]) if not model_args["season_length"] else model_args["season_length"]  # noqa
     if model_args["model_name"] == "auto":
         models = [model(season_length=season_length) for model in model_dict.values()]
     else:
@@ -75,7 +75,7 @@ def choose_model(model_args, results_df):
     """
     if model_args["model_name"] == "auto":
         model_args["model_name"] = get_best_model_from_results_df(results_df)
-    model_args["season_length"] = get_season_length(model_args["frequency"])
+    model_args["season_length"] = get_season_length(model_args["frequency"]) if not model_args["season_length"] else model_args["season_length"]  # noqa
     model = model_dict[model_args["model_name"]]
     return model(season_length=model_args["season_length"])
 


### PR DESCRIPTION
## Description

Enable `'season_length'` as setteable parameter when creating the model, superseding `get_season_length()`.

Fixes #6973

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)
- [x] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



