### PR TITLE
Pinned New Version of snowflake-sqlalchemy Supporting SQLAlchemy 2

### DIFF
--- a/docs/integrations/data-integrations/snowflake.mdx
+++ b/docs/integrations/data-integrations/snowflake.mdx
@@ -13,24 +13,6 @@ Before proceeding, ensure the following prerequisites are met:
 1. Install MindsDB locally via [Docker](/setup/self-hosted/docker) or [Docker Desktop](/setup/self-hosted/docker-desktop).
 2. To connect Snowflake to MindsDB, install the required dependencies following [this instruction](/setup/self-hosted/docker#install-dependencies).
 
-<Tip>
-Please note that, if you are using Docker to run MindsDB, before installing the dependencies for this integration as per the instructions given above, it is currently necessary to install Git in the container. To do this, run the following commands:
-
-Start an interactive shell in the container:
-```bash
-docker exec -it mindsdb_container sh
-```
-If you haven't specified a name when spinning up the MindsDB container with `docker run`, you can find it by running `docker ps`.
-
-Install Git:
-```bash
-apt-get -y update
-apt-get -y install git
-``` 
-
-The need to perform this step will be removed in future versions of MindsDB.
-</Tip>
-
 ## Connection
 
 Establish a connection to your Snowflake database from MindsDB by executing the following SQL command:

--- a/mindsdb/integrations/handlers/snowflake_handler/README.md
+++ b/mindsdb/integrations/handlers/snowflake_handler/README.md
@@ -13,24 +13,6 @@ Before proceeding, ensure the following prerequisites are met:
 1. Install MindsDB locally via [Docker](/setup/self-hosted/docker) or [Docker Desktop](/setup/self-hosted/docker-desktop).
 2. To connect Snowflake to MindsDB, install the required dependencies following [this instruction](/setup/self-hosted/docker#install-dependencies).
 
-<Tip>
-Please note that, if you are using Docker to run MindsDB, before installing the dependencies for this integration as per the instructions given above, it is currently necessary to install Git in the container. To do this, run the following commands:
-
-Start an interactive shell in the container:
-```bash
-docker exec -it mindsdb_container sh
-```
-If you haven't specified a name when spinning up the MindsDB container with `docker run`, you can find it by running `docker ps`.
-
-Install Git:
-```bash
-apt-get -y update
-apt-get -y install git
-``` 
-
-The need to perform this step will be removed in future versions of MindsDB.
-</Tip>
-
 ## Connection
 
 Establish a connection to your Snowflake database from MindsDB by executing the following SQL command:

--- a/mindsdb/integrations/handlers/snowflake_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/snowflake_handler/requirements.txt
@@ -1,2 +1,2 @@
 snowflake-connector-python>=2.7.12
-snowflake-sqlalchemy @ git+https://github.com/ea-rus/snowflake-sqlalchemy
+snowflake-sqlalchemy>=1.6.1

--- a/mindsdb/integrations/handlers/snowflake_handler/snowflake_handler.py
+++ b/mindsdb/integrations/handlers/snowflake_handler/snowflake_handler.py
@@ -1,6 +1,6 @@
 from pandas import DataFrame
-from snowflake import connector
 from snowflake.sqlalchemy import snowdialect
+from snowflake import connector
 
 from mindsdb.utilities import log
 from mindsdb_sql.parser.ast.base import ASTNode


### PR DESCRIPTION
## Description

This PR pins the new release of `snowflake-sqlalchemy` that supports SQLAlchemy 2. Here is the relevant reference: https://github.com/snowflakedb/snowflake-sqlalchemy/issues/380

In relation to this change, the following has also been done:
1. A previously added tip to install Git (when using Docker) in order to support the use of the forked repository for the above package has been removed from the documentation and the README.
2. The imports in the handler have been re-organized to prevent a circular dependency issue.

Fixes https://github.com/mindsdb/mindsdb/issues/9024

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [X]   Test Location: `tests/unit/handlers/test_snowflake.py` for unit tests and `mindsdb/integrations/handlers/snowflake_handler/tests/test_snowflake_handler.py` for integration tests.
 - [X]   Verification Steps: Run the above test modules (for integration tests, a Snowflake account will be required).

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [X] Necessary documentation updates are either made or tracked in issues.
- [X] Relevant unit and integration tests are updated or added.