### PR TITLE
Add deprecation warnings for RAG handler and kb skill

### DIFF
--- a/mindsdb/integrations/handlers/rag_handler/rag_handler.py
+++ b/mindsdb/integrations/handlers/rag_handler/rag_handler.py
@@ -12,9 +12,16 @@ from mindsdb.integrations.handlers.rag_handler.settings import (
 from mindsdb.integrations.libs.base import BaseMLEngine
 from mindsdb.utilities import log
 
-# these require no additional arguments
 
 logger = log.getLogger(__name__)
+
+logger.warning("\nThe RAG handler has been deprecated and is no longer being actively supported. \n"
+               "It will be fully removed in v24.8.x.x, "
+               "for RAG workflows, please migrate to "
+               "Agents + Retrieval skill. \n"
+               "Example usage can be found here: \n"
+               "https://github.com/mindsdb/mindsdb_python_sdk/blob/staging/examples"
+               "/using_agents_with_retrieval.py")
 
 
 class RAGHandler(BaseMLEngine):
@@ -40,10 +47,10 @@ class RAGHandler(BaseMLEngine):
             )
 
     def create(
-        self,
-        target: str,
-        df: pd.DataFrame = None,
-        args: Optional[Dict] = None,
+            self,
+            target: str,
+            df: pd.DataFrame = None,
+            args: Optional[Dict] = None,
     ):
         """
         Dispatch is running embeddings and storing in a VectorDB, unless user already has embeddings persisted
@@ -54,7 +61,7 @@ class RAGHandler(BaseMLEngine):
         ml_engine_args = self.engine_storage.get_connection_args()
 
         # for a model created with USING, only get api for that specific llm type
-        args.update({k: v for k, v in ml_engine_args.items() if args["llm_type"] in k})
+        args.update({k:v for k, v in ml_engine_args.items() if args["llm_type"] in k})
 
         input_args = build_llm_params(args)
 
@@ -67,7 +74,6 @@ class RAGHandler(BaseMLEngine):
 
         if args.run_embeddings:
             if "context_columns" not in args and df is not None:
-
                 # if no context columns provided, use all columns in df
                 logger.info("No context columns provided, using all columns in df")
                 args.context_columns = df.columns.tolist()

--- a/mindsdb/interfaces/skills/skill_tool.py
+++ b/mindsdb/interfaces/skills/skill_tool.py
@@ -6,10 +6,13 @@ from mindsdb_sql.parser.ast import Select, BinaryOperation, Identifier, Constant
 
 from mindsdb.integrations.libs.vectordatabase_handler import TableField
 from mindsdb.interfaces.storage import db
+from mindsdb.utilities import log
 from .sql_agent import SQLAgent
 
 _DEFAULT_TOP_K_SIMILARITY_SEARCH = 5
 _DEFAULT_SQL_LLM_MODEL = 'gpt-3.5-turbo'
+
+logger = log.getLogger(__name__)
 
 
 class SkillType(enum.Enum):
@@ -34,11 +37,11 @@ class SkillToolController:
         return self.command_executor
 
     def get_sql_agent(
-        self,
-        database: str,
-        include_tables: Optional[List[str]] = None,
-        ignore_tables: Optional[List[str]] = None,
-        sample_rows_in_table_info: int = 3,
+            self,
+            database: str,
+            include_tables: Optional[List[str]] = None,
+            ignore_tables: Optional[List[str]] = None,
+            sample_rows_in_table_info: int = 3,
     ):
         return SQLAgent(
             self.get_command_executor(),
@@ -58,7 +61,8 @@ class SkillToolController:
             from mindsdb.interfaces.skills.custom.text2sql.mindsdb_sql_toolkit import MindsDBSQLToolkit
             from langchain_community.tools.sql_database.tool import QuerySQLDataBaseTool
         except ImportError:
-            raise ImportError('To use the text-to-SQL skill, please install langchain with `pip install mindsdb[langchain]`')
+            raise ImportError(
+                'To use the text-to-SQL skill, please install langchain with `pip install mindsdb[langchain]`')
         database = skill.params['database']
         tables = skill.params['tables']
         tables_to_include = [f'{database}.{table}' for table in tables]
@@ -128,6 +132,9 @@ class SkillToolController:
     def _make_knowledge_base_tools(self, skill: db.Skills) -> dict:
         # To prevent dependency on Langchain unless an actual tool uses it.
         description = skill.params.get('description', '')
+
+        logger.warning("This skill is deprecated and will be removed in the future. "
+                       "Please use `retrieval` skill instead ")
 
         return dict(
             name='Knowledge Base Retrieval',


### PR DESCRIPTION
## Description

Code now includes warnings about the upcoming deprecation of the RAG handler and certain skills that encourages users to migrate to supported methods. The RAG handler will be completely removed in v24.8.x.x. Additionally, an informative warning is shown for skills that are now deprecated, recommending the retrieval skill as an alternative.

CC: @martyna-mindsdb - FYI - doc updates required. More background [here](https://docs.google.com/document/d/1yAkHNm7b-CP7JKBrVrWrcwPP9vzCMueQLo2Ej_wXtN0/edit)

next steps:

- update docs
- include a note on these changes in the next release notes

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



