### PR TITLE
Change default storage type to `absent`

### DIFF
--- a/mindsdb/interfaces/file/file_controller.py
+++ b/mindsdb/interfaces/file/file_controller.py
@@ -109,10 +109,9 @@ class FileController:
             self.fs_store.put(store_file_path, base_dir=self.dir)
         except Exception as e:
             logger.error(e)
-            raise
-        finally:
             if file_dir is not None:
                 shutil.rmtree(file_dir)
+            raise
 
         return file_record.id
 

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -114,7 +114,7 @@ class Config():
         api_host = "127.0.0.1" if not self.use_docker_env else "0.0.0.0"
         self._default_config = {
             'permanent_storage': {
-                'location': 'local'
+                'location': 'absent'
             },
             'storage_dir': os.environ['MINDSDB_STORAGE_DIR'],
             'paths': paths,


### PR DESCRIPTION
## Description

At the moment default storage type is `local`. This means that each item will be copied for backup.
That is not necessary if run mindsdb locally.

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



