### PR TITLE
hide data insights docs

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -290,7 +290,6 @@
               "group": "Data Preparation",
               "pages": [
                 "sql/feature-eng",
-                "sql/data-insights",
                 "sql/feature-importance"
               ] 
             },


### PR DESCRIPTION
## Description

currently this functionality is not available and it will be refined in future ([as mentioned here](https://mindsdbcommunity.slack.com/archives/C01S2T35H18/p1721742012436429?thread_ts=1720615623.582209&cid=C01S2T35H18)), so hiding this doc page for now

Fixes #issue_number

## Type of change

- [ ] 📄 This change is a documentation update
