### PR TITLE
Fix for agent decoupling fixex

### DIFF
--- a/mindsdb/api/executor/command_executor.py
+++ b/mindsdb/api/executor/command_executor.py
@@ -1432,13 +1432,12 @@ class ExecuteCommands:
         )
 
         skills = statement.params.pop('skills', [])
-        model_name = statement.params.pop('model_name', None)
         provider = statement.params.pop('provider', None)
         try:
             _ = self.session.agents_controller.add_agent(
                 name=name,
                 project_name=project_name,
-                model_name=model_name,
+                model_name=statement.model,
                 skills=skills,
                 provider=provider,
                 params=statement.params

--- a/mindsdb/interfaces/agents/agents_controller.py
+++ b/mindsdb/interfaces/agents/agents_controller.py
@@ -309,7 +309,11 @@ class AgentsController:
 
         from .langchain_agent import LangchainAgent
 
-        model, _ = self.check_model_provider(agent.model_name, agent.provider)
+        model, provider = self.check_model_provider(agent.model_name, agent.provider)
+        # update old agents
+        if agent.provider is None and provider is not None:
+            agent.provider = provider
+            db.session.commit()
 
         lang_agent = LangchainAgent(agent, model)
         return lang_agent.get_completion(messages, trace_id, observation_id)

--- a/mindsdb/migrations/versions/2024-07-19_45eb2eb61f70_add_provider_to_agent.py
+++ b/mindsdb/migrations/versions/2024-07-19_45eb2eb61f70_add_provider_to_agent.py
@@ -27,12 +27,15 @@ def upgrade():
     agents = table('agents',
                    sa.Column('id', sa.Integer, primary_key=True),
                    sa.Column('params', sa.JSON),
+                   sa.Column('model_name', sa.String()),
                    sa.Column('provider', sa.String()))
 
     conn = op.get_bind()
     for agent in conn.execute(select(agents)):
         if agent.params and 'provider' in agent.params:
             conn.execute(update(agents).where(agents.c.id == agent.id).values(provider=agent.params['provider']))
+        if agent.model_name is None:
+            conn.execute(update(agents).where(agents.c.id == agent.id).values(model_name=agent.params['model_name']))
     # ### end Alembic commands ###
 
 


### PR DESCRIPTION
## Description

Changes:
- copy detected provider in runtime to agent.provider
- don't use agent.params['model_name'], use agent.model_name
- copy model_name in migrations

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



