### PR TITLE
Fix: agent with KB skill returns results directly 

### DIFF
--- a/mindsdb/interfaces/agents/langchain_agent.py
+++ b/mindsdb/interfaces/agents/langchain_agent.py
@@ -246,7 +246,6 @@ class LangchainAgent:
                     name=tool['name'],
                     func=tool['func'],
                     description=tool['description'],
-                    return_direct=True
                 ))
                 continue
             all_tools.append(tool)


### PR DESCRIPTION
## Description

Removed `return_direct` from tool config. It allows to send results from tool too llm for preparing response

Fixes #issue_number

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



