### PR TITLE
adding llama3 and llama31 from Groq endpoint.

### DIFF
--- a/mindsdb/integrations/handlers/langchain_handler/constants.py
+++ b/mindsdb/integrations/handlers/langchain_handler/constants.py
@@ -1,7 +1,15 @@
 from langchain.agents import AgentType
 
-SUPPORTED_PROVIDERS = {'openai', 'anthropic', 'anyscale', 'litellm', 'ollama'}
+SUPPORTED_PROVIDERS = {'openai', 'anthropic', 'anyscale', 'litellm', 'ollama', 'groq'}
 # Chat models
+GROQ_CHAT_MODELS = {
+    'llama-3.1-405b-reasoning',
+    'llama-3.1-70b-versatile',
+    'llama-3.1-8b-instant',
+    'llama3-70b-8192',
+    'mixtral-8x7b-32768'
+}
+
 ANTHROPIC_CHAT_MODELS = {
     'claude-3-opus-20240229',
     'claude-3-sonnet-20240229',

--- a/mindsdb/integrations/handlers/langchain_handler/langchain_handler.py
+++ b/mindsdb/integrations/handlers/langchain_handler/langchain_handler.py
@@ -10,6 +10,7 @@ from langchain.chains.conversation.memory import ConversationSummaryBufferMemory
 from langchain.schema import SystemMessage
 from langchain_openai import ChatOpenAI
 from langchain_community.chat_models import ChatAnthropic, ChatAnyscale, ChatLiteLLM, ChatOllama
+from langchain_groq import ChatGroq
 from langchain_core.prompts import PromptTemplate
 from langfuse import Langfuse
 from langfuse.callback import CallbackHandler
@@ -18,6 +19,7 @@ import numpy as np
 import pandas as pd
 
 from mindsdb.integrations.handlers.langchain_handler.constants import (
+    GROQ_CHAT_MODELS,
     ANTHROPIC_CHAT_MODELS,
     DEFAULT_AGENT_TIMEOUT_SECONDS,
     DEFAULT_AGENT_TOOLS,
@@ -63,6 +65,7 @@ class LangChainHandler(BaseMLEngine):
         - Anyscale
         - LiteLLM
         - Ollama
+        - Groq
 
     Supported standard tools:
         - python_repl
@@ -91,6 +94,8 @@ class LangChainHandler(BaseMLEngine):
             return args['provider']
         if args['model_name'] in ANTHROPIC_CHAT_MODELS:
             return 'anthropic'
+        if args['model_name'] in GROQ_CHAT_MODELS:
+            return 'groq'
         if args['model_name'] in OPEN_AI_CHAT_MODELS:
             return 'openai'
         if args['model_name'] in OLLAMA_CHAT_MODELS:
@@ -154,6 +159,8 @@ class LangChainHandler(BaseMLEngine):
 
         if args['provider'] == 'anthropic':
             return ChatAnthropic(**model_kwargs)
+        if args['provider'] == 'groq':
+            return ChatGroq(**model_kwargs)
         if args['provider'] == 'openai':
             # Some newer GPT models (e.g. gpt-4o when released) don't have token counting support yet.
             # By setting this manually in ChatOpenAI, we count tokens like compatible GPT models.

--- a/mindsdb/integrations/libs/llm/config.py
+++ b/mindsdb/integrations/libs/llm/config.py
@@ -9,6 +9,19 @@ class BaseLLMConfig(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
 
+class GroqConfig(BaseLLMConfig):
+    model: str
+    temperature: Optional[float]
+    max_tokens: Optional[int]
+    top_p: Optional[float]
+    top_k: Optional[int]
+    default_request_timeout: Optional[float]
+    # Inferred from GROQ_API_KEY if not provided.
+    groq_api_key: Optional[str]
+    groq_api_url: Optional[str]
+
+
+
 # See https://api.python.langchain.com/en/latest/chat_models/langchain_community.chat_models.openai.ChatOpenAI.html#langchain_community.chat_models.openai.ChatOpenAI
 # This config does not have to be exclusively used with Langchain.
 class OpenAIConfig(BaseLLMConfig):

--- a/mindsdb/integrations/libs/llm/utils.py
+++ b/mindsdb/integrations/libs/llm/utils.py
@@ -11,7 +11,7 @@ from langchain.text_splitter import (
 )
 
 from mindsdb.integrations.libs.llm.config import (AnthropicConfig, AnyscaleConfig, BaseLLMConfig, LiteLLMConfig,
-                                                  OllamaConfig, OpenAIConfig, MindsdbConfig)
+                                                  OllamaConfig, OpenAIConfig, MindsdbConfig,  GroqConfig)
 
 # Default to latest GPT-4 model (https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo)
 DEFAULT_OPENAI_MODEL = 'gpt-4-0125-preview'
@@ -19,6 +19,7 @@ DEFAULT_OPENAI_MODEL = 'gpt-4-0125-preview'
 DEFAULT_OPENAI_MAX_TOKENS = 2048
 DEFAULT_OPENAI_MAX_RETRIES = 3
 
+DEFAULT_GROQ_MODEL = 'llama3-70b-8192'
 DEFAULT_ANTHROPIC_MODEL = 'claude-3-haiku-20240307'
 
 DEFAULT_ANYSCALE_MODEL = 'meta-llama/Llama-2-7b-chat-hf'
@@ -104,6 +105,19 @@ def get_llm_config(provider: str, config: Dict) -> BaseLLMConfig:
             openai_organization=config.get('api_organization', None),
             request_timeout=config.get('request_timeout', None),
         )
+
+    if provider == 'groq':
+        return GroqConfig(
+            model=config.get('model_name', DEFAULT_GROQ_MODEL),
+            temperature=temperature,
+            max_tokens=config.get('max_tokens', None),
+            top_p=config.get('top_p', None),
+            top_k=config.get('top_k', None),
+            default_request_timeout=config.get('default_request_timeout', None),
+            groq_api_key=config['api_keys'].get('groq', None),
+            groq_api_url=config.get('base_url', None),
+        )
+
     if provider == 'anthropic':
         return AnthropicConfig(
             model=config.get('model_name', DEFAULT_ANTHROPIC_MODEL),

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -11,7 +11,7 @@ waitress >= 1.4.4
 pymongo[srv] >= 4.1.1
 psutil
 sqlalchemy >= 2.0.0, < 3.0.0
-psycopg2-binary  # This is required for using sqlalchemy with postgres
+psycopg2-binary
 alembic >= 1.3.3
 redis >=5.0.0, < 6.0.0
 walrus==0.9.3
@@ -37,17 +37,12 @@ protobuf==3.20.3
 hierarchicalforecast~=0.4.0
 google-auth-oauthlib
 msal
-#langchain==0.1.11
-transformers
-langchain>=0.1.9,<=2.1.0
-langchain-community==0.2.6
-langchain-core>=0.1.46, <0.3.0
-#langchain-core==0.2.10
-#langchain-core==0.1.46
-#langchain-community==0.0.27
-langchain-openai>=0.1.6
-langchain-text_splitters>=0.0.1
-langchain_groq
+langchain>=0.1.9,<=0.2.11
+langchain-openai>=0.1.6,<=0.1.19
+langchain-core==0.2.24
+langchain-community==0.0.27
+langchain-text_splitters>=0.0.1,<=0.2.2
+langchain-groq==0.1.5
 langfuse==2.35.0
 lark
 prometheus-client==0.20.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,7 +6,7 @@ flask == 2.2.5
 python-multipart >= 0.0.5
 pyparsing == 2.3.1
 cryptography>=35.0
-psycopg[binary]
+psycopg2-binary  # This is required for using sqlalchemy with postgres
 waitress >= 1.4.4
 pymongo[srv] >= 4.1.1
 psutil

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -37,11 +37,17 @@ protobuf==3.20.3
 hierarchicalforecast~=0.4.0
 google-auth-oauthlib
 msal
-langchain==0.1.11
-langchain-core==0.1.46
-langchain-community==0.0.27
-langchain-openai==0.1.6
-langchain-text_splitters==0.0.1
+#langchain==0.1.11
+transformers
+langchain>=0.1.9,<=2.1.0
+langchain-community==0.2.6
+langchain-core>=0.1.46, <0.3.0
+#langchain-core==0.2.10
+#langchain-core==0.1.46
+#langchain-community==0.0.27
+langchain-openai>=0.1.6
+langchain-text_splitters>=0.0.1
+langchain_groq
 langfuse==2.35.0
 lark
 prometheus-client==0.20.0


### PR DESCRIPTION
…requirements

## Description

Groq provides a fast access to llama models which is a few times faster than other provides including gpt, and it is on par with other models and much cheaper. Considering number of times mindsdb engine might access to the model, speed, accuracy, and price are the main factors. 


## Type of change
It is a new feature which is backward compatible as it only adds new provider. Having said that, there were a few version conflicts which I fixed although kept the other version commented in the requirements.txt. 

(Please delete options that are not relevant)

- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:
I have tested this multiple times on my server where I dont keep any left over caching. Here I have attached a photo 

## Additional Media:

<img width="668" alt="image" src="https://github.com/user-attachments/assets/691bb74f-831f-489d-ba35-aebee52fa709">

## Checklist:

I have tried to follow instruction as much as possible and keeping ALL THE NOTATION very close to other models. 



