### PR TITLE
Default to Generate for Ollama

### DIFF
--- a/mindsdb/integrations/handlers/ollama_handler/ollama_handler.py
+++ b/mindsdb/integrations/handlers/ollama_handler/ollama_handler.py
@@ -104,7 +104,7 @@ class OllamaHandler(BaseMLEngine):
         df['__mdb_prompt'] = prompts
 
         # setup endpoint
-        endpoint = args.get('mode')
+        endpoint = args.get('mode', 'generate')
 
         # call llm
         completions = []


### PR DESCRIPTION
## Description

Add a default mode for inference when calling the Ollama API. This avoids confusing behavior with JSON parsing errors or None types coming back in a SQL response. It also provides a reasonable default when a configuration hasn't specified which mode to use.

This fixes a situation where an JSON error is returned for a query:
```
ERROR:  [ollama_engine/llama3_1]: JSONDecodeError: Extra data: line 1 column 5 (char 4)
```

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected: Follow the [instructions](https://docs.mindsdb.com/integrations/ai-engines/ollama) to setup and run a prediction using ollama.

 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



