### PR TITLE
Update ray_serve_handler.py

### DIFF
--- a/mindsdb/integrations/handlers/ray_serve_handler/ray_serve_handler.py
+++ b/mindsdb/integrations/handlers/ray_serve_handler/ray_serve_handler.py
@@ -30,10 +30,16 @@ class RayServeHandler(BaseMLEngine):
         args = args['using']  # ignore the rest of the problem definition
         args['target'] = target
         self.model_storage.json_set('args', args)
+        # TODO: use headers dynamically
+        headers = {
+            'Content-Type': 'application/json; format=pandas-records',
+        }
+        if 'headers' in args and 'authorization' in args['headers']:  #added header authorization key based condition
+            headers['authorization'] = args['headers']['authorization']
         try:
             resp = requests.post(args['train_url'],
                                  json={'df': df.to_json(orient='records'), 'target': target},
-                                 headers={'content-type': 'application/json; format=pandas-records'})
+                                 headers=headers)
         except requests.exceptions.InvalidSchema:
             raise Exception("Error: The URL provided for the training endpoint is invalid.")
 
@@ -43,9 +49,15 @@ class RayServeHandler(BaseMLEngine):
 
     def predict(self, df, args=None):
         args = self.model_storage.json_get('args')  # override any incoming args for now
+        # TODO: use headers dynamically
+        headers = {
+            'Content-Type': 'application/json; format=pandas-records',
+        }
+        if 'headers' in args and 'authorization' in args['headers']:  #added header authorization key based condition
+            headers['authorization'] = args['headers']['authorization']
         resp = requests.post(args['predict_url'],
                              json={'df': df.to_json(orient='records')},
-                             headers={'content-type': 'application/json; format=pandas-records'})
+                             headers=headers)
         answer = resp.json()
         predictions = pd.DataFrame({args['target']: answer['prediction']})
         return predictions


### PR DESCRIPTION
MindsDB rayserve model  in GUI should accept headers parameters as well for security purpose. details: 
- Changed header to dynamic way. in Create function and call accordingly in the post request.  thanks

## Description

Please include a summary of the change and the issue it solves. 

Fixes #issue_number
https://github.com/mindsdb/mindsdb/issues/9559
## Type of change
Update ray_serve_handler for authorization request and request headers could work dynamically. 
(Please delete options that are not relevant)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📄 This change requires a documentation update

## Verification Process
I only verified it on local and found working. 
Actually this change will not affect the existing model.
If someone want to pass authorization token in headers parameter or not , the functionality will work accordingly. 



## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Relevant unit and integration tests are done on local.



