### PR TITLE
Fix: self.handlers_import_status could be changed during iteration

### DIFF
--- a/mindsdb/interfaces/database/integrations.py
+++ b/mindsdb/interfaces/database/integrations.py
@@ -761,7 +761,7 @@ class IntegrationController:
         # tries to import all not imported yet
 
         result = {}
-        for handler_name in self.handlers_import_status.keys():
+        for handler_name in list(self.handlers_import_status.keys()):
             handler_meta = self.get_handler_meta(handler_name)
             result[handler_name] = handler_meta
 


### PR DESCRIPTION
## Description

self.handlers_import_status could be changed during iteration: 
- when handlers imported in thread 
- or `/handlers` endpoint requested from user


## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



