### PR TITLE
Logging Agents History

### DIFF
--- a/mindsdb/interfaces/storage/db.py
+++ b/mindsdb/interfaces/storage/db.py
@@ -483,6 +483,36 @@ class Agents(Base):
             "created_at": self.created_at,
         }
 
+class AgentsHistory(Base):
+    __tablename__ = "agents_history"
+    id = Column(Integer, primary_key=True)
+    agent_id = Column(Integer, ForeignKey("agents.id", name="fk_agent_id"), nullable=False)
+    type = Column(String)  # TODO replace with enum if needed
+    text = Column(String)
+    sender_type = Column(String)  # 'AI' or 'Human'
+    destination = Column(String)
+    sent_at = Column(DateTime, default=datetime.datetime.now)
+    error = Column(String, nullable=True)
+    trace_id = Column(String, nullable=True)
+    observation_id = Column(String, nullable=True)
+    tools = Column(String, nullable=True)  # Store as a comma-separated string
+    stream_id = Column(String, nullable=True)  # Null if no stream, unique hash if it is a stream
+
+    def as_dict(self) -> Dict:
+        return {
+            "id": self.id,
+            "agent_id": self.agent_id,
+            "type": self.type,
+            "text": self.text,
+            "sender_type": self.sender_type,
+            "destination": self.destination,
+            "sent_at": self.sent_at,
+            "error": self.error,
+            "trace_id": self.trace_id,
+            "observation_id": self.observation_id,
+            "tools": self.tools,
+            "stream_id": self.stream_id,
+        }
 
 class KnowledgeBase(Base):
     __tablename__ = "knowledge_base"

--- a/mindsdb/migrations/versions/2024-08-05_4af5fbe71287_add_agents_history.py
+++ b/mindsdb/migrations/versions/2024-08-05_4af5fbe71287_add_agents_history.py
@@ -1,0 +1,44 @@
+"""add_agents_history
+
+Revision ID: 4af5fbe71287
+Revises: 45eb2eb61f70
+Create Date: 2024-08-05 11:22:56.297128
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import mindsdb.interfaces.storage.db  # noqa
+
+
+
+# revision identifiers, used by Alembic.
+revision = '4af5fbe71287'
+down_revision = '45eb2eb61f70'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('agents_history',
+    sa.Column('id', sa.INTEGER(), nullable=False),
+    sa.Column('agent_id', sa.INTEGER(), nullable=False),
+    sa.Column('type', sa.VARCHAR(), nullable=True),
+    sa.Column('text', sa.VARCHAR(), nullable=True),
+    sa.Column('sender_type', sa.VARCHAR(), nullable=True),
+    sa.Column('destination', sa.VARCHAR(), nullable=True),
+    sa.Column('sent_at', sa.DATETIME(), nullable=True),
+    sa.Column('error', sa.VARCHAR(), nullable=True),
+    sa.Column('trace_id', sa.VARCHAR(), nullable=True),
+    sa.Column('observation_id', sa.VARCHAR(), nullable=True),
+    sa.Column('tools', sa.VARCHAR(), nullable=True),
+    sa.Column('stream_id', sa.VARCHAR(), nullable=True),
+    sa.ForeignKeyConstraint(['agent_id'], ['agents.id'], name='fk_agent_id'),
+    sa.PrimaryKeyConstraint('id')
+    )
+
+
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    op.drop_table('agents_history')


### PR DESCRIPTION
## Description

This PR adds a new database class/table called AgentsHistory, that works similiar ChatBotsHistory.

Both human and AI messages are logged inside of the AgentsController.

For streaming, a "logging generator" is used ontop of the streaming iterator. It intercepts the chunks and logs them as they are retrieved.

Closes ML-102

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)


## Verification Process

To ensure the changes are working as expected:
Run a completion using an Agent/Agent Controller. Such as with the Agent Skill tutorial.
Check the mindsdb database for entries in the agents_history table.



