### PR TITLE
Fix documentdb connection_args

### DIFF
--- a/mindsdb/integrations/handlers/documentdb_handler/connection_args.py
+++ b/mindsdb/integrations/handlers/documentdb_handler/connection_args.py
@@ -36,7 +36,7 @@ connection_args = OrderedDict(
         'label': 'Port',
     },
     kwargs={
-        'type': dict,
+        'type': ARG_TYPE.DICT,
         'description': 'Additional parameters of DocumentDB same as MongoDB.',
         'required': False,
         'label': 'Kwargs',


### PR DESCRIPTION
## Description

There was an error in dockementdb connection_args: instead of `ARG_TYPE.DICT` there was just dict. Because of it, the connection_args was not be able to dump into json string.

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



