### PR TITLE
Use filetype instead of python-magic

### DIFF
--- a/docker/mindsdb.Dockerfile
+++ b/docker/mindsdb.Dockerfile
@@ -57,7 +57,7 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloa
 RUN --mount=target=/var/lib/apt,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     apt update && apt-get upgrade -y \
-    && apt-get install -y libmagic1 libpq5 freetds-bin curl
+    && apt-get install -y libpq5 freetds-bin curl
 RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked pip install -r requirements/requirements-dev.txt
 
 COPY docker/mindsdb_config.release.json /root/mindsdb_config.json
@@ -86,7 +86,7 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloa
 RUN --mount=target=/var/lib/apt,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     apt update && apt-get upgrade -y \
-    && apt-get install -y libmagic1 libpq5 freetds-bin curl
+    && apt-get install -y libpq5 freetds-bin curl
 
 COPY --link --from=build /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
 COPY docker/mindsdb_config.release.json /root/mindsdb_config.json

--- a/docs/contribute/install.mdx
+++ b/docs/contribute/install.mdx
@@ -86,14 +86,6 @@ mindsdb: http API: started on 47334
 
 You can access the MindsDB Editor at `localhost:47334`.
 
-<Tip>
-If you get the `ImportError: failed to find libmagic` error, you should install the `libmagic` manually by running one of the commands below:
-
-```bash
-pip install python-magic-bin # for linux and windows
-brew install libmagic # for macOS
-```
-</Tip>
 
 ## Install dependencies
 

--- a/docs/setup/self-hosted/pip/linux.mdx
+++ b/docs/setup/self-hosted/pip/linux.mdx
@@ -148,13 +148,6 @@ dependencies. Make sure to allocate min. 3 GB of disk space to avoid the
 Before anything, activate your virtual environment where your MindsDB is
 installed. It is to avoid the `No module named mindsdb` error.
 
-### How to Overcome `ImportError: failed to find libmagic`
-
-If you get the `ImportError: failed to find libmagic` error, you should install the `libmagic` manually by running the command below:
-
-```bash
-pip install python-magic-bin
-```
 
 ## Further Issues?
 

--- a/docs/setup/self-hosted/pip/macos.mdx
+++ b/docs/setup/self-hosted/pip/macos.mdx
@@ -145,14 +145,6 @@ export LDFLAGS="-L/usr/local/opt/libomp/lib"
 export CPPFLAGS="-I/usr/local/opt/libomp/include"
 ```
 
-### How to Overcome `ImportError: failed to find libmagic`
-
-If you get the `ImportError: failed to find libmagic` error, you should install the `libmagic` manually by running the command below:
-
-```bash
-brew install libmagic
-```
-
 ## Further Issues?
 
 You can try to replicate your issue using the

--- a/docs/setup/self-hosted/pip/source.mdx
+++ b/docs/setup/self-hosted/pip/source.mdx
@@ -117,14 +117,6 @@ the `starting` phase. But if the server has started and you still get this
 error, please report it on our
 [GitHub repository](https://github.com/mindsdb/mindsdb/issues).
 
-### How to Overcome `ImportError: failed to find libmagic`
-
-If you get the `ImportError: failed to find libmagic` error, you should install the `libmagic` manually by running one of the commands below:
-
-```bash
-pip install python-magic-bin  # for linux and windows
-brew install libmagic  # for macOS
-```
 
 ## Further Issues?
 

--- a/docs/setup/self-hosted/pip/windows.mdx
+++ b/docs/setup/self-hosted/pip/windows.mdx
@@ -140,14 +140,6 @@ If the installation fails when installing **torch** or **torchvision**, try to
 install them manually by following the instructions on their
 [official website](https://pytorch.org/get-started/locally/).
 
-### How to Overcome `ImportError: failed to find libmagic`
-
-If you get the `ImportError: failed to find libmagic` error, you should install the `libmagic` manually by running the command below:
-
-```bash
-pip install python-magic-bin
-```
-
 ## Further Issues?
 
 You can try to replicate your issue using the

--- a/mindsdb/integrations/handlers/file_handler/file_handler.py
+++ b/mindsdb/integrations/handlers/file_handler/file_handler.py
@@ -8,7 +8,7 @@ from io import BytesIO, StringIO
 from pathlib import Path
 from urllib.parse import urlparse
 
-import magic
+import filetype
 import pandas as pd
 import requests
 from charset_normalizer import from_bytes
@@ -210,7 +210,7 @@ class FileHandler(DatabaseHandler):
 
     @staticmethod
     def is_it_xlsx(file_path: str) -> bool:
-        file_type = magic.from_file(file_path, mime=True)
+        file_type = filetype.guess(file_path)
         if file_type in [
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             "application/vnd.ms-excel",

--- a/mindsdb/integrations/handlers/file_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/file_handler/requirements.txt
@@ -1,4 +1,4 @@
 charset-normalizer
-python-magic >= 0.4.27
+filetype
 openpyxl  # Optional dep of langchain for txt files
 pymupdf   # Optional dep for PDF files

--- a/tests/scripts/check_requirements.py
+++ b/tests/scripts/check_requirements.py
@@ -116,7 +116,6 @@ PACKAGE_NAME_MAP = {
     "hubspot-api-client": ["hubspot"],
     "pytest-lazy-fixture": ["pytest_lazyfixture"],
     "eventbrite-python": ["eventbrite"],
-    "python-magic": ["magic"],
     "clickhouse-sqlalchemy": ["clickhouse_sqlalchemy"],
     "pillow": ["PIL"],
     "auto-ts": ["auto_ts"],


### PR DESCRIPTION
## Description

This PR remove `python-magic` as a dependency for file type guessing and uses `filetype` as no dependency library.

Fixes #9600 

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [X] 📄 This change requires a documentation update

## Additional Media:

- [X] I have attached a screenshot showcasing the new functionality or change.
![Screenshot from 2024-08-07 14-11-02](https://github.com/user-attachments/assets/f7d7194f-da62-43c2-97ed-a1950d47855b)


## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [X] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



