### PR TITLE
Allow to use interval by agent

### DIFF
--- a/mindsdb/interfaces/skills/skill_tool.py
+++ b/mindsdb/interfaces/skills/skill_tool.py
@@ -87,7 +87,6 @@ class SkillToolController:
                     'Use the conversation context to decide which table to query. '
                     f'These are the available tables: {tables_list}.\n'
                     f'ALWAYS consider these special cases:\n'
-                    f'- Not all SQL functions are supported. Do NOT use the following functions: INTERVAL. \n'
                     f'- For TIMESTAMP type columns, make sure you include the time portion in your query (e.g. WHERE date_column = "2020-01-01 12:00:00")'
                     f'Here are the rest of the instructions:\n'
                     f'{tool.description}'

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,4 +1,4 @@
-docker >= 5.0.3
+docker >= 7.1.3
 hierarchicalforecast
 netifaces >= 0.11.0
 openai==1.24.0


### PR DESCRIPTION
## Description

Related to https://linear.app/mindsdb/issue/ML-66/mindsdb-sql-does-not-support-interval

In [mindsdb_sql](https://github.com/mindsdb/mindsdb_sql/pull/392) support of wrong interval syntax was made: 
- `interval 3 month`
- It doesn't work in postgres, but when it parsed it converted to `interval '3 month'`, and then it works in postgres

Now we can to use interval by agent and it should work fine

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



