### PR TITLE
Upgrade Llamaindex to latest

### DIFF
--- a/mindsdb/integrations/handlers/llama_index_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/llama_index_handler/requirements.txt
@@ -1,4 +1,4 @@
-llama-index==0.10.3
+llama-index==0.10.13
 openai == 1.24.0
 pydantic-settings >= 2.1.0
 llama-index-readers-web


### PR DESCRIPTION
## Description

This PR upgrades LlamaIndex to the latest `0.10.13` version

Fixes #https://github.com/mindsdb/mindsdb/security/dependabot/130




