### PR TITLE
Upgrade Litellm version

### DIFF
--- a/docs/integrations/ai-engines/langchain.mdx
+++ b/docs/integrations/ai-engines/langchain.mdx
@@ -23,7 +23,6 @@ Available models include the following:
 - Anyscale ([how to get the API key](https://docs.endpoints.anyscale.com/guides/authenticate/))
 - Ollama ([how to download Ollama](https://ollama.com/download))
 
-The LiteLLM model provider is available in MindsDB Cloud only. Use the MindsDB API key, which can be generated in the MindsDB Cloud editor at `cloud.mindsdb.com/account`.
 </Info>
 
 ## Setup
@@ -165,7 +164,7 @@ USING
      mode = 'conversational',                -- conversational mode
      user_column = 'question',               -- column name that stores input from the user
      assistant_column = 'answer',            -- column name that stores output of the model (see PREDICT column)
-     base_url = 'https://ai.dev.mindsdb.com',
+     base_url = 'http://0.0.0.0:4000,
      verbose = True,
      prompt_template = 'Answer the users input in a helpful way: {{question}}';
 ```

--- a/mindsdb/integrations/handlers/langchain_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/langchain_handler/requirements.txt
@@ -2,7 +2,7 @@ openai==1.24.0
 wikipedia==1.4.0
 tiktoken==0.5.2
 anthropic>=0.26.1
-litellm==1.35.0
+litellm==1.40.15
 chromadb # Knowledge bases.
 langchain-experimental==0.0.53
 -r mindsdb/integrations/handlers/openai_handler/requirements.txt

--- a/mindsdb/integrations/libs/llm/utils.py
+++ b/mindsdb/integrations/libs/llm/utils.py
@@ -34,7 +34,7 @@ DEFAULT_ANYSCALE_BASE_URL = "https://api.endpoints.anyscale.com/v1"
 
 DEFAULT_LITELLM_MODEL = "gpt-3.5-turbo"
 DEFAULT_LITELLM_PROVIDER = "openai"
-DEFAULT_LITELLM_BASE_URL = "https://ai.dev.mindsdb.com"
+DEFAULT_LITELLM_BASE_URL = "http://0.0.0.0:4000"
 
 DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434"
 DEFAULT_OLLAMA_MODEL = "llama2"


### PR DESCRIPTION
## Description

Upgrade litellm version in langchain. Also, this PR removes the default depricated `ai.mindsdb.dev` URL and sets default litellm proxy url.

Fixes:

1. https://github.com/mindsdb/mindsdb/security/dependabot/131
2. https://github.com/mindsdb/mindsdb/security/dependabot/133
3. https://github.com/mindsdb/mindsdb/security/dependabot/144

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update





