### PR TITLE
FileUpload from  allowed domains

### DIFF
--- a/docs/mindsdb_sql/sql/create/file.mdx
+++ b/docs/mindsdb_sql/sql/create/file.mdx
@@ -9,6 +9,19 @@ Follow the steps below to upload a file to MindsDB.
 Note that the trailing whitespaces on column names are erased upon uploading a file to MindsDB.
 </Note>
 
+<Warning>
+
+MindsDB supports file uploads from specific domains:
+
+1. **Amazon S3**: Use the S3 object URL.
+2. **Google Drive**: Use the shareable link. Ensure the file is publicly accessible.
+3. **Azure Blob Storage**: Use the blob URL.
+4. **Dropbox**: Use the shareable link. Ensure the file is publicly accessible.
+5. **GitHub**: Use the raw content URL.
+6. **OneDrive**: Use the shareable link. Ensure the file is publicly accessible.
+
+</Warning>
+
 1. Access the MindsDB Editor.
 2. Navigate to `Add data` section by clicking the `Add data` button located in
    the top right corner.
@@ -31,6 +44,7 @@ Note that the trailing whitespaces on column names are erased upon uploading a f
    <p align="center">
      <img src="/assets/sql/add-file-to-mindsdb-cloud-2.png" />
    </p>
+
 
 ## What's Next?
 

--- a/mindsdb/api/http/namespaces/file.py
+++ b/mindsdb/api/http/namespaces/file.py
@@ -22,6 +22,7 @@ from mindsdb.utilities.fs import safe_extract
 logger = log.getLogger(__name__)
 MAX_FILE_SIZE = 1024 * 1024 * 100  # 100Mb
 
+
 @ns_conf.route("/")
 class FilesList(Resource):
     @ns_conf.doc("get_files_list")
@@ -122,7 +123,7 @@ class File(Resource):
                         "Error getting file info",
                         "Сan't determine remote file size",
                     )
-                if file_size >  MAX_FILE_SIZE:
+                if file_size > MAX_FILE_SIZE:
                     return http_error(
                         400, "File is too big", "Upload limit for file is 100Mb"
                     )

--- a/mindsdb/api/http/namespaces/file.py
+++ b/mindsdb/api/http/namespaces/file.py
@@ -125,7 +125,7 @@ class File(Resource):
                     )
                 if file_size > MAX_FILE_SIZE:
                     return http_error(
-                        400, "File is too big", "Upload limit for file is 100Mb"
+                        400, "File is too big", f"Upload limit for file is {MAX_FILE_SIZE >> 20} MB"
                     )
             with requests.get(url, stream=True) as r:
                 if r.status_code != 200:

--- a/mindsdb/api/http/namespaces/file.py
+++ b/mindsdb/api/http/namespaces/file.py
@@ -16,11 +16,11 @@ from mindsdb.metrics.metrics import api_endpoint_metrics
 from mindsdb.utilities.config import Config
 from mindsdb.utilities.context import context as ctx
 from mindsdb.utilities import log
-from mindsdb.utilities.security import is_private_url, clear_filename
+from mindsdb.utilities.security import is_private_url, clear_filename, is_allowed_url
 from mindsdb.utilities.fs import safe_extract
 
 logger = log.getLogger(__name__)
-
+MAX_FILE_SIZE = 1024 * 1024 * 100  # 100Mb
 
 @ns_conf.route("/")
 class FilesList(Resource):
@@ -97,6 +97,8 @@ class File(Resource):
 
         if data.get("source_type") == "url":
             url = data["source"]
+            if not is_allowed_url(url):
+                return http_error(400, "Invalid File URL source. Only S3, Dropbox, GitHub, Google Drive and Azure Blob URLs are allowed.")
             data["file"] = clear_filename(data["name"])
 
             config = Config()
@@ -120,7 +122,7 @@ class File(Resource):
                         "Error getting file info",
                         "Сan't determine remote file size",
                     )
-                if file_size > 1024 * 1024 * 100:
+                if file_size >  MAX_FILE_SIZE:
                     return http_error(
                         400, "File is too big", "Upload limit for file is 100Mb"
                     )

--- a/mindsdb/utilities/security.py
+++ b/mindsdb/utilities/security.py
@@ -48,12 +48,11 @@ def is_allowed_url(url):
     """
     Checks if the provided URL is from an allowed host.
 
-    This function parses the URL and checks the network location part (netloc) 
+    This function parses the URL and checks the network location part (netloc)
     against a list of allowed hosts.
-    
+
     :param url: The URL to check.
     :return bool:  True if the URL is from an allowed host, False otherwise.
     """
     parsed_url = urlparse(url.lower())
     return parsed_url.netloc in ALLOWED_DOMAINS
-    

--- a/mindsdb/utilities/security.py
+++ b/mindsdb/utilities/security.py
@@ -31,3 +31,26 @@ def clear_filename(filename: str) -> str:
     for c in badchars:
         filename = filename.replace(c, '')
     return filename
+    
+#TODO: make this list configurable in config.json
+ALLOWED_DOMAINS = [
+    "s3.amazonaws.com",
+    "drive.google.com",
+    "blob.core.windows.net",
+    "dropbox.com",
+    "githubusercontent.com",
+    "onedrive.live.com"
+]
+
+def is_allowed_url(url):
+    """
+    Checks if the provided URL is from an allowed host.
+
+    This function parses the URL and checks the network location part (netloc) 
+    against a list of allowed hosts.
+    
+    :param url: The URL to check.
+    :return bool:  True if the URL is from an allowed host, False otherwise.
+    """
+    parsed_url = urlparse(url)
+    return parsed_url.netloc in ALLOWED_DOMAINS

--- a/mindsdb/utilities/security.py
+++ b/mindsdb/utilities/security.py
@@ -31,8 +31,9 @@ def clear_filename(filename: str) -> str:
     for c in badchars:
         filename = filename.replace(c, '')
     return filename
-    
-#TODO: make this list configurable in config.json
+
+
+# TODO: make this list configurable in config.json
 ALLOWED_DOMAINS = [
     "s3.amazonaws.com",
     "drive.google.com",
@@ -42,13 +43,14 @@ ALLOWED_DOMAINS = [
     "onedrive.live.com"
 ]
 
+
 def is_allowed_url(url):
     """
     Checks if the provided URL is from an allowed host.
 
-    This function parses the URL and checks the network location part (netloc) 
+    This function parses the URL and checks the network location part (netloc)
     against a list of allowed hosts.
-    
+
     :param url: The URL to check.
     :return bool:  True if the URL is from an allowed host, False otherwise.
     """

--- a/mindsdb/utilities/security.py
+++ b/mindsdb/utilities/security.py
@@ -48,11 +48,12 @@ def is_allowed_url(url):
     """
     Checks if the provided URL is from an allowed host.
 
-    This function parses the URL and checks the network location part (netloc)
+    This function parses the URL and checks the network location part (netloc) 
     against a list of allowed hosts.
-
+    
     :param url: The URL to check.
     :return bool:  True if the URL is from an allowed host, False otherwise.
     """
-    parsed_url = urlparse(url)
+    parsed_url = urlparse(url.lower())
     return parsed_url.netloc in ALLOWED_DOMAINS
+    


### PR DESCRIPTION
## Description

This PR Allows file upload URLs only from trusted domains as s3, g drive, azure blob.


Fixes https://linear.app/mindsdb/issue/BE-53/[dns-rebinding]-file-upload-from-url

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [X] 📄 This change requires a documentation update

## Additional Media:

- Google Drive file upload:
![Screenshot from 2024-08-13 17-19-39](https://github.com/user-attachments/assets/d9ff657a-f706-4d98-9098-585b34cfa3de)



## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [X] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



