### PR TITLE
Fixed Check for Relative Imports When Imported Handler Has No Requirements File

### DIFF
--- a/mindsdb/integrations/handlers/aurora_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/aurora_handler/requirements.txt
@@ -1,2 +1,1 @@
 -r mindsdb/integrations/handlers/mysql_handler/requirements.txt
--r mindsdb/integrations/handlers/postgres_handler/requirements.txt

--- a/mindsdb/integrations/handlers/cloud_sql_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/cloud_sql_handler/requirements.txt
@@ -1,3 +1,2 @@
 -r mindsdb/integrations/handlers/mysql_handler/requirements.txt
--r mindsdb/integrations/handlers/postgres_handler/requirements.txt
 -r mindsdb/integrations/handlers/mssql_handler/requirements.txt

--- a/mindsdb/integrations/handlers/cockroach_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/cockroach_handler/requirements.txt
@@ -1,1 +1,0 @@
--r mindsdb/integrations/handlers/postgres_handler/requirements.txt

--- a/mindsdb/integrations/handlers/kinetica_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/kinetica_handler/requirements.txt
@@ -1,1 +1,0 @@
--r mindsdb/integrations/handlers/postgres_handler/requirements.txt

--- a/mindsdb/integrations/handlers/materialize_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/materialize_handler/requirements.txt
@@ -1,1 +1,0 @@
--r mindsdb/integrations/handlers/postgres_handler/requirements.txt

--- a/mindsdb/integrations/handlers/opengauss_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/opengauss_handler/requirements.txt
@@ -1,1 +1,0 @@
--r mindsdb/integrations/handlers/postgres_handler/requirements.txt

--- a/mindsdb/integrations/handlers/orioledb_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/orioledb_handler/requirements.txt
@@ -1,1 +1,0 @@
--r mindsdb/integrations/handlers/postgres_handler/requirements.txt

--- a/mindsdb/integrations/handlers/pgvector_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/pgvector_handler/requirements.txt
@@ -1,2 +1,1 @@
 pgvector
--r mindsdb/integrations/handlers/postgres_handler/requirements.txt

--- a/mindsdb/integrations/handlers/redshift_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/redshift_handler/requirements.txt
@@ -1,1 +1,0 @@
--r mindsdb/integrations/handlers/postgres_handler/requirements.txt

--- a/mindsdb/integrations/handlers/supabase_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/supabase_handler/requirements.txt
@@ -1,1 +1,0 @@
--r mindsdb/integrations/handlers/postgres_handler/requirements.txt

--- a/mindsdb/integrations/handlers/timescaledb_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/timescaledb_handler/requirements.txt
@@ -1,1 +1,0 @@
--r mindsdb/integrations/handlers/postgres_handler/requirements.txt

--- a/mindsdb/integrations/handlers/yugabyte_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/yugabyte_handler/requirements.txt
@@ -1,1 +1,0 @@
--r mindsdb/integrations/handlers/postgres_handler/requirements.txt

--- a/tests/scripts/check_requirements.py
+++ b/tests/scripts/check_requirements.py
@@ -250,9 +250,12 @@ def check_relative_reqs():
 
             # Report on imports of other handlers that are missing a corresponding requirements.txt entry
             for line, imported_handler_name in imported_handlers.items():
-                if imported_handler_name not in required_handlers:
-                    errors.append(
-                        f"{line} <- {imported_handler_name} not in handler requirements.txt. Add it like: \"-r mindsdb/integrations/handlers/{imported_handler_name}/requirements.txt\"")
+                # Check if the imported handler has a requirements.txt file.
+                imported_handler_req_file = f"mindsdb/integrations/handlers/{imported_handler_name}/requirements.txt"
+                if os.path.exists(imported_handler_req_file):
+                    if imported_handler_name not in required_handlers:
+                        errors.append(
+                            f"{line} <- {imported_handler_name} not in handler requirements.txt. Add it like: \"-r {imported_handler_req_file}\"")
 
             # Print all the errors for this .py file
             print_errors(file, errors)


### PR DESCRIPTION
## Description

This PR updates the 'check requirements' CI workflow to check if the `requirements.txt` file for a handler imported in another handler exists before enforcing it in its own requirements.

Additionally, non-existent references to a PostgreSQL requirements.txt file has been removed across all handlers except for QuestDB, which has already been removed [here](https://github.com/mindsdb/mindsdb/pull/9622).

Fixes https://github.com/mindsdb/mindsdb/issues/9626

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added - N/A