### PR TITLE
Crawl only allowed sites

### DIFF
--- a/docs/integrations/ai-engines/llamaindex.mdx
+++ b/docs/integrations/ai-engines/llamaindex.mdx
@@ -74,6 +74,20 @@ Here is the output:
 
 ```
 
+### Configuring SimpleWebPageReader for Specific Domains
+
+When SimpleWebPageReader is used it can be configured to interact only with specific domains by using the `web_crawling_allowed_sites` setting in the `config.json` file. 
+This feature allows you to restrict the handler to read and process content only from the domains you specify, enhancing security and control over web interactions.
+
+To configure this, simply list the allowed domains under the `web_crawling_allowed_sites` key in `config.json`. For example:
+
+```json
+"web_crawling_allowed_sites": [
+    "https://docs.mindsdb.com",
+    "https://another-allowed-site.com"
+]
+```
+
 <Tip>
 
 **Next Steps**

--- a/docs/integrations/app-integrations/web-crawler.mdx
+++ b/docs/integrations/app-integrations/web-crawler.mdx
@@ -73,6 +73,19 @@ FROM my_web.crawler
 WHERE url = '<link-to-pdf-file>' 
 LIMIT 1;
 ```
+### Configuring Web Handler for Specific Domains
+
+The Web Handler can be configured to interact only with specific domains by using the `web_crawling_allowed_sites` setting in the `config.json` file. 
+This feature allows you to restrict the handler to crawl and process content only from the domains you specify, enhancing security and control over web interactions.
+
+To configure this, simply list the allowed domains under the `web_crawling_allowed_sites` key in `config.json`. For example:
+
+```json
+"web_crawling_allowed_sites": [
+    "https://docs.mindsdb.com",
+    "https://another-allowed-site.com"
+]
+```
 
 ## Troubleshooting
 

--- a/docs/mindsdb_sql/sql/create/file.mdx
+++ b/docs/mindsdb_sql/sql/create/file.mdx
@@ -9,18 +9,6 @@ Follow the steps below to upload a file to MindsDB.
 Note that the trailing whitespaces on column names are erased upon uploading a file to MindsDB.
 </Note>
 
-<Warning>
-
-MindsDB supports file uploads from specific domains:
-
-1. **Amazon S3**: Use the S3 object URL.
-2. **Google Drive**: Use the shareable link. Ensure the file is publicly accessible.
-3. **Azure Blob Storage**: Use the blob URL.
-4. **Dropbox**: Use the shareable link. Ensure the file is publicly accessible.
-5. **GitHub**: Use the raw content URL.
-6. **OneDrive**: Use the shareable link. Ensure the file is publicly accessible.
-
-</Warning>
 
 1. Access the MindsDB Editor.
 2. Navigate to `Add data` section by clicking the `Add data` button located in
@@ -45,6 +33,19 @@ MindsDB supports file uploads from specific domains:
      <img src="/assets/sql/add-file-to-mindsdb-cloud-2.png" />
    </p>
 
+### Configuring URL File Upload for Specific Domains
+
+The File Uploader can be configured to interact only with specific domains by using the `file_upload_domains` setting in the `config.json` file. 
+This feature allows you to restrict the handler to upoad and process files only from the domains you specify, enhancing security and control over web interactions.
+
+To configure this, simply list the allowed domains under the `file_upload_domains` key in `config.json`. For example:
+
+```json
+"file_upload_domains": [
+   "s3.amazonaws.com",
+    "drive.google.com"
+]
+```
 
 ## What's Next?
 

--- a/mindsdb/api/http/namespaces/file.py
+++ b/mindsdb/api/http/namespaces/file.py
@@ -16,7 +16,7 @@ from mindsdb.metrics.metrics import api_endpoint_metrics
 from mindsdb.utilities.config import Config
 from mindsdb.utilities.context import context as ctx
 from mindsdb.utilities import log
-from mindsdb.utilities.security import is_private_url, clear_filename, is_allowed_url
+from mindsdb.utilities.security import is_private_url, clear_filename, is_allowed_host
 from mindsdb.utilities.fs import safe_extract
 
 logger = log.getLogger(__name__)
@@ -98,7 +98,7 @@ class File(Resource):
 
         if data.get("source_type") == "url":
             url = data["source"]
-            if not is_allowed_url(url):
+            if not is_allowed_host(url):
                 return http_error(400, "Invalid File URL source. Only S3, Dropbox, GitHub, Google Drive and Azure Blob URLs are allowed.")
             data["file"] = clear_filename(data["name"])
 

--- a/mindsdb/integrations/handlers/llama_index_handler/README.md
+++ b/mindsdb/integrations/handlers/llama_index_handler/README.md
@@ -1,3 +1,8 @@
+---
+title: LlamaIndex
+sidebarTitle: LlamaIndex
+---
+
 ## LlamaIndex Handler
 
 This documentation describes the integration of MindsDB with [LlamaIndex](https://docs.llamaindex.ai/en/stable/), a framework for building context-augmented generative AI applications with LLMs. 
@@ -45,7 +50,6 @@ CREATE MODEL qa_model
 PREDICT answer
 USING 
   engine = 'llama_index', 
-  index_class = 'VectorStoreIndex',
   reader = 'SimpleWebPageReader',
   source_url_link = 'https://mindsdb.com/about',
   input_column = 'question';
@@ -65,9 +69,23 @@ Here is the output:
 +---------------------------+-------------------------------+
 |question                   |answer                         |
 +---------------------------+-------------------------------+
-|What is MindsDBs story?|MindsDB is a fast-growing open-source infrastructure company founded in 2017 by Adam Carrigan and Jorge Torres...|
+|What is MindsDB's story?    |MindsDB is a fast-growing open-source ...|
 +---------------------------+-------------------------------+
 
+```
+
+### Configuring SimpleWebPageReader for Specific Domains
+
+When SimpleWebPageReader is used it can be configured to interact only with specific domains by using the `web_crawling_allowed_sites` setting in the `config.json` file. 
+This feature allows you to restrict the handler to read and process content only from the domains you specify, enhancing security and control over web interactions.
+
+To configure this, simply list the allowed domains under the `web_crawling_allowed_sites` key in `config.json`. For example:
+
+```json
+"web_crawling_allowed_sites": [
+    "https://docs.mindsdb.com",
+    "https://another-allowed-site.com"
+]
 ```
 
 <Tip>

--- a/mindsdb/integrations/handlers/llama_index_handler/llama_index_handler.py
+++ b/mindsdb/integrations/handlers/llama_index_handler/llama_index_handler.py
@@ -13,7 +13,7 @@ from llama_index.core import Settings
 
 from mindsdb.integrations.libs.base import BaseMLEngine
 from mindsdb.utilities.config import Config
-from mindsdb.utilities.security import is_private_url
+from mindsdb.utilities.security import is_private_url, validate_crawling_sites
 from mindsdb.integrations.handlers.llama_index_handler.settings import llama_index_config, LlamaIndexModel
 from mindsdb.integrations.libs.api_handler_exceptions import MissingConnectionParams
 from mindsdb.integrations.utilities.handler_utils import get_api_key
@@ -62,11 +62,8 @@ class LlamaIndexHandler(BaseMLEngine):
             reader = list(map(lambda x: Document(text=x), dstrs.tolist()))
         elif args_reader == "SimpleWebPageReader":
             url = args["using"]["source_url_link"]
-            config = Config()
-            is_cloud = config.get("cloud", False)
-            if is_cloud and is_private_url(url):
-                raise Exception(f"URL is private: {url}")
-
+            if not validate_crawling_sites(url):
+                raise ValueError('The provided URL is not allowed for web crawling. Please check web_crawling_allowed_sites in config.json')
             reader = SimpleWebPageReader(html_to_text=True).load_data([url])
         else:
             raise Exception(

--- a/mindsdb/integrations/handlers/web_handler/README.md
+++ b/mindsdb/integrations/handlers/web_handler/README.md
@@ -73,6 +73,19 @@ FROM my_web.crawler
 WHERE url = '<link-to-pdf-file>' 
 LIMIT 1;
 ```
+### Configuring Web Handler for Specific Domains
+
+The Web Handler can be configured to interact only with specific domains by using the `web_crawling_allowed_sites` setting in the `config.json` file. 
+This feature allows you to restrict the handler to crawl and process content only from the domains you specify, enhancing security and control over web interactions.
+
+To configure this, simply list the allowed domains under the `web_crawling_allowed_sites` key in `config.json`. For example:
+
+```json
+"web_crawling_allowed_sites": [
+    "https://docs.mindsdb.com",
+    "https://another-allowed-site.com"
+]
+```
 
 ## Troubleshooting
 

--- a/mindsdb/integrations/handlers/web_handler/web_handler.py
+++ b/mindsdb/integrations/handlers/web_handler/web_handler.py
@@ -6,7 +6,7 @@ from mindsdb_sql.parser import ast
 from mindsdb.integrations.libs.api_handler import APIHandler, APITable
 from mindsdb.integrations.utilities.sql_utils import extract_comparison_conditions, project_dataframe
 
-from mindsdb.utilities.security import is_private_url, validate_crawling_sites
+from mindsdb.utilities.security import validate_crawling_sites
 from mindsdb.utilities.config import Config
 
 from .urlcrawl_helpers import get_all_websites

--- a/mindsdb/integrations/handlers/web_handler/web_handler.py
+++ b/mindsdb/integrations/handlers/web_handler/web_handler.py
@@ -1,14 +1,9 @@
 import pandas as pd
-
 from mindsdb.integrations.libs.response import HandlerStatusResponse
 from mindsdb_sql.parser import ast
-
 from mindsdb.integrations.libs.api_handler import APIHandler, APITable
 from mindsdb.integrations.utilities.sql_utils import extract_comparison_conditions, project_dataframe
-
 from mindsdb.utilities.security import validate_crawling_sites
-from mindsdb.utilities.config import Config
-
 from .urlcrawl_helpers import get_all_websites
 
 

--- a/mindsdb/integrations/handlers/web_handler/web_handler.py
+++ b/mindsdb/integrations/handlers/web_handler/web_handler.py
@@ -6,7 +6,7 @@ from mindsdb_sql.parser import ast
 from mindsdb.integrations.libs.api_handler import APIHandler, APITable
 from mindsdb.integrations.utilities.sql_utils import extract_comparison_conditions, project_dataframe
 
-from mindsdb.utilities.security import is_private_url
+from mindsdb.utilities.security import is_private_url, validate_crawling_sites
 from mindsdb.utilities.config import Config
 
 from .urlcrawl_helpers import get_all_websites
@@ -43,19 +43,13 @@ class CrawlerTable(APITable):
             raise NotImplementedError(
                 'You must specify what url you want to crawl, for example: SELECT * FROM crawl WHERE url = "someurl"')
 
+        if not validate_crawling_sites(urls):
+            raise ValueError('The provided URL is not allowed for web crawling. Please check web_crawling_allowed_sites in config.json')
+
         if query.limit is None:
             raise NotImplementedError('You must specify a LIMIT clause which defines the number of pages to crawl')
 
         limit = query.limit.value
-
-        config = Config()
-        is_cloud = config.get("cloud", False)
-        if is_cloud:
-            urls = [
-                url
-                for url in urls
-                if not is_private_url(url)
-            ]
 
         result = get_all_websites(urls, limit, html=False)
         if len(result) > limit:

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -162,7 +162,9 @@ class Config():
             "cache": {
                 "type": "local"
             },
-            'ml_task_queue': ml_queue
+            'ml_task_queue': ml_queue,
+            "file_upload_domains": [],
+            "web_crawling_allowed_sites": [],
         }
 
         return _merge_configs(self._default_config, self._override_config)

--- a/mindsdb/utilities/security.py
+++ b/mindsdb/utilities/security.py
@@ -66,5 +66,3 @@ def validate_crawling_sites(urls):
     # Check if all provided URLs are from the allowed sites
     valid = all(urlparse(url).netloc in allowed_netlocs for url in urls)
     return valid
-
-

--- a/mindsdb/utilities/security.py
+++ b/mindsdb/utilities/security.py
@@ -64,8 +64,7 @@ def validate_crawling_sites(urls):
     if isinstance(urls, str):
         urls = [urls]
     # Check if all provided URLs are from the allowed sites
-    valid = all(
-        any(urlparse(url).netloc == allowed_netloc for allowed_netloc in allowed_netlocs)
-        for url in urls
-    )
+    valid = all(urlparse(url).netloc in allowed_netlocs for url in urls)
     return valid
+
+

--- a/mindsdb/utilities/security.py
+++ b/mindsdb/utilities/security.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlparse
 import socket
 import ipaddress
-
+from mindsdb.utilities.config import Config
 
 def is_private_url(url: str):
     """
@@ -33,18 +33,7 @@ def clear_filename(filename: str) -> str:
     return filename
 
 
-# TODO: make this list configurable in config.json
-ALLOWED_DOMAINS = [
-    "s3.amazonaws.com",
-    "drive.google.com",
-    "blob.core.windows.net",
-    "dropbox.com",
-    "githubusercontent.com",
-    "onedrive.live.com"
-]
-
-
-def is_allowed_url(url):
+def is_allowed_host(url):
     """
     Checks if the provided URL is from an allowed host.
 
@@ -54,5 +43,28 @@ def is_allowed_url(url):
     :param url: The URL to check.
     :return bool:  True if the URL is from an allowed host, False otherwise.
     """
-    parsed_url = urlparse(url.lower())
-    return parsed_url.netloc in ALLOWED_DOMAINS
+    config = Config()
+    parsed_url = urlparse(url)
+    return parsed_url.netloc in config.get('file_upload_domains', [])
+
+
+def validate_crawling_sites(urls):
+    """
+    Checks if the provided URL is from one of the allowed sites for web crawling.
+
+    :param urls: The list of URLs to check.
+    :return bool: True if the URL is from one of the allowed sites, False otherwise.
+    """
+    config = Config()
+    allowed_urls = config.get('web_crawling_allowed_sites', [])
+    allowed_netlocs = [urlparse(allowed_url).netloc for allowed_url in allowed_urls]
+    if not allowed_urls:
+        return True
+    if isinstance(urls, str):
+        urls = [urls]
+    # Check if all provided URLs are from the allowed sites
+    valid = all(
+        any(urlparse(url).netloc == allowed_netloc for allowed_netloc in allowed_netlocs)
+        for url in urls
+    )
+    return valid

--- a/mindsdb/utilities/security.py
+++ b/mindsdb/utilities/security.py
@@ -3,6 +3,7 @@ import socket
 import ipaddress
 from mindsdb.utilities.config import Config
 
+
 def is_private_url(url: str):
     """
     Raises exception if url is private


### PR DESCRIPTION
## Description

This PR adds two `config.json` keys to limit the allowed hosts for File Upload from URL and crawling sites for Web Crawler and LalamaIndex WebPageReader.

Fixes #https://linear.app/mindsdb/issue/BE-54/[dns-rebinding]-web-handler-and-lalamaindex-web-page-reader

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [X] 📄 This change requires a documentation update

## Additional Media:
If only `docs.mindsdb.com` is added to `web_crawling_allowed_sites`
![Screenshot from 2024-08-16 14-20-04](https://github.com/user-attachments/assets/9e7ccf0a-d23c-4e50-9a89-94a6ca7eab58)



## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [X] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



