### PR TITLE
Improved getting of handler type

### DIFF
--- a/mindsdb/interfaces/database/integrations.py
+++ b/mindsdb/interfaces/database/integrations.py
@@ -294,10 +294,12 @@ class IntegrationController:
                 base_dir=integrations_dir
             )
 
-        integration_module = self.get_handler_module(integration_record.engine)
+        handler_meta = self.get_handler_meta(integration_record.engine)
         integration_type = None
-        if integration_module is not None:
-            integration_type = getattr(integration_module, 'type', None)
+        if isinstance(handler_meta, dict):
+            # in other cases, the handler directory is likely not to exist.
+            integration_type = handler_meta.get('type')
+        integration_module = self.get_handler_module(integration_record.engine)
 
         if show_secrets is False:
             connection_args = getattr(integration_module, 'connection_args', None)

--- a/mindsdb/interfaces/database/integrations.py
+++ b/mindsdb/interfaces/database/integrations.py
@@ -297,7 +297,7 @@ class IntegrationController:
         handler_meta = self.get_handler_meta(integration_record.engine)
         integration_type = None
         if isinstance(handler_meta, dict):
-            # in other cases, the handler directory is likely not to exist.
+            # in other cases, the handler directory is likely not exist.
             integration_type = handler_meta.get('type')
         integration_module = self.get_handler_module(integration_record.engine)
 


### PR DESCRIPTION
## Description

In the original version type of handler was get from handler module. But module may be `None` if import is not success. 
From other side, `handler_meta` should always exists if handler folder exists, regardless of import status.

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



