### PR TITLE
Fix: "Alias can not contain multiple parts" error

### DIFF
--- a/mindsdb/api/executor/command_executor.py
+++ b/mindsdb/api/executor/command_executor.py
@@ -1614,7 +1614,7 @@ class ExecuteCommands:
                     "connection_id": self.context.get('connection_id')
                 }
                 if function_name in functions_results:
-                    return Constant(functions_results[function_name], alias=Identifier(function_name))
+                    return Constant(functions_results[function_name], alias=Identifier(parts=[function_name]))
 
             if isinstance(node, Variable):
                 var_name = node.value
@@ -1624,7 +1624,7 @@ class ExecuteCommands:
                     logger.error(f"Unknown variable: {column_name}")
                     raise Exception(f"Unknown variable '{var_name}'")
                 else:
-                    return Constant(result[0], alias=Identifier(column_name))
+                    return Constant(result[0], alias=Identifier(parts=[column_name]))
 
         query_traversal(statement, adapt_query)
 

--- a/tests/unit/executor/test_base_queires.py
+++ b/tests/unit/executor/test_base_queires.py
@@ -442,6 +442,13 @@ class TestSelect(BaseExecutorDummyML):
         first_row = ret.to_dict('split')['data'][0]
         assert first_row == [1, 1, 1, 10]
 
+    def test_system_vars(self):
+
+        ret = self.run_sql('select @@session.auto_increment_increment, @@character_set_client')
+
+        assert ret.iloc[0, 0] == 1
+        assert ret.iloc[0, 1] == 'utf8'
+
 
 class TestDML(BaseExecutorDummyML):
 


### PR DESCRIPTION
## Description

Fix: prevent of creating alias with multiple parts for system variable

Fixes #9554

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



