### PR TITLE
Delete dbl: show error if it is used by KB

### DIFF
--- a/mindsdb/interfaces/database/integrations.py
+++ b/mindsdb/interfaces/database/integrations.py
@@ -244,6 +244,11 @@ class IntegrationController:
         if len(active_models) > 0:
             raise Exception(f'Unable to drop ml engine with active models: {active_models}')
 
+        # check linked KBs
+        kb = db.KnowledgeBase.query.filter_by(vector_database_id=integration_record.id).first()
+        if kb is not None:
+            raise Exception(f'Unable to drop, integration is used by knowledge base: {kb.name}')
+
         # check linked predictors
         models = get_model_records()
         for model in models:


### PR DESCRIPTION
## Description

When database is used by knowledge base and user tries to delete it, the error is:
![image](https://github.com/user-attachments/assets/5ee40985-1024-4f06-b21b-1f2c2c4b57ee)

After this PR it will be:
![image](https://github.com/user-attachments/assets/3545346b-ba08-42c3-bf1a-c1e530cd7e00)


Fixes #issue_number

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



