### PR TITLE
Don't Automatically Convert KB Name to Lower Case During Creation

### DIFF
--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -345,9 +345,6 @@ class KnowledgeBaseController:
 
         project_id = project.id
 
-        # not difference between cases in sql
-        name = name.lower()
-
         kb = self.get(name, project_id)
         if kb is not None:
             if if_not_exists:


### PR DESCRIPTION
This is a confusing side effect that can easily introduce bugs:
- Insert into a KB with capital name & try to get KB with same name fails
- Automatically created KB names (from files, websites, etc) containing capital names will be automatically renamed silently

We should leave the casing of the KB name as-is.


