### PR TITLE
Pinned Package Version of langchain-nvidia-ai-endpoints for Compatibility

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -42,7 +42,7 @@ langchain-core==0.1.46
 langchain-community==0.0.27
 langchain-openai==0.1.6
 langchain-text_splitters==0.0.1
-langchain-nvidia-ai-endpoints
+langchain-nvidia-ai-endpoints==0.1.7
 langfuse==2.35.0
 lark
 prometheus-client==0.20.0


### PR DESCRIPTION
## Description

This PR pins the version of the `langchain-nvidia-ai-endpoints` for compatibility with `langchain-core`.
It can be seen [here](https://github.com/langchain-ai/langchain-nvidia/compare/libs/ai-endpoints/v0.1.7...libs/ai-endpoints/v0.2.0) that in the change log for release 0.2.0 of `langchain-nvidia-ai-endpoints`, the minimum version of `langchain-core` has been bumped up to 0.1.47, which is incompatible with our 0.1.46.

Fixes https://github.com/mindsdb/mindsdb/issues/9690

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas - N/A
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added - N/A