### PR TITLE
Use default ssl certificate for mongo server

### DIFF
--- a/mindsdb/api/mongo/server.py
+++ b/mindsdb/api/mongo/server.py
@@ -251,18 +251,9 @@ class MongoRequestHandler(SocketServer.BaseRequestHandler):
 
     def _init_ssl(self):
         import ssl
-        import tempfile
-        import atexit
-        import os
 
-        from mindsdb.utilities.wizards import make_ssl_cert
+        ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
 
-        CERT_PATH = tempfile.mkstemp(prefix='mindsdb_cert_', text=True)[1]
-        make_ssl_cert(CERT_PATH)
-        atexit.register(lambda: os.remove(CERT_PATH))
-
-        ssl_context = ssl.SSLContext()
-        ssl_context.load_cert_chain(CERT_PATH)
         ssl_socket = ssl_context.wrap_socket(
             self.request,
             server_side=True,

--- a/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
+++ b/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
@@ -881,7 +881,7 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
             make_ssl_cert(cert_path)
             atexit.register(lambda: os.remove(cert_path))
         elif not os.path.exists(cert_path):
-            logger.error(f"Certificate not exists: {cert_path}")
+            logger.error("Certificate defined in 'certificate_path' setting does not exist")
 
         # TODO make it session local
         server_capabilities.set(CAPABILITIES.CLIENT_SSL, config["api"]["mysql"]["ssl"])

--- a/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
+++ b/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
@@ -880,6 +880,8 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
             cert_path = tempfile.mkstemp(prefix="mindsdb_cert_", text=True)[1]
             make_ssl_cert(cert_path)
             atexit.register(lambda: os.remove(cert_path))
+        elif not os.path.exists(cert_path):
+            logger.error(f"Certificate not exists: {cert_path}")
 
         # TODO make it session local
         server_capabilities.set(CAPABILITIES.CLIENT_SSL, config["api"]["mysql"]["ssl"])


### PR DESCRIPTION
## Description

Removed creation of cert file in mongo server, default ssl cert file is used instead

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



