### PR TITLE
Update docker-bake.hcl

### DIFF
--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -90,7 +90,7 @@ target "images" {
       },
       {
         name = "cloud"
-        extras = ".[lightwood,huggingface,statsforecast-extra,neuralforecast-extra,timegpt,mssql,youtube,gmail,pgvector,writer,rag,github,snowflake,clickhouse,bigquery,elasticsearch,s3,dynamodb,databricks,oracle] darts datasetsforecast"
+        extras = ".[lightwood,huggingface,statsforecast-extra,neuralforecast-extra,timegpt,mssql,youtube,gmail,pgvector,writer,rag,github,snowflake,clickhouse,bigquery,elasticsearch,s3,dynamodb,databricks,oracle,db2,teradata,hive] darts datasetsforecast"
         target = ""
       },
     ]


### PR DESCRIPTION
This PR adds IBM DB2, Teradata and Apache Hive to cloud