### PR TITLE
Add `created_at` field to skills response

### DIFF
--- a/mindsdb/interfaces/storage/db.py
+++ b/mindsdb/interfaces/storage/db.py
@@ -452,6 +452,7 @@ class Skills(Base):
             "agent_ids": [a.id for a in self.agents],
             "type": self.type,
             "params": self.params,
+            "created_at": self.created_at,
         }
 
 


### PR DESCRIPTION
## Description

Please include a summary of the change and the issue it solves. 

Adds the field `created_at` to skills response.

Fixes #issue_number

![Screenshot 2024-09-11 at 7 43 27 PM](https://github.com/user-attachments/assets/fadf8184-8bb9-4718-ae37-ee2bfcb9fe94)

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process


To ensure the changes are working as expected:

 - [X]   Test Location: Specify the URL or path for testing.



