### PR TITLE
Fix describe of ray server handler

### DIFF
--- a/mindsdb/integrations/libs/ml_handler_process/describe_process.py
+++ b/mindsdb/integrations/libs/ml_handler_process/describe_process.py
@@ -71,7 +71,7 @@ def describe_process(integration_id: int, attribute: Optional[Union[str, list]],
                 engine_storage=handlerStorage,
                 model_storage=modelStorage
             )
-            return ml_handler.describe(attribute=attribute)
+            return ml_handler.describe(attribute)
         except NotImplementedError:
             return DataFrame()
         except Exception as e:
@@ -96,7 +96,7 @@ def describe_process(integration_id: int, attribute: Optional[Union[str, list]],
                     engine_storage=handlerStorage,
                     model_storage=modelStorage
                 )
-                attrs_df = ml_handler.describe(attribute=attribute)
+                attrs_df = ml_handler.describe(attribute)
             except NotImplementedError:
                 pass
             except Exception as e:


### PR DESCRIPTION
## Description

Because first param in describe function could be named differently (for example in ray server handler): call describe function without name of first parameter. 

Fixes #issue_number

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



