### PR TITLE
Allow to use/redefine any connection parameters for Postgres handler

### DIFF
--- a/mindsdb/integrations/handlers/postgres_handler/connection_args.py
+++ b/mindsdb/integrations/handlers/postgres_handler/connection_args.py
@@ -46,6 +46,12 @@ connection_args = OrderedDict(
         'description': 'sslmode that will be used for connection.',
         'required': False,
         'label': 'sslmode'
+    },
+    parameters={
+        'type': ARG_TYPE.DICT,
+        'description': 'Connection string parameters',
+        'required': False,
+        'label': 'parameters'
     }
 )
 

--- a/mindsdb/integrations/handlers/postgres_handler/connection_args.py
+++ b/mindsdb/integrations/handlers/postgres_handler/connection_args.py
@@ -47,11 +47,11 @@ connection_args = OrderedDict(
         'required': False,
         'label': 'sslmode'
     },
-    parameters={
+    connection_parameters={
         'type': ARG_TYPE.DICT,
         'description': 'Connection string parameters',
         'required': False,
-        'label': 'parameters'
+        'label': 'connection_parameters'
     }
 )
 

--- a/mindsdb/integrations/handlers/postgres_handler/postgres_handler.py
+++ b/mindsdb/integrations/handlers/postgres_handler/postgres_handler.py
@@ -58,12 +58,12 @@ class PostgresHandler(DatabaseHandler):
         }
 
         # https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
-        parameters = self.connection_args.get('parameters')
-        if isinstance(parameters, dict) is False:
-            parameters = {}
-        if 'connect_timeout' not in parameters:
-            parameters['connect_timeout'] = 10
-        config.update(parameters)
+        connection_parameters = self.connection_args.get('connection_parameters')
+        if isinstance(connection_parameters, dict) is False:
+            connection_parameters = {}
+        if 'connect_timeout' not in connection_parameters:
+            connection_parameters['connect_timeout'] = 10
+        config.update(connection_parameters)
 
         if self.connection_args.get('sslmode'):
             config['sslmode'] = self.connection_args.get('sslmode')

--- a/mindsdb/integrations/handlers/postgres_handler/postgres_handler.py
+++ b/mindsdb/integrations/handlers/postgres_handler/postgres_handler.py
@@ -57,6 +57,14 @@ class PostgresHandler(DatabaseHandler):
             'dbname': self.connection_args.get('database')
         }
 
+        # https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
+        parameters = self.connection_args.get('parameters')
+        if isinstance(parameters, dict) is False:
+            parameters = {}
+        if 'connect_timeout' not in parameters:
+            parameters['connect_timeout'] = 10
+        config.update(parameters)
+
         if self.connection_args.get('sslmode'):
             config['sslmode'] = self.connection_args.get('sslmode')
 
@@ -81,7 +89,7 @@ class PostgresHandler(DatabaseHandler):
 
         config = self._make_connection_args()
         try:
-            self.connection = psycopg.connect(**config, connect_timeout=10)
+            self.connection = psycopg.connect(**config)
             self.is_connected = True
             return self.connection
         except psycopg.Error as e:


### PR DESCRIPTION
## Description

This allows to use or redefine any connection parameters for postgres (and any dependent) handler
```sql
CREATE DATABASE example_db_xxx3
WITH ENGINE = "postgres",
PARAMETERS = {
    "user": "demo_user",
    "password": "demo_password",
    "host": "samples.mindsdb.com",
    "port": "5432",
    "database": "demo",
    "schema": "demo_data",
    "connection_parameters": {
        "connect_timeout": 30
    }
};

```


Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



