### PR TITLE
Updated the Pydantic Model for Amazon Bedrock to Dismiss Warning

### DIFF
--- a/mindsdb/integrations/handlers/bedrock_handler/settings.py
+++ b/mindsdb/integrations/handlers/bedrock_handler/settings.py
@@ -109,7 +109,7 @@ class AmazonBedrockHandlerModelConfig(BaseModel):
 
     Attributes
     ----------
-    model_id : Text
+    id : Text
         The ID of the model in Amazon Bedrock.
 
     mode : Optional[Text]
@@ -140,7 +140,7 @@ class AmazonBedrockHandlerModelConfig(BaseModel):
         The connection arguments passed required to connect to Amazon Bedrock. These are AWS credentials provided when creating the engine.
     """
     # User-provided Handler Model Prameters: These are parameters specific to the MindsDB handler for Amazon Bedrock provided by the user.
-    model_id: Text = Field(None)
+    id: Text = Field(None)
     mode: Optional[Text] = Field(AmazonBedrockHandlerSettings.DEFAULT_MODE)
     prompt_template: Optional[Text] = Field(None)
     question_column: Optional[Text] = Field(None)
@@ -205,9 +205,9 @@ class AmazonBedrockHandlerModelConfig(BaseModel):
             ValueError: If the model ID provided is invalid or the parameters provided are invalid for the chosen model.
         """
         # TODO: Set the default model ID for other modes.
-        if model.model_id is None:
+        if model.id is None:
             if model.mode in ['default', 'conversational']:
-                model.model_id = AmazonBedrockHandlerSettings.DEFAULT_TEXT_MODEL_ID
+                model.id = AmazonBedrockHandlerSettings.DEFAULT_TEXT_MODEL_ID
 
         bedrock_client = create_amazon_bedrock_client(
             "bedrock",
@@ -216,7 +216,7 @@ class AmazonBedrockHandlerModelConfig(BaseModel):
 
         try:
             # Check if the model ID is valid and accessible.
-            response = bedrock_client.get_foundation_model(modelIdentifier=model.model_id)
+            response = bedrock_client.get_foundation_model(modelIdentifier=model.id)
         except ClientError as e:
             raise ValueError(f"Invalid Amazon Bedrock model ID: {e}!")
 


### PR DESCRIPTION
## Description

This PR updates the `AmazonBedrockHandlerModelConfig` Pydantic model of the Amazon Bedrock integration by converting the `model_id` parameter to `id` in order to dismiss the warning given below that is displayed when MindsDB is started up:
`/usr/local/lib/python3.10/site-packages/pydantic/_internal/_fields.py:132: UserWarning: Field "model_id" in AmazonBedrockHandlerModelConfig has conflict with protected namespace "model_".`

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added - N/A