### PR TITLE
Add Flush to Langfuse & Handle Errors Properly for Getting Traces

### DIFF
--- a/mindsdb/interfaces/agents/langchain_agent.py
+++ b/mindsdb/interfaces/agents/langchain_agent.py
@@ -22,6 +22,7 @@ from langchain_nvidia_ai_endpoints import ChatNVIDIA
 from langchain_core.prompts import PromptTemplate
 from langchain_core.tools import Tool
 from langfuse import Langfuse
+from langfuse.api.resources.commons.errors.not_found_error import NotFoundError as TraceNotFoundError
 from langfuse.callback import CallbackHandler
 
 from mindsdb.integrations.handlers.openai_handler.constants import (
@@ -288,9 +289,16 @@ class LangchainAgent:
             self.api_trace.update(output=response)
 
             # update metadata with tool usage
-            trace = self.langfuse.get_trace(self.trace_id)
-            trace_metadata['tool_usage'] = get_tool_usage(trace)
-            self.api_trace.update(metadata=trace_metadata)
+            try:
+                # Ensure all batched traces are sent before fetching.
+                self.langfuse.flush()
+                trace = self.langfuse.get_trace(self.trace_id)
+                trace_metadata['tool_usage'] = get_tool_usage(trace)
+                self.api_trace.update(metadata=trace_metadata)
+            except TraceNotFoundError:
+                logger.warning(f'Langfuse trace {self.trace_id} not found')
+            except Exception as e:
+                logger.error(f'Something went wrong while processing Langfuse trace {self.trace_id}: {str(e)}')
         return response
 
     def _get_completion_stream(

--- a/mindsdb/interfaces/agents/langfuse_callback_handler.py
+++ b/mindsdb/interfaces/agents/langfuse_callback_handler.py
@@ -29,6 +29,8 @@ class LangfuseCallbackHandler(BaseCallbackHandler):
         """Run when tool starts running."""
         parent_run_uuid = kwargs.get('parent_run_id', uuid4()).hex
         action_span = self.action_uuid_to_span.get(parent_run_uuid)
+        if action_span is None:
+            return
         metadata = {
             'tool_name': serialized.get("name", "tool"),
             'started': datetime.datetime.now().isoformat()
@@ -39,6 +41,8 @@ class LangfuseCallbackHandler(BaseCallbackHandler):
         """Run when tool ends running."""
         parent_run_uuid = kwargs.get('parent_run_id', uuid4()).hex
         action_span = self.action_uuid_to_span.get(parent_run_uuid)
+        if action_span is None:
+            return
         action_span.update(
             output=output,  # tool output is action output (unless superseded by a global action output)
             metadata={'finished': datetime.datetime.now().isoformat()}
@@ -50,6 +54,8 @@ class LangfuseCallbackHandler(BaseCallbackHandler):
         """Run when tool errors."""
         parent_run_uuid = kwargs.get('parent_run_id', uuid4()).hex
         action_span = self.action_uuid_to_span.get(parent_run_uuid)
+        if action_span is None:
+            return
         try:
             error_str = str(error)
         except Exception:
@@ -75,6 +81,8 @@ class LangfuseCallbackHandler(BaseCallbackHandler):
         if chain_uuid not in self.chain_uuid_to_span:
             return
         chain_span = self.chain_uuid_to_span.pop(chain_uuid)
+        if chain_span is None:
+            return
         chain_span.update(output=str(outputs))
         chain_span.end()
 
@@ -102,6 +110,8 @@ class LangfuseCallbackHandler(BaseCallbackHandler):
         if run_uuid not in self.action_uuid_to_span:
             return
         action_span = self.action_uuid_to_span.pop(run_uuid)
+        if action_span is None:
+            return
         if finish is not None:
             action_span.update(output=finish)  # supersedes tool output
         action_span.end()


### PR DESCRIPTION
## Description

Fixes https://linear.app/mindsdb/issue/CLOUD-458/langfusenotfounderror-error

See https://github.com/orgs/langfuse/discussions/2879 for more context.

To ensure all batched traces are sent to Langfuse before fetching traces that should exist, we add a call to `flush` before `get_trace`.

This PR also adds error handling to `get_trace`. We should extend this work by implementing similar error handling for _all_ code paths that use Langfuse, not just `get_trace`.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



