### PR TITLE
Updated the Uses of host in the SAP Hana Integration Docs to address

### DIFF
--- a/docs/integrations/data-integrations/sap-hana.mdx
+++ b/docs/integrations/data-integrations/sap-hana.mdx
@@ -22,7 +22,7 @@ CREATE DATABASE sap_hana_datasource
 WITH
     ENGINE = 'hana',
     PARAMETERS = {
-        "host": "123e4567-e89b-12d3-a456-426614174000.hana.trial-us10.hanacloud.ondemand.com",
+        "address": "123e4567-e89b-12d3-a456-426614174000.hana.trial-us10.hanacloud.ondemand.com",
         "port": "443",
         "user": "demo_user",
         "password": "demo_password",
@@ -32,7 +32,7 @@ WITH
 
 Required connection parameters include the following:
 
-* `host`: The hostname, IP address, or URL of the SAP HANA database.
+* `address`: The hostname, IP address, or URL of the SAP HANA database.
 * `port`: The port number for connecting to the SAP HANA database.
 * `user`: The username for the SAP HANA database.
 * `password`: The password for the SAP HANA database.

--- a/mindsdb/integrations/handlers/hana_handler/README.md
+++ b/mindsdb/integrations/handlers/hana_handler/README.md
@@ -22,7 +22,7 @@ CREATE DATABASE sap_hana_datasource
 WITH
     ENGINE = 'hana',
     PARAMETERS = {
-        "host": "123e4567-e89b-12d3-a456-426614174000.hana.trial-us10.hanacloud.ondemand.com",
+        "address": "123e4567-e89b-12d3-a456-426614174000.hana.trial-us10.hanacloud.ondemand.com",
         "port": "443",
         "user": "demo_user",
         "password": "demo_password",
@@ -32,7 +32,7 @@ WITH
 
 Required connection parameters include the following:
 
-* `host`: The hostname, IP address, or URL of the SAP HANA database.
+* `address`: The hostname, IP address, or URL of the SAP HANA database.
 * `port`: The port number for connecting to the SAP HANA database.
 * `user`: The username for the SAP HANA database.
 * `password`: The password for the SAP HANA database.

--- a/mindsdb/integrations/handlers/hana_handler/tests/test_hana_handler.py
+++ b/mindsdb/integrations/handlers/hana_handler/tests/test_hana_handler.py
@@ -31,7 +31,7 @@ class HanaHandlerTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.kwargs = {
-            "host": os.environ.get('HANA_HOST', 'localhost'),
+            "address": os.environ.get('HANA_ADDRESS', 'localhost'),
             "port": os.environ.get('HANA_PORT', 30015),
             "user": "DBADMIN",
             "password": os.environ.get('HANA_PASSWORD'),


### PR DESCRIPTION
## Description

This PR updates the incorrect uses of `host` in the docs for the SAP Hana integration to `address`.

## Type of change

- [X] 📄 This change is a documentation update

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas - N/A
- [X] Necessary documentation updates are either made or tracked in issues.
- [X] Relevant unit and integration tests are updated or added.



