### PR TITLE
Reset index when join dataframes

### DIFF
--- a/mindsdb/api/executor/sql_query/result_set.py
+++ b/mindsdb/api/executor/sql_query/result_set.py
@@ -220,7 +220,7 @@ class ResultSet:
         if self._df is None:
             self._df = df
         else:
-            self._df = pd.concat([self._df, df])
+            self._df = pd.concat([self._df, df], ignore_index=True)
 
     def add_raw_values(self, values):
 


### PR DESCRIPTION
## Description

When two dataframes are concatenated, the resulting dataframe will have duplicate indexes.
```python
a = df([1,2,3], columns=['a'])
b = df([1,2,3], columns=['a'])
pandas.concat([a, b]).index
# Index([0, 1, 2, 0, 1, 2], dtype='int64')
```
this is cause of error here https://github.com/mindsdb/mindsdb/blob/main/mindsdb/integrations/libs/ml_exec_base.py#L247
```
ValueError: cannot reindex on an axis with duplicate labels
```

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



