### PR TITLE
Chat-bot Support for Multiple Tables and Multiple ID Columns (MS Teams Chat-bot for Channels)

### DIFF
--- a/mindsdb/integrations/handlers/ms_teams_handler/ms_teams_handler.py
+++ b/mindsdb/integrations/handlers/ms_teams_handler/ms_teams_handler.py
@@ -148,7 +148,6 @@ class MSTeamsHandler(APIChatHandler):
             'tables': [
                 {
                     'polling': {
-                        'type': 'message_count',
                         'table': 'chats',
                         'chat_id_col': 'id',
                         'count_col': 'lastMessagePreview_id'
@@ -163,7 +162,6 @@ class MSTeamsHandler(APIChatHandler):
                 },
                 {
                     'polling': {
-                        'type': 'message_count',
                         'table': 'channels',
                         'chat_id_col': ['teamId', 'id'],
                         'count_col': 'lastMessagePreview_id'

--- a/mindsdb/integrations/handlers/ms_teams_handler/ms_teams_handler.py
+++ b/mindsdb/integrations/handlers/ms_teams_handler/ms_teams_handler.py
@@ -144,17 +144,39 @@ class MSTeamsHandler(APIChatHandler):
         params = {
             'polling': {
                 'type': 'message_count',
-                'table': 'chats',
-                'chat_id_col': 'id',
-                'count_col': 'lastMessagePreview_id'
             },
-            'chat_table': {
-                'name': 'chat_messages',
-                'chat_id_col': 'chatId',
-                'username_col': 'from_user_displayName',
-                'text_col': 'body_content',
-                'time_col': 'createdDateTime',
-            }
+            'tables': [
+                {
+                    'polling': {
+                        'type': 'message_count',
+                        'table': 'chats',
+                        'chat_id_col': 'id',
+                        'count_col': 'lastMessagePreview_id'
+                    },
+                    'chat_table': {
+                        'name': 'chat_messages',
+                        'chat_id_col': 'chatId',
+                        'username_col': 'from_user_displayName',
+                        'text_col': 'body_content',
+                        'time_col': 'createdDateTime',
+                    }
+                },
+                {
+                    'polling': {
+                        'type': 'message_count',
+                        'table': 'channels',
+                        'chat_id_col': ['teamId', 'id'],
+                        'count_col': 'lastMessagePreview_id'
+                    },
+                    'chat_table': {
+                        'name': 'channel_messages',
+                        'chat_id_col': ['channelIdentity_teamId', 'channelIdentity_channelId'],
+                        'username_col': 'from_user_displayName',
+                        'text_col': 'body_content',
+                        'time_col': 'createdDateTime',
+                    }
+                }
+            ]
         }
 
         return params

--- a/mindsdb/integrations/handlers/ms_teams_handler/settings.py
+++ b/mindsdb/integrations/handlers/ms_teams_handler/settings.py
@@ -113,6 +113,7 @@ class MSTeamsHandlerConfig(BaseSettings):
         "webUrl",
         "membershipType",
         "teamId",
+        "lastMessagePreview_id"
     ]
 
     CHANNEL_MESSAGES_TABLE_COLUMNS: List = [

--- a/mindsdb/interfaces/chatbot/chatbot_task.py
+++ b/mindsdb/interfaces/chatbot/chatbot_task.py
@@ -71,10 +71,10 @@ class ChatBotTask(BaseTask):
 
         self.chat_pooling.run(stop_event)
 
-    def on_message(self, chat_memory, message: ChatBotMessage):
+    def on_message(self, chat_memory, message: ChatBotMessage, table_name=None):
 
         try:
-            self._on_message(chat_memory, message)
+            self._on_message(chat_memory, message, table_name)
         except (SystemExit, KeyboardInterrupt):
             raise
         except Exception:
@@ -82,7 +82,7 @@ class ChatBotTask(BaseTask):
             logger.error(error)
             self.set_error(str(error))
 
-    def _on_message(self, chat_memory, message: ChatBotMessage):
+    def _on_message(self, chat_memory, message: ChatBotMessage, table_name=None):
         # add question to history
         # TODO move it to realtime pooling
         chat_memory.add_to_history(message)
@@ -105,7 +105,7 @@ class ChatBotTask(BaseTask):
         )
 
         # send to chat adapter
-        self.chat_pooling.send_message(response_message)
+        self.chat_pooling.send_message(response_message, table_name=table_name)
         logger.debug(f'>>chatbot {chat_id} out: {response_message.text}')
 
         # send to history

--- a/mindsdb/interfaces/chatbot/chatbot_task.py
+++ b/mindsdb/interfaces/chatbot/chatbot_task.py
@@ -53,8 +53,8 @@ class ChatBotTask(BaseTask):
 
         polling = chat_params['polling']['type']
         if polling == 'message_count':
-            self.chat_pooling = MessageCountPolling(self, chat_params)
-            self.memory = HandlerMemory(self, chat_params)
+            self.chat_pooling = MessageCountPolling(self, chat_params if isinstance(chat_params, list) else [chat_params])
+            self.memory = HandlerMemory(self, chat_params if isinstance(chat_params, list) else [chat_params])
 
         elif polling == 'realtime':
             self.chat_pooling = RealtimePolling(self, chat_params)

--- a/mindsdb/interfaces/chatbot/chatbot_task.py
+++ b/mindsdb/interfaces/chatbot/chatbot_task.py
@@ -53,8 +53,9 @@ class ChatBotTask(BaseTask):
 
         polling = chat_params['polling']['type']
         if polling == 'message_count':
-            self.chat_pooling = MessageCountPolling(self, chat_params if isinstance(chat_params, list) else [chat_params])
-            self.memory = HandlerMemory(self, chat_params if isinstance(chat_params, list) else [chat_params])
+            chat_params = chat_params['tables'] if 'tables' in chat_params else [chat_params]
+            self.chat_pooling = MessageCountPolling(self, chat_params)
+            self.memory = HandlerMemory(self, chat_params)
 
         elif polling == 'realtime':
             self.chat_pooling = RealtimePolling(self, chat_params)

--- a/mindsdb/interfaces/chatbot/memory.py
+++ b/mindsdb/interfaces/chatbot/memory.py
@@ -94,19 +94,20 @@ class HandlerMemory(BaseMemory):
         text_col = t_params['text_col']
         username_col = t_params['username_col']
         time_col = t_params['time_col']
+        chat_id_cols = t_params['chat_id_col'] if isinstance(t_params['chat_id_col'], list) else [t_params['chat_id_col']]
 
         ast_query = Select(
             targets=[Identifier(text_col),
                      Identifier(username_col),
                      Identifier(time_col)],
             from_table=Identifier(t_params['name']),
-            where=BinaryOperation(
+            where=[BinaryOperation(
                 op='=',
                 args=[
-                    Identifier(t_params['chat_id_col']),
-                    Constant(chat_id)
+                    Identifier(chat_id_col),
+                    Constant(chat_id[idx])
                 ]
-            ),
+            ) for idx, chat_id_col in enumerate(chat_id_cols)],
             order_by=[OrderBy(Identifier(time_col))],
             limit=Constant(self.MAX_DEPTH),
         )

--- a/mindsdb/interfaces/chatbot/memory.py
+++ b/mindsdb/interfaces/chatbot/memory.py
@@ -21,14 +21,14 @@ class BaseMemory:
         self.chat_params = chat_params
         self.chat_task = chat_task
 
-    def get_chat(self, chat_id):
-        return ChatMemory(self, chat_id)
+    def get_chat(self, chat_id, table_name=None):
+        return ChatMemory(self, chat_id, table_name=table_name)
 
-    def hide_history(self, chat_id, left_count):
+    def hide_history(self, chat_id, left_count, table_name=None):
         '''
         set date to start hiding messages
         '''
-        history = self.get_chat_history(chat_id)
+        history = self.get_chat_history(chat_id, table_name=table_name)
         if left_count > len(history) - 1:
             left_count = len(history) - 1
         sent_at = history[-left_count].sent_at
@@ -62,12 +62,13 @@ class BaseMemory:
         if chat_id in self._cache:
             del self._cache[chat_id]
 
-    def get_chat_history(self, chat_id, cached=True):
-        if cached and chat_id in self._cache:
-            history = self._cache[chat_id]
+    def get_chat_history(self, chat_id, table_name=None, cached=True):
+        key = (chat_id, table_name) if table_name else chat_id
+        if cached and key in self._cache:
+            history = self._cache[key]
         else:
-            history = self._get_chat_history(chat_id)
-            self._cache[chat_id] = history
+            history = self._get_chat_history(chat_id, table_name)
+            self._cache[key] = history
 
         history = self._apply_hiding(chat_id, history)
         return history
@@ -88,8 +89,10 @@ class HandlerMemory(BaseMemory):
         # do nothing. sent message will be stored by handler db
         pass
 
-    def _get_chat_history(self, chat_id):
-        t_params = self.chat_params['chat_table']
+    def _get_chat_history(self, chat_id, table_name):
+        t_params = next(
+            chat_params['chat_table'] for chat_params in self.chat_params if chat_params['chat_table']['name'] == table_name
+        )
 
         text_col = t_params['text_col']
         username_col = t_params['username_col']
@@ -179,14 +182,19 @@ class ChatMemory:
     '''
     interface to work with individual chat
     '''
-    def __init__(self, memory, chat_id):
+    def __init__(self, memory, chat_id, table_name=None):
         self.memory = memory
         self.chat_id = chat_id
+        self.table_name = table_name
 
         self.cached = False
 
     def get_history(self, cached=True):
-        result = self.memory.get_chat_history(self.chat_id, cached=cached and self.cached)
+        if self.table_name:
+            result = self.memory.get_chat_history(self.chat_id, self.table_name, cached=cached and self.cached)
+        else:
+            result = self.memory.get_chat_history(self.chat_id, cached=cached and self.cached)
+
         self.cached = True
         return result
 
@@ -203,4 +211,4 @@ class ChatMemory:
         '''
         set date to start hiding messages
         '''
-        self.memory.hide_history(self.chat_id, left_count)
+        self.memory.hide_history(self.chat_id, left_count, table_name=self.table_name)

--- a/mindsdb/interfaces/chatbot/memory.py
+++ b/mindsdb/interfaces/chatbot/memory.py
@@ -66,8 +66,12 @@ class BaseMemory:
         key = (chat_id, table_name) if table_name else chat_id
         if cached and key in self._cache:
             history = self._cache[key]
+
         else:
-            history = self._get_chat_history(chat_id, table_name)
+            if table_name is None:
+                history = self._get_chat_history(chat_id)
+            else:
+                history = self._get_chat_history(chat_id, table_name)
             self._cache[key] = history
 
         history = self._apply_hiding(chat_id, history)

--- a/mindsdb/interfaces/chatbot/polling.py
+++ b/mindsdb/interfaces/chatbot/polling.py
@@ -18,11 +18,13 @@ class BasePolling:
     def start(self, stop_event):
         raise NotImplementedError
 
-    def send_message(self, message: ChatBotMessage):
+    def send_message(self, message: ChatBotMessage, table_name=None):
         chat_id = message.destination
         text = message.text
 
-        t_params = self.params["chat_table"]
+        t_params = self.params["chat_table"] if table_name is None else next(
+            (t["chat_table"] for t in self.params if t["chat_table"]["name"] == table_name)
+        )
         chat_id_cols = t_params["chat_id_col"] if isinstance(t_params["chat_id_col"], list) else [t_params["chat_id_col"]]
 
         ast_query = Insert(
@@ -46,22 +48,27 @@ class MessageCountPolling(BasePolling):
     def run(self, stop_event):
         while True:
             try:
-                chat_ids = self.check_message_count()
-                logger.debug(f"number of chat ids found: {len(chat_ids)}")
-                for chat_id in chat_ids:
-                    try:
-                        chat_memory = self.chat_task.memory.get_chat(chat_id)
-                    except Exception as e:
-                        logger.error(f"Problem retrieving chat memory: {e}")
+                for chat_params in self.params:
+                    chat_ids = self.check_message_count(chat_params)
+                    logger.debug(f"number of chat ids found: {len(chat_ids)}")
 
-                    try:
-                        message = self.get_last_message(chat_memory)
-                    except Exception as e:
-                        logger.error(f"Problem getting last message: {e}")
-                        message = None
+                    for chat_id in chat_ids:
+                        try:
+                            chat_memory = self.chat_task.memory.get_chat(
+                                chat_id,
+                                table_name=chat_params["chat_table"]["name"],
+                            )
+                        except Exception as e:
+                            logger.error(f"Problem retrieving chat memory: {e}")
 
-                    if message:
-                        self.chat_task.on_message(chat_memory, message)
+                        try:
+                            message = self.get_last_message(chat_memory)
+                        except Exception as e:
+                            logger.error(f"Problem getting last message: {e}")
+                            message = None
+
+                        if message:
+                            self.chat_task.on_message(chat_memory, message, table_name=chat_params["chat_table"]["name"])
 
             except Exception as e:
                 logger.error(e)
@@ -84,8 +91,8 @@ class MessageCountPolling(BasePolling):
             return
         return last_message
 
-    def check_message_count(self):
-        p_params = self.params["polling"]
+    def check_message_count(self, chat_params):
+        p_params = chat_params["polling"]
 
         chat_ids = []
 

--- a/mindsdb/interfaces/chatbot/polling.py
+++ b/mindsdb/interfaces/chatbot/polling.py
@@ -19,7 +19,7 @@ class BasePolling:
         raise NotImplementedError
 
     def send_message(self, message: ChatBotMessage, table_name=None):
-        chat_id = message.destination
+        chat_id = message.destination if isinstance(message.destination, tuple) else (message.destination,)
         text = message.text
 
         t_params = self.params["chat_table"] if table_name is None else next(


### PR DESCRIPTION
## Description

This PR improves the MS Teams chat-bot with the ability to respond in channels.

In the process of doing so, the following improvements have been made to the chat-bot interface,
1. Added support for tables whose rows are unique based on a composite key. At the moment, the `chat_id_col` parameter of the config only accepts a single ID column, but in the case of the `channels` and `channel_messages` table of the MS Teams integration, rows are uniquely identified based both the team ID and channel ID.
2. Added support for chat-bots that require multiple polling tasks. With the current implementation, only a single polling task is supported per chat-bot. However, for the MS Teams integration, two message count polling tasks are required for chat messages and channel messages.

Fixes https://linear.app/mindsdb/issue/BE-214/resolve-inability-to-communicate-with-ms-teams-channel

## Type of change

- [X] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

![image](https://github.com/user-attachments/assets/71409fb6-e316-4723-bb87-b41c56acf241)

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.

