### PR TITLE
Langfuse minor fix during login/auth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,14 @@ services:
       # SENTRY_IO_FORCE_RUN: "true" # Uncomment me to force-start sentry on local development. Good for profiling, but may annoy other devs on sentry.io with the "noise"
       # MINDSDB_LOG_LEVEL: "DEBUG"
       # OPENAI_API_KEY: "..."
+      LANGFUSE_HOST: "OMITTED_FOR_SECURITY"
+      LANGFUSE_PUBLIC_KEY: "OMITTED_FOR_SECURITY"
+      LANGFUSE_SECRET_KEY: "OMITTED_FOR_SECURITY"
+      LANGFUSE_RELEASE: "local"
+      # LANGFUSE_DEBUG: "True"
+      LANGFUSE_TIMEOUT: "10"
+      LANGFUSE_SAMPLE_RATE: "1.0"
+
     volumes:
       - type: bind
         source: .

--- a/mindsdb/interfaces/agents/langchain_agent.py
+++ b/mindsdb/interfaces/agents/langchain_agent.py
@@ -201,7 +201,8 @@ class LangchainAgent:
             self.langfuse = Langfuse(
                 public_key=os.getenv('LANGFUSE_PUBLIC_KEY'),
                 secret_key=os.getenv('LANGFUSE_SECRET_KEY'),
-                host=os.getenv('LANGFUSE_HOST')
+                host=os.getenv('LANGFUSE_HOST'),
+                release=os.getenv('LANGFUSE_RELEASE', 'local'),
             )
 
         # agent is using current langchain model
@@ -473,10 +474,14 @@ class LangchainAgent:
                     tags=get_tags(metadata),
                     metadata=metadata,
                 )
-                if not self.langfuse_callback_handler.auth_check():
-                    logger.error(
-                        f"Incorrect Langfuse credentials provided to Langchain handler. Full args: {args}"
-                    )
+                try:
+                    # This try is critical to catch fatal errors which would otherwise prevent the agent from running properly
+                    if not self.langfuse_callback_handler.auth_check():
+                        logger.error(
+                            f"Incorrect Langfuse credentials provided to Langchain handler. Full args: {args}"
+                        )
+                except Exception as e:
+                    logger.error(f'Something went wrong while running langfuse_callback_handler.auth_check {str(e)}')
 
             # custom tracer
             if self.mdb_langfuse_callback_handler is None:


### PR DESCRIPTION
## Description

Without this any agentic calls fail if LangFuse is offline or temporarily unavailable due to the uncaught exception of auth.  Also adds the "release" into the init and adds example values into the docker compose file

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)