### PR TITLE
Support having LAST in function

### DIFF
--- a/mindsdb/interfaces/query_context/context_controller.py
+++ b/mindsdb/interfaces/query_context/context_controller.py
@@ -45,10 +45,10 @@ class QueryContextController:
 
         query_str = l_query.to_string()
 
-        rec = self.__get_context_record(context_name, query_str)
+        rec = self._get_context_record(context_name, query_str)
 
         if rec is None or len(rec.values) == 0:
-            values = self.__get_init_last_values(l_query, dn, session)
+            values = self._get_init_last_values(l_query, dn, session)
             if rec is None:
                 self.__add_context_record(context_name, query_str, values)
                 if context_name.startswith('job-if-'):
@@ -147,7 +147,7 @@ class QueryContextController:
             db.session.delete(rec)
         db.session.commit()
 
-    def __get_init_last_values(self, l_query: LastQuery, dn, session) -> dict:
+    def _get_init_last_values(self, l_query: LastQuery, dn, session) -> dict:
         """
         Gets current last values for query.
         Creates and executes query for it:
@@ -254,7 +254,7 @@ class QueryContextController:
         return vars
 
     # DB
-    def __get_context_record(self, context_name: str, query_str: str) -> db.QueryContext:
+    def _get_context_record(self, context_name: str, query_str: str) -> db.QueryContext:
         """
         Find and return record for context and query string
         """
@@ -281,7 +281,7 @@ class QueryContextController:
         """
         Updates context record with new values
         """
-        rec = self.__get_context_record(context_name, query_str)
+        rec = self._get_context_record(context_name, query_str)
         rec.values = values
         db.session.commit()
 

--- a/mindsdb/interfaces/query_context/last_query.py
+++ b/mindsdb/interfaces/query_context/last_query.py
@@ -3,7 +3,7 @@ import copy
 from collections import defaultdict
 
 from mindsdb_sql.parser.ast import (
-    Identifier, Select, BinaryOperation, Last, Constant, Star, ASTNode, NullConstant, OrderBy
+    Identifier, Select, BinaryOperation, Last, Constant, Star, ASTNode, NullConstant, OrderBy, Function, TypeCast
 )
 from mindsdb_sql.planner.utils import query_traversal
 
@@ -24,7 +24,7 @@ class LastQuery:
             return
 
         self.last_idx = defaultdict(list)
-        last_tables = self.__find_last_columns(query)
+        last_tables = self._find_last_columns(query)
         if last_tables is None:
             return
 
@@ -32,7 +32,7 @@ class LastQuery:
 
         self.last_tables = last_tables
 
-    def __find_last_columns(self, query: ASTNode) -> Union[dict, None]:
+    def _find_last_columns(self, query: ASTNode) -> Union[dict, None]:
         """
           This function:
            - Searches LAST column in the input query
@@ -46,7 +46,8 @@ class LastQuery:
                     'table': <table identifier>,
                     'column': <column name>,
                     'links': [<link to ast node>, ... ],
-                    'target_idx': <number of column in select target>
+                    'target_idx': <number of column in select target>,
+                    'gen_init_query': if true: to generate query to initial values for las
                 }
         """
 
@@ -54,10 +55,26 @@ class LastQuery:
         tables_idx = defaultdict(dict)
         conditions = []
 
-        def _index_query(node, is_table, parent_query, **kwargs):
+        def replace_last_in_tree(node, injected):
+            # go into functions and type casts
+            if isinstance(node, TypeCast):
+                if isinstance(node.arg, Last):
+                    node.arg = injected
+                    return injected
+                return replace_last_in_tree(node.arg, injected)
+            if isinstance(node, Function):
+                for i, arg in enumerate(node.args):
+                    if isinstance(arg, Last):
+                        node.args[i] = injected
+                        return injected
+                    found = replace_last_in_tree(arg, injected)
+                    if found:
+                        return found
+
+        def index_query(node, is_table, parent_query, **kwargs):
 
             parent_query_id = id(parent_query)
-
+            last = None
             if is_table and isinstance(node, Identifier):
                 # memorize table
                 tables_idx[parent_query_id][node.parts[-1]] = node
@@ -66,23 +83,42 @@ class LastQuery:
 
             # find last in where
             if isinstance(node, BinaryOperation):
-                if isinstance(node.args[0], Identifier) and isinstance(node.args[1], Last):
-                    # memorize node
-                    conditions.append([parent_query_id, node])
+                if isinstance(node.args[0], Identifier):
+                    col = node.args[0]
+                    gen_init_query = True
+
+                    # col > last
+                    if isinstance(node.args[1], Last):
+                        last = Constant(None)
+                        # inject constant
+                        node.args[1] = last
+
+                    # col > coalesce(last, 0) OR col > cast(coalense(last ...))
+                    else:
+                        injected = Constant(None)
+                        last = replace_last_in_tree(node.args[1], injected)
+                        gen_init_query = False
+
+            if last is not None:
+                # memorize
+                conditions.append({
+                    'query_id': parent_query_id,
+                    'condition': node,
+                    'last': last,
+                    'column': col,
+                    'gen_init_query': gen_init_query  # generate query to fetch initial last values from table
+                })
 
         # find lasts
-        query_traversal(query, _index_query)
+        query_traversal(query, index_query)
 
         if len(conditions) == 0:
             return
 
         self.query_orig = copy.deepcopy(query)
 
-        for parent_query_id, node in conditions:
-            # inject constant
-            link = Constant(None)
-            node.args[1] = link
-            self.last_idx[parent_query_id].append(node)
+        for info in conditions:
+            self.last_idx[info['query_id']].append(info)
 
         # index query targets
         query_id = id(query)
@@ -110,9 +146,10 @@ class LastQuery:
         # make info about query
 
         last_columns = {}
-        for parent_query_id, nodes in self.last_idx.items():
-            for node in nodes:
-                col, last = node.args
+        for parent_query_id, items in self.last_idx.items():
+            for info in items:
+                col = info['column']
+                last = info['last']
                 tables = tables_idx[parent_query_id]
 
                 uniq_tables = len(set([id(v) for v in tables.values()]))
@@ -120,12 +157,12 @@ class LastQuery:
 
                     table = tables.get(col.parts[-2])
                     if table is None:
-                        raise Exception('cant find table')
+                        raise ValueError('cant find table')
                 elif uniq_tables == 1:
                     table = list(tables.values())[0]
                 else:
                     # or just skip it?
-                    raise Exception('cant find table')
+                    raise ValueError('cant find table')
 
                 col_name = col.parts[-1]
 
@@ -138,19 +175,20 @@ class LastQuery:
                             # will try to get by name
                             ...
                         else:
-                            raise Exception('Last value should be in query target')
+                            raise ValueError('Last value should be in query target')
 
                     last_columns[table_name] = {
                         'table': table,
                         'column': col_name,
                         'links': [last],
-                        'target_idx': target_idx
+                        'target_idx': target_idx,
+                        'gen_init_query': info['gen_init_query']
                     }
 
                 elif last_columns[table_name]['column'] == col_name:
                     last_columns[table_name]['column'].append(last)
                 else:
-                    raise Exception('possible to use only one column')
+                    raise ValueError('possible to use only one column')
 
         return last_columns
 
@@ -172,6 +210,7 @@ class LastQuery:
                 'table_name': table_name,
                 'column_name': info['column'],
                 'target_idx': info['target_idx'],
+                'gen_init_query': info['gen_init_query'],
             }
             for table_name, info in self.last_tables.items()
         ]
@@ -188,11 +227,15 @@ class LastQuery:
         return self.query
 
     def get_init_queries(self):
+        """
+        A generator of queries to get initial value of the last
+        """
 
         back_up_values = []
         # replace values
-        for nodes in self.last_idx.values():
-            for node in nodes:
+        for items in self.last_idx.values():
+            for info in items:
+                node = info['condition']
                 back_up_values.append([node.op, node.args[1]])
                 node.op = 'is not'
                 node.args[1] = NullConstant()
@@ -200,13 +243,16 @@ class LastQuery:
         query2 = copy.deepcopy(self.query)
 
         # return values
-        for nodes in self.last_idx.values():
-            for node in nodes:
+        for items in self.last_idx.values():
+            for info in items:
+                node = info['condition']
                 op, arg1 = back_up_values.pop(0)
                 node.op = op
                 node.args[1] = arg1
 
         for info in self.get_last_columns():
+            if not info['gen_init_query']:
+                continue
             col = Identifier(info['column_name'])
             query2.targets = [col]
             query2.order_by = [

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -17,7 +17,7 @@ redis >=5.0.0, < 6.0.0
 walrus==0.9.3
 flask-compress >= 1.0.0
 appdirs >= 1.0.0
-mindsdb-sql ~= 0.19.0
+mindsdb-sql ~= 0.20.0
 pydantic >= 2.7.0
 mindsdb-evaluator >= 0.0.7, < 0.1.0
 checksumdir >= 1.2.0

--- a/tests/unit/executor/test_base_queires.py
+++ b/tests/unit/executor/test_base_queires.py
@@ -410,6 +410,39 @@ class TestSelect(BaseExecutorDummyML):
         assert len(ret) == 1
         assert ret.a[0] == 8
 
+    def test_last_coalesce(self):
+        df = pd.DataFrame([
+            {'a': 1, 'b': 'a'},
+            {'a': 2, 'b': 'b'},
+            {'a': 3, 'b': 'c'},
+        ])
+
+        self.set_data('tasks', df)
+
+        sql = '''
+            select * from dummy_data.tasks 
+            where a > coalesce(last, 1)
+        '''
+
+        # first call two rows
+        ret = self.run_sql(sql)
+        assert len(ret) == 2
+
+        # second call zero rows
+        ret = self.run_sql(sql)
+        assert len(ret) == 0
+
+        # add rows to dataframe
+        df.loc[len(df.index)] = [4, 'd']  # should be tracked
+        df.loc[len(df.index)] = [0, 'z']  # not tracked
+        self.set_data('tasks', df)
+
+        ret = self.run_sql(sql)
+
+        # have to be one new line
+        assert len(ret) == 1
+        assert ret.a[0] == 4
+
     @patch('mindsdb.integrations.handlers.postgres_handler.Handler')
     def test_interval(self, data_handler):
         df = pd.DataFrame([


### PR DESCRIPTION
## Description

Support having LAST in function. 
It can be useful in case when we want to set default value instead of the LAST. 
For example here the first run of the query return all rows with id>10 
```sql
Select * from integration.table
where id > coalesce(LAST, 10)
```

If only LAST is used (without function, is the current behavior), the first run of the query will return 0 rows
```sql
Select * from integration.table
where id > LAST
```
 
For both cases next run of the query will return only rows where id is greater than it was on previous run

For datetime columns it could require to use type cast:
```sql
Select * from integration.table
where created_at > coalesce(LAST, '2010-11-12')::timestamp
```

Demo:



Dependent on: https://github.com/mindsdb/mindsdb_sql/pull/407

Fixes #issue_number

## Type of change

- [x ] ⚡ New feature (non-breaking change which adds functionality)
## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



