### PR TITLE
Langchain adapter for mindsdb KB

### DIFF
--- a/mindsdb/integrations/utilities/rag/loaders/vector_store_loader/MDBVectorStore.py
+++ b/mindsdb/integrations/utilities/rag/loaders/vector_store_loader/MDBVectorStore.py
@@ -1,0 +1,54 @@
+from mindsdb_sql.parser.ast import Select, BinaryOperation, Identifier, Constant, Star
+from mindsdb.integrations.libs.vectordatabase_handler import TableField
+
+from typing import Any, List, Optional
+
+from langchain_core.documents import Document
+from langchain_core.embeddings import Embeddings
+from langchain_core.vectorstores import VectorStore
+
+
+class MDBVectorStore(VectorStore):
+
+    def __init__(self, kb_table) -> None:
+        self.kb_table = kb_table
+
+    @property
+    def embeddings(self) -> Optional[Embeddings]:
+        return None
+
+    def similarity_search(
+        self,
+        query: str,
+        k: int = 4,
+        **kwargs: Any,
+    ) -> List[Document]:
+
+        query = Select(
+            targets=[Star()],
+            where=BinaryOperation(op='=', args=[
+                Identifier(TableField.CONTENT.value), Constant(query)
+            ]),
+            limit=Constant(k),
+        )
+
+        df = self.kb_table.select_query(query)
+
+        docs = []
+        for _, row in df.iterrows():
+            metadata = row[TableField.METADATA.value]
+            if metadata is None:
+                metadata = {}
+            docs.append(Document(
+                page_content=row[TableField.CONTENT.value],
+                metadata=metadata
+            ))
+
+        return docs
+
+    def add_texts(self, *args, **kwargs) -> List[str]:
+        raise NotImplementedError
+
+    @classmethod
+    def from_texts(self, *args, **kwargs):
+        raise NotImplementedError

--- a/mindsdb/integrations/utilities/rag/loaders/vector_store_loader/vector_store_loader.py
+++ b/mindsdb/integrations/utilities/rag/loaders/vector_store_loader/vector_store_loader.py
@@ -6,6 +6,7 @@ from langchain_core.vectorstores import VectorStore
 from pydantic import BaseModel
 
 from mindsdb.integrations.utilities.rag.settings import VectorStoreType, VectorStoreConfig
+from mindsdb.integrations.utilities.rag.loaders.vector_store_loader.MDBVectorStore import MDBVectorStore
 from mindsdb.utilities import log
 
 
@@ -27,8 +28,7 @@ class VectorStoreLoader(BaseModel):
         Loads the vector store based on the provided config and embeddings model
         :return:
         """
-        self.vector_store = VectorStoreFactory.create(self.embedding_model, self.config)
-        return self.vector_store
+        return MDBVectorStore(kb_table=self.config.kb_table)
 
 
 class VectorStoreFactory:

--- a/mindsdb/integrations/utilities/rag/settings.py
+++ b/mindsdb/integrations/utilities/rag/settings.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List, Union
+from typing import List, Union, Any
 
 from langchain_community.vectorstores.chroma import Chroma
 from langchain_community.vectorstores.pgvector import PGVector
@@ -92,6 +92,7 @@ class VectorStoreConfig(BaseModel):
     persist_directory: str = None
     collection_name: str = DEFAULT_COLLECTION_NAME
     connection_string: str = None
+    kb_table: Any = None
 
     class Config:
         arbitrary_types_allowed = True

--- a/mindsdb/interfaces/agents/tools.py
+++ b/mindsdb/interfaces/agents/tools.py
@@ -40,7 +40,11 @@ def _build_retrieval_tool(tool: dict, pred_args: dict, skill: db.Skills):
         if not kb:
             raise ValueError(f"Knowledge base not found: {kb_name}")
 
-        rag_params['vector_store_config'] = _build_vector_store_config_from_knowledge_base(rag_params, kb, executor)
+        kb_table = executor.session.kb_controller.get_table(kb.name, kb.project_id)
+
+        rag_params['vector_store_config'] = {
+            'kb_table': kb_table
+        }
 
     # Can run into weird validation errors when unpacking rag_params directly into constructor.
     rag_config = RAGPipelineModel(

--- a/tests/unit/executor/test_agent.py
+++ b/tests/unit/executor/test_agent.py
@@ -133,3 +133,24 @@ class TestAgent(BaseExecutorDummyML):
                 found = True
         if not found:
             raise AttributeError('Agent response is not found')
+
+    @patch('openai.OpenAI')
+    def test_agent_retrieval(self, mock_openai):
+        self.run_sql('create knowledge base kb_review')
+        # self.run_sql('''
+        #   create skill retr_skill
+        #   using
+        #       type = 'retrieval',
+        #       source = 'kb_review',
+        #       description = 'user reviews'
+        # ''')
+        # self.run_sql('''
+        #   create agent retrieve_agent
+        #    using
+        #   skills=['retr_skill'],
+        #   model='gpt-4o',
+        #   provider='openai',
+        #   prompt_template='Answer the user input in a helpful way using tools',
+        #   mode='retrieval'
+        # ''')
+        # ret = self.run_sql('main purpose to buy Kindle Voyage according to reviews')

--- a/tests/unit/executor/test_agent.py
+++ b/tests/unit/executor/test_agent.py
@@ -1,3 +1,4 @@
+import os
 import pandas as pd
 from tests.unit.executor_test_base import BaseExecutorDummyML
 
@@ -5,14 +6,28 @@ from unittest.mock import patch
 
 
 def set_openai_completion(mock_openai, response):
-    mock_openai().chat.completions.create.return_value = {
-        'choices': [{
-            'message': {
-                'role': 'system',
-                'content': response
-            }
-        }]
-    }
+
+    if not isinstance(response, list):
+        response = [response]
+
+    def resp_f(*args, **kwargs):
+        # return all responses in sequence, then yield only latest from list
+
+        if len(response) == 1:
+            resp = response[0]
+        else:
+            resp = response.pop(0)
+
+        return {
+            'choices': [{
+                'message': {
+                    'role': 'system',
+                    'content': resp
+                }
+            }]
+        }
+
+    mock_openai().chat.completions.create.side_effect = resp_f
 
 
 class TestAgent(BaseExecutorDummyML):
@@ -136,21 +151,66 @@ class TestAgent(BaseExecutorDummyML):
 
     @patch('openai.OpenAI')
     def test_agent_retrieval(self, mock_openai):
-        self.run_sql('create knowledge base kb_review')
-        # self.run_sql('''
-        #   create skill retr_skill
-        #   using
-        #       type = 'retrieval',
-        #       source = 'kb_review',
-        #       description = 'user reviews'
-        # ''')
-        # self.run_sql('''
-        #   create agent retrieve_agent
-        #    using
-        #   skills=['retr_skill'],
-        #   model='gpt-4o',
-        #   provider='openai',
-        #   prompt_template='Answer the user input in a helpful way using tools',
-        #   mode='retrieval'
-        # ''')
-        # ret = self.run_sql('main purpose to buy Kindle Voyage according to reviews')
+
+        self.run_sql(
+            '''
+                CREATE model emb_model
+                PREDICT output
+                using
+                  column='content',
+                  engine='dummy_ml',
+                  join_learn_process=true
+            '''
+        )
+
+        self.run_sql('create knowledge base kb_review using model=emb_model')
+
+        self.run_sql('''
+          create skill retr_skill
+          using
+              type = 'retrieval',
+              source = 'kb_review',
+              description = 'user reviews'
+        ''')
+
+        os.environ['OPENAI_API_KEY'] = '--'
+
+        self.run_sql('''
+          create agent retrieve_agent
+           using
+          model='gpt-3.5-turbo',
+          provider='openai',
+          prompt_template='Answer the user input in a helpful way using tools',
+          skills=['retr_skill'],
+          max_iterations=5,
+          mode='retrieval'
+        ''')
+
+        agent_response = 'the answer is yes'
+        user_question = 'answer my question'
+        from textwrap import dedent
+        set_openai_completion(mock_openai, [
+            # first step, use kb
+            dedent(f'''
+              Thought: Do I need to use a tool? Yes
+              Action: retr_skill
+              Action Input: {user_question}
+            '''),
+
+            # step2, answer to user
+            agent_response
+        ])
+
+        with patch('mindsdb.interfaces.knowledge_base.controller.KnowledgeBaseTable.select_query') as kb_select:
+            # kb response
+            kb_select.return_value = pd.DataFrame([{'id': 1, 'content': 'ok', 'metadata': {}}])
+            ret = self.run_sql(f'''
+                select * from retrieve_agent where question = '{user_question}'
+            ''')
+
+            # check agent output
+            assert agent_response in ret.answer[0]
+
+            # check kb input
+            args, _ = kb_select.call_args
+            assert user_question in args[0].where.args[1].value


### PR DESCRIPTION
## Description

Created adapter with which langchain can access to mindsdb knowledge base as to vector store.
Langchain is used in RAG pipeline during executing retrieval skill. This adapter should allow to use any mindsdb vector store type  by langchain
  

Fixes https://linear.app/mindsdb/issue/BE-81/pgvector-integration-testing

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



