### PR TITLE
Delete venv only if BYOM use it

### DIFF
--- a/mindsdb/integrations/handlers/byom_handler/byom_handler.py
+++ b/mindsdb/integrations/handlers/byom_handler/byom_handler.py
@@ -286,7 +286,8 @@ class BYOMHandler(BaseMLEngine):
             self.engine_storage.json_set('methods', info['methods'])
 
         except Exception as e:
-            model_proxy.remove_venv()
+            if hasattr(model_proxy, 'remove_venv'):
+                model_proxy.remove_venv()
             raise e
 
     def update_engine(self, connection_args: dict) -> None:
@@ -339,7 +340,8 @@ class BYOMHandler(BaseMLEngine):
             self.engine_storage.json_set('methods', methods)
 
         except Exception as e:
-            model_proxy.remove_venv()
+            if hasattr(model_proxy, 'remove_venv'):
+                model_proxy.remove_venv()
             raise e
 
     def function_list(self):


### PR DESCRIPTION
## Description

If exception raised during BYOM engine creation and engine type is 'inhouse', then correct error message is missed, because new exception raised when try to delete venv.

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



