### PR TITLE
Fix retrieval skill for stream mode

### DIFF
--- a/mindsdb/api/http/namespaces/agents.py
+++ b/mindsdb/api/http/namespaces/agents.py
@@ -286,6 +286,9 @@ def _completion_event_generator(
         # Have to commit/flush here so DB isn't locked while streaming.
         db.session.commit()
 
+        if 'mode' not in existing_agent.params and any(skill.type == 'retrieval' for skill in existing_agent.skills):
+            existing_agent.params['mode'] = 'retrieval'
+
         completion_stream = session.agents_controller.get_completion(
             existing_agent,
             messages,

--- a/mindsdb/interfaces/agents/tools.py
+++ b/mindsdb/interfaces/agents/tools.py
@@ -48,7 +48,7 @@ def _build_retrieval_tool(tool: dict, pred_args: dict, skill: db.Skills):
 
     # Can run into weird validation errors when unpacking rag_params directly into constructor.
     if 'embedding_model' in rag_params:
-        embedding_model=rag_params['embedding_model']
+        embedding_model = rag_params['embedding_model']
     else:
         embedding_model = DEFAULT_EMBEDDINGS_MODEL_CLASS()
 

--- a/mindsdb/interfaces/agents/tools.py
+++ b/mindsdb/interfaces/agents/tools.py
@@ -47,8 +47,13 @@ def _build_retrieval_tool(tool: dict, pred_args: dict, skill: db.Skills):
         }
 
     # Can run into weird validation errors when unpacking rag_params directly into constructor.
+    if 'embedding_model' in rag_params:
+        embedding_model=rag_params['embedding_model']
+    else:
+        embedding_model = DEFAULT_EMBEDDINGS_MODEL_CLASS()
+
     rag_config = RAGPipelineModel(
-        embedding_model=rag_params.get('embedding_model', DEFAULT_EMBEDDINGS_MODEL_CLASS())
+        embedding_model=embedding_model
     )
     if 'documents' in rag_params:
         rag_config.documents = rag_params['documents']


### PR DESCRIPTION
## Description

Fixes:

1. fixed error for stream mode when retrieval skill is used

Workaround before fix: add this param manually:
```python
agent = con.agents.create(
  name=f'ollama_agent_retr',
  skills=['retrieval_skill'],
  model='mistral',
  provider='ollama',
  params={
      'mode': 'retrieval',   #  <---------------------------------------------------
      'base_url': 'http://localhost:11434',
      "embedding_model_args": {"model": "nomic-embed-text", 'class': 'OllamaEmbeddings'}
  }
)
```

2. Fixed error if  OPENAI_API_KEY env variable is not defined
```
 validation error for OpenAIEmbeddings\n__root__\n  Did not find openai_api_key, please add an environment variable `OPENAI_API_KEY` which contains it, or pass `openai_api_key` as a named parameter. (type=value_error)
```


Fixes #issue_number

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



