### PR TITLE
Fix concurrency in github actions

### DIFF
--- a/.github/workflows/build_deploy_dev.yml
+++ b/.github/workflows/build_deploy_dev.yml
@@ -9,7 +9,7 @@ on:
 # Cancel any existing runs of this workflow on the same branch/pr
 # We always want to build/deploy/test a new commit over an older one
 concurrency:
-  group: ${{ github.workflow_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build_deploy_prod.yml
+++ b/.github/workflows/build_deploy_prod.yml
@@ -10,7 +10,7 @@ on:
 # Cancel any existing runs of this workflow on the same branch/pr
 # We always want to build/deploy/test a new commit over an older one
 concurrency:
-  group: ${{ github.workflow_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build_deploy_staging.yml
+++ b/.github/workflows/build_deploy_staging.yml
@@ -10,7 +10,7 @@ on:
 # Cancel any existing runs of this workflow on the same branch/pr
 # We always want to build/deploy/test a new commit over an older one
 concurrency:
-  group: ${{ github.workflow_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -117,6 +117,7 @@ jobs:
       - name: Check requirements files are installable
         if: ${{ needs.changes.outputs.not-docs == 'true' }}
         run: |
+          echo "${{ github.workflow }}-${{ github.head_ref || github.ref }}"
           # Install dev requirements and build our pip package
           pip install -r requirements/requirements-dev.txt
           python setup.py sdist

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -12,7 +12,7 @@ defaults:
 # Cancel any existing runs of this workflow on the same branch/pr
 # We always want to build/deploy/test a new commit over an older one
 concurrency:
-  group: ${{ github.workflow_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Due to changes to deal with PRs coming from forks, all workflows are currently running in the same concurrency group, and cancelling each other.
This solves the issue by using `head` ref in the concurrency group to use the source branch with `pull_request_target` workflows.