### PR TITLE
Enabled Authentication via Environment Variables and the Configuration File

### DIFF
--- a/mindsdb/api/common/check_auth.py
+++ b/mindsdb/api/common/check_auth.py
@@ -1,4 +1,3 @@
-import os
 import traceback
 
 from mindsdb.utilities import log
@@ -8,8 +7,8 @@ logger = log.getLogger(__name__)
 
 def check_auth(username, password, scramble_func, salt, company_id, config):
     try:
-        hardcoded_user = os.environ.get('MINDSDB_USERNAME')
-        hardcoded_password = os.environ.get('MINDSDB_PASSWORD')
+        hardcoded_user = config['auth'].get('username')
+        hardcoded_password = config['auth'].get('password')
         if hardcoded_password is None:
             hardcoded_password = ''
         hardcoded_password_hash = scramble_func(hardcoded_password, salt)

--- a/mindsdb/api/http/namespaces/default.py
+++ b/mindsdb/api/http/namespaces/default.py
@@ -1,4 +1,3 @@
-import os
 import time
 
 from flask import request, session
@@ -35,7 +34,7 @@ def check_auth() -> bool:
 
         return True
 
-    return session.get('username') == os.environ.get('MINDSDB_USERNAME')
+    return session.get('username') == config['auth']['username']
 
 
 @ns_conf.route('/login', methods=['POST'])
@@ -66,9 +65,13 @@ class LoginRoute(Resource):
                 'Username and password should be string'
             )
 
+        config = Config()
+        inline_username = config['auth']['username']
+        inline_password = config['auth']['password']
+
         if (
-            username != os.environ.get('MINDSDB_USERNAME')
-            or password != os.environ.get('MINDSDB_PASSWORD')
+            username != inline_username
+            or password != inline_password
         ):
             return http_error(
                 401, 'Forbidden',

--- a/mindsdb/api/mongo/classes/session.py
+++ b/mindsdb/api/mongo/classes/session.py
@@ -1,5 +1,4 @@
 import base64
-import os
 
 from mindsdb.api.mongo.classes.scram import Scram
 
@@ -14,8 +13,8 @@ class Session():
         self.scram = Scram(method=method, get_salted_password=self.get_salted_password)
 
     def get_salted_password(self, username, method=None):
-        real_user = os.environ.get('MINDSDB_USERNAME', '')
-        password = os.environ.get('MINDSDB_PASSWORD', '')
+        real_user = self.config['auth'].get('username', '')
+        password = self.config['auth'].get('password', '')
         if username != real_user:
             raise Exception(f'Wrong username {username}')
 

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -124,6 +124,8 @@ class Config():
                 self._override_config['auth'] = {}
 
             self._override_config['auth']['http_auth_enabled'] = True
+            self._override_config['username'] = http_username
+            self._override_config['password'] = http_password
 
         api_host = "127.0.0.1" if not self.use_docker_env else "0.0.0.0"
         self._default_config = {

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -124,8 +124,8 @@ class Config():
                 self._override_config['auth'] = {}
 
             self._override_config['auth']['http_auth_enabled'] = True
-            self._override_config['username'] = http_username
-            self._override_config['password'] = http_password
+            self._override_config['auth']['username'] = http_username
+            self._override_config['auth']['password'] = http_password
 
         api_host = "127.0.0.1" if not self.use_docker_env else "0.0.0.0"
         self._default_config = {

--- a/tests/integration_tests/flows/config/config.json
+++ b/tests/integration_tests/flows/config/config.json
@@ -1,6 +1,8 @@
 {
     "auth": {
-        "required": false
+        "required": false,
+        "username": "mindsdb",
+        "password": "mindsdb"
     },
     "api": {
         "http": {

--- a/tests/integration_tests/flows/config/docker_config.json
+++ b/tests/integration_tests/flows/config/docker_config.json
@@ -1,7 +1,9 @@
 {
     "auth": {
         "required": false,
-        "http_auth_enabled": false
+        "http_auth_enabled": false,
+        "username": "mindsdb",
+        "password": null
     },
     "api": {
         "http": {

--- a/tests/integration_tests/flows/test_mysql_api.py
+++ b/tests/integration_tests/flows/test_mysql_api.py
@@ -83,7 +83,7 @@ class BaseStuff:
                 command=cmd,
                 remove=True,
                 volumes={str(tmpdirname): {'bind': '/temp', 'mode': 'ro'}},
-                environment={"MYSQL_PWD": os.environ.get("MINDSDB_PASSWORD")}
+                environment={"MYSQL_PWD": self.config["auth"]["password"]}
             )
         return self.to_dicts(res.decode(encoding))
 
@@ -169,7 +169,7 @@ class TestMySqlApi(BaseStuff):
         cls.launch_query_tmpl = "mysql --host=%s --port=%s --user=%s --database=mindsdb" % (
             cls.config["api"]["mysql"]["host"],
             cls.config["api"]["mysql"]["port"],
-            os.environ.get("MINDSDB_USERNAME")
+            cls.config["auth"]["username"]
         )
 
     @classmethod

--- a/tests/integration_tests/flows/test_mysql_bin_api.py
+++ b/tests/integration_tests/flows/test_mysql_bin_api.py
@@ -1,5 +1,4 @@
 import mysql.connector
-import os
 import pytest
 
 from .test_mysql_api import TestMySqlApi, Dlist
@@ -27,8 +26,8 @@ class TestMySqlBinApi(TestMySqlApi):
             host=self.config["api"]["mysql"]["host"],
             port=self.config["api"]["mysql"]["port"],
             database='mindsdb',
-            user=os.environ.get('MINDSDB_USERNAME'),
-            password=os.environ.get('MINDSDB_PASSWORD'),
+            user=self.config["auth"]["username"],
+            password=self.config["auth"]["password"]
         )
         cursor = cnx.cursor(prepared=True)
 


### PR DESCRIPTION
## Description

This PR enables HTTP authentication credentials to be set via environment variables as well as via the configuration file.

It is, of course, recommended that environment variables be used for this purpose as mentioned in the documentation.

## Type of change

- [X] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [X] Relevant unit and integration tests are updated or added.