### PR TITLE
DOCS: Fix Typos on Generative AI Tables Page

### DIFF
--- a/docs/generative-ai-tables.mdx
+++ b/docs/generative-ai-tables.mdx
@@ -23,7 +23,7 @@ MindsDB revolutionizes machine learning within enterprise databases by introduci
 
 AI tables, introduced by MindsDB, abstract AI models as virtual tables so you can simply query AI models for predictions.
 
-With MinsdDB, you can join multiple AI tables (that abstract AI models) with multiple data tables (that provide input to the models) to get all predictions at once.
+With MindsDB, you can join multiple AI tables (that abstract AI models) with multiple data tables (that provide input to the models) to get all predictions at once.
 
 Let's look at some examples.
 
@@ -91,7 +91,7 @@ The `products_sold` table stores the following columns:
 +----------------------------+-----------------------------+-------------+----------+
 ```
 
-The `reponse_generator_model` requires the two tables to be joined to provide it with sufficient input data.
+The `response_generator_model` requires the two tables to be joined to provide it with sufficient input data.
 
 ### Make Predictions
 


### PR DESCRIPTION
## Description

This PR fixes 2 typos in the [Generative AI Tables](https://docs.mindsdb.com/generative-ai-tables) page.

#### Typo 1

![Screenshot 2024-10-24 022605 (1)](https://github.com/user-attachments/assets/7e3041ff-274d-4165-8773-d682b412b44a)

#### Typo 2

![Screenshot 2024-10-24 022635 (1)](https://github.com/user-attachments/assets/d153914e-f63c-422f-b688-523be89e7589)

## Type of change

- [x] 📄 Minor Docs Typo Fix

## Verification Process

To ensure the changes are working as expected:

- Locate the [Generative AI Tables](https://docs.mindsdb.com/generative-ai-tables) page and ensure the typos are fixed in the above sections after merge and deployment.

## Checklist:

- [x] This PR follows MindsDB Contributing Guidelines.
