### PR TITLE
DOCS: Fix Typo on AI Engines BYOM Page

### DIFF
--- a/docs/integrations/ai-engines/byom.mdx
+++ b/docs/integrations/ai-engines/byom.mdx
@@ -133,7 +133,7 @@ Let's briefly go over the files that need to be uploaded:
     ```sql
     dependency_package_1 == version
     dependency_package_2 >= version
-    dependency_package_3 >= verion, < version
+    dependency_package_3 >= version, < version
     ...
     ```
 


### PR DESCRIPTION
## Description

This PR fixes a typo in the [Bring Your Own Model](https://docs.mindsdb.com/integrations/ai-engines/byom) page.

#### Typo 1

![Screenshot 2024-10-24 025118 (1)](https://github.com/user-attachments/assets/909230f9-9418-4c5f-8db3-e5b321cb0137)

## Type of change

- [x] 📄 Minor Docs Typo Fix

## Verification Process

To ensure the changes are working as expected:

- Locate the [Bring Your Own Model](https://docs.mindsdb.com/integrations/ai-engines/byom) page and ensure the typo is fixed in the above section after merge and deployment.

## Checklist:

- [x] This PR follows MindsDB Contributing Guidelines.
