### PR TITLE
DOCS: Fix Typo on Nixtla's NeuralForecast Integration Page

### DIFF
--- a/docs/integrations/ai-engines/neuralforecast.mdx
+++ b/docs/integrations/ai-engines/neuralforecast.mdx
@@ -36,7 +36,7 @@ USING
 
 To ensure that the model is created based on the NeuralForecast engine, include the `USING` clause at the end.
 
-The `frequency` parameter informs the model about the expected time difference between each measurement ([supported values here](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases)). And the `train_time` parameter defines the training time - it defaults to 1, and lower values will reduce trainig time linearly by reducing the number of searches allowed for the best configuration by AutoNHITS. You can also define `exogenous_vars` as a parameter in the `USING` clause - these are complementary variables in the table that may improve forecast accuracy.
+The `frequency` parameter informs the model about the expected time difference between each measurement ([supported values here](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases)). And the `train_time` parameter defines the training time - it defaults to 1, and lower values will reduce training time linearly by reducing the number of searches allowed for the best configuration by AutoNHITS. You can also define `exogenous_vars` as a parameter in the `USING` clause - these are complementary variables in the table that may improve forecast accuracy.
 
 ## Example
 


### PR DESCRIPTION
## Description

This PR fixes a typo in the [Nixtla's NeuralForecast Integration with MindsDB](https://docs.mindsdb.com/integrations/ai-engines/neuralforecast) page.

#### Typo 1

![Screenshot 2024-10-24 030214 (1)](https://github.com/user-attachments/assets/b74a6aa3-1db8-42fb-8e06-8d846fa6c533)

## Type of change

- [x] 📄 Minor Docs Typo Fix

## Verification Process

To ensure the changes are working as expected:

- Locate the [Nixtla's NeuralForecast Integration with MindsDB](https://docs.mindsdb.com/integrations/ai-engines/neuralforecast) page and ensure the typo is fixed in the above section after merge and deployment.

## Checklist:

- [x] This PR follows MindsDB Contributing Guidelines.
