### PR TITLE
DOCS: Fix Typo on Nixtla's TimeGPT Integration Page

### DIFF
--- a/docs/integrations/ai-engines/timegpt.mdx
+++ b/docs/integrations/ai-engines/timegpt.mdx
@@ -31,7 +31,7 @@ HORIZON 3 -- model forecasts the next 3 rows
 USING ENGINE = 'timegpt';
 ```
 
-To ensure that the model is created based on the TimeGPT engine, include the `USING` clause at the end, which defines the `engine` and lists all parameters used with time-series models, including `OREDER BY`, `GROUP BY`, `HORIZON`.
+To ensure that the model is created based on the TimeGPT engine, include the `USING` clause at the end, which defines the `engine` and lists all parameters used with time-series models, including `ORDER BY`, `GROUP BY`, `HORIZON`.
 
 What's different about the TimeGPT engine is that it does not expose the `WINDOW` parameter in its API, so as a user you need to send a payload with at least N rows, where N depends on the model and the frequency of the series. This is automatically handled by MindsDB in the [TimeGPT handler code](https://github.com/mindsdb/mindsdb/tree/main/mindsdb/integrations/handlers/timegpt_handler).
 


### PR DESCRIPTION
## Description

This PR fixes a typo in the [Nixtla's TimeGPT Integration](https://docs.mindsdb.com/integrations/ai-engines/timegpt) page.

#### Typo 1

![Screenshot 2024-10-24 032908 (1)](https://github.com/user-attachments/assets/6931fd09-8475-4f0c-ac35-5d0853fd85d6)

## Type of change

- [x] 📄 Minor Docs Typo Fix

## Verification Process

To ensure the changes are working as expected:

- Locate the [Nixtla's TimeGPT Integration](https://docs.mindsdb.com/integrations/ai-engines/timegpt) page and ensure the typo is fixed in the above section after merge and deployment.

## Checklist:

- [x] This PR follows MindsDB Contributing Guidelines.
