### PR TITLE
DOCS: Fix Typo on Docker Desktop Extension Page

### DIFF
--- a/docs/setup/self-hosted/docker-desktop.mdx
+++ b/docs/setup/self-hosted/docker-desktop.mdx
@@ -6,7 +6,7 @@ sidebarTitle: Docker Desktop
 MindsDB provides an extension for Docker Desktop that facilitates running MindsDB on Docker Desktop.
 
 <Tip>
-Visit the [GitHub repository for MinsdDB Docker Desktop Extension](https://github.com/mindsdb/mindsdb-docker-extension) to learn more.
+Visit the [GitHub repository for MindsDB Docker Desktop Extension](https://github.com/mindsdb/mindsdb-docker-extension) to learn more.
 </Tip>
 
 ## Prerequisites

--- a/docs/setup/self-hosted/docker.mdx
+++ b/docs/setup/self-hosted/docker.mdx
@@ -3,7 +3,7 @@ title: Docker for MindsDB
 sidebarTitle: Docker
 ---
 
-MindsDB provides Docker images that facilitate running MindsDB in Docker containers.
+MindsDB provides Docker images that facilitate running MinsdDB in Docker containers.
 
 <Tip>
 As MindsDB integrates with numerous [data sources](/integrations/data-overview) and [AI frameworks](/integrations/ai-overview), each integration requires a set of dependencies. Hence, MindsDB provides multiple Docker images for different tasks, as outlined below.

--- a/docs/setup/self-hosted/docker.mdx
+++ b/docs/setup/self-hosted/docker.mdx
@@ -3,7 +3,7 @@ title: Docker for MindsDB
 sidebarTitle: Docker
 ---
 
-MindsDB provides Docker images that facilitate running MinsdDB in Docker containers.
+MindsDB provides Docker images that facilitate running MindsDB in Docker containers.
 
 <Tip>
 As MindsDB integrates with numerous [data sources](/integrations/data-overview) and [AI frameworks](/integrations/ai-overview), each integration requires a set of dependencies. Hence, MindsDB provides multiple Docker images for different tasks, as outlined below.


### PR DESCRIPTION
## Description

This PR fixes a typo in the [Docker Desktop Extension](https://docs.mindsdb.com/setup/self-hosted/docker-desktop) page.

#### Typo 1

![Screenshot 2024-10-24 033538 (1)](https://github.com/user-attachments/assets/d6549f2f-d512-46be-9e6a-e6d40ff962a0)

## Type of change

- [x] 📄 Minor Docs Typo Fix

## Verification Process

To ensure the changes are working as expected:

- Locate the [Docker Desktop Extension](https://docs.mindsdb.com/setup/self-hosted/docker-desktop) page and ensure the typo is fixed in the above section after merge and deployment.

## Checklist:

- [x] This PR follows MindsDB Contributing Guidelines.
