### PR TITLE
DOCS: Fix Typo on Docker for MindsDB Page

### DIFF
--- a/docs/setup/self-hosted/docker.mdx
+++ b/docs/setup/self-hosted/docker.mdx
@@ -3,7 +3,7 @@ title: Docker for MindsDB
 sidebarTitle: Docker
 ---
 
-MindsDB provides Docker images that facilitate running MinsdDB in Docker containers.
+MindsDB provides Docker images that facilitate running MindsDB in Docker containers.
 
 <Tip>
 As MindsDB integrates with numerous [data sources](/integrations/data-overview) and [AI frameworks](/integrations/ai-overview), each integration requires a set of dependencies. Hence, MindsDB provides multiple Docker images for different tasks, as outlined below.


### PR DESCRIPTION
## Description

This PR fixes a typo in the [Docker for MindsDB](https://docs.mindsdb.com/setup/self-hosted/docker) page.

#### Typo 1

![Screenshot 2024-10-24 035619 (1)](https://github.com/user-attachments/assets/d56fe566-04fb-4980-a7b4-2a97928be400)

## Type of change

- [x] 📄 Minor Docs Typo Fix

## Verification Process

To ensure the changes are working as expected:

- Locate the [Docker for MindsDB](https://docs.mindsdb.com/setup/self-hosted/docker) page and ensure the typo is fixed in the above section after merge and deployment.

## Checklist:

- [x] This PR follows MindsDB Contributing Guidelines.
