### PR TITLE
DOCS: Fix Typo on Build a Chatbot with a Knowledge Base Page

### DIFF
--- a/docs/use-cases/ai_agents/create-chatbot-kb.mdx
+++ b/docs/use-cases/ai_agents/create-chatbot-kb.mdx
@@ -5,7 +5,7 @@ sidebarTitle: Chatbot with a Knowledge Base
 
 MindsDB provides the `CREATE CHATBOT` statement that lets you customize your chatbot with an AI model and a data source of your choice. Follow this tutorial to learn build a chatbot with a knowledge base.
 
-The `CREATE CHATBOT` statement requires the following componenets:
+The `CREATE CHATBOT` statement requires the following components:
 
 1. **Chat app**: A connection to a chat app, such as [Slack](/integrations/app-integrations/slack#method-1-chatbot-responds-in-direct-messages-to-a-slack-app) or [MS Teams](/integrations/app-integrations/microsoft-teams).
 


### PR DESCRIPTION
## Description

This PR fixes a typo on the page of [Build a Chatbot with a Knowledge Base](https://docs.mindsdb.com/use-cases/ai_agents/create-chatbot-kb).

#### Typo 1

![Screenshot 2024-10-24 041059 (1)](https://github.com/user-attachments/assets/42d3c545-9082-4971-a619-9c38a152c76d)

## Type of change

- [x] 📄 Minor Docs Typo Fix

## Verification Process

To ensure the changes are working as expected:

- Locate the [Build a Chatbot with a Knowledge Base](https://docs.mindsdb.com/use-cases/ai_agents/create-chatbot-kb) page and ensure the typo is fixed in the above section after merge and deployment.

## Checklist:

- [x] This PR follows MindsDB Contributing Guidelines.
