### PR TITLE
DOCS: Fix Typo on Data Enrichment Overview Page

### DIFF
--- a/docs/use-cases/data_enrichment/overview.mdx
+++ b/docs/use-cases/data_enrichment/overview.mdx
@@ -3,7 +3,7 @@ title: Data Enrichment
 sidebarTitle: Overview
 ---
 
-With MindsDB, you can easily enrich your data with AI-generated content. Process natural language, analyze text, create images, and more with varous [AI/ML models](/integrations/ai-overview) accessible through MindsDB.
+With MindsDB, you can easily enrich your data with AI-generated content. Process natural language, analyze text, create images, and more with various [AI/ML models](/integrations/ai-overview) accessible through MindsDB.
 
 <p align="center">
   <img src="/assets/use_cases/data_enrichment.jpg" />


### PR DESCRIPTION
## Description

This PR fixes a typo in the [Data Enrichment Overview](https://docs.mindsdb.com/use-cases/data_enrichment/overview) page.

#### Typo 1

![Screenshot 2024-10-24 045847 (1)](https://github.com/user-attachments/assets/d8395330-f546-48d8-b31c-3f9f08cf2e58)

## Type of change

- [x] 📄 Minor Docs Typo Fix

## Verification Process

To ensure the changes are working as expected:

- Locate the [Data Enrichment Overview](https://docs.mindsdb.com/use-cases/data_enrichment/overview) page and ensure the typo is fixed in the above section after merge and deployment.

## Checklist:

- [x] This PR follows MindsDB Contributing Guidelines.
