### PR TITLE
Fixing OpenAI conversational mode prompt requirements

### DIFF
--- a/mindsdb/integrations/handlers/openai_handler/openai_handler.py
+++ b/mindsdb/integrations/handlers/openai_handler/openai_handler.py
@@ -692,7 +692,7 @@ class OpenAIHandler(BaseMLEngine):
                 return tidy_comps
 
             completions = []
-            if mode != 'conversational':
+            if mode != 'conversational' or 'prompt' not in args:
                 initial_prompt = {
                     "role": "system",
                     "content": "You are a helpful assistant. Your task is to continue the chat.",


### PR DESCRIPTION

## Description

This allows the OpenAI handler to work correctly in all 3 modes, instead of just the third, by fixing a bug in assigning the prompt when not available.

3 Modes for reference: 
1. a prompt_template

2. a question_column and an optional context_column

3. a prompt, user_column and assistant_column

Fixes ML-147 

https://github.com/mindsdb/mindsdb/issues/9716

Fixes #9716

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)





