### PR TITLE
Added Holding Messages to Chat-bot Responses

### DIFF
--- a/mindsdb/interfaces/chatbot/chatbot_task.py
+++ b/mindsdb/interfaces/chatbot/chatbot_task.py
@@ -112,7 +112,7 @@ class ChatBotTask(BaseTask):
 
         # send to chat adapter
         self.chat_pooling.send_message(response_message, table_name=table_name)
-        logger.debug(f'>>chatbot {chat_id} out: {response_message.text}')
+        logger.debug(f'>>chatbot {chat_id} out (holding message): {response_message.text}')
 
     def _on_message(self, message: ChatBotMessage, chat_id, chat_memory, table_name=None):
         # add question to history

--- a/mindsdb/interfaces/chatbot/chatbot_task.py
+++ b/mindsdb/interfaces/chatbot/chatbot_task.py
@@ -17,6 +17,8 @@ from .types import ChatBotMessage
 
 logger = log.getLogger(__name__)
 
+HOLDING_MESSAGE = "Bot is typing..."
+
 
 class ChatBotTask(BaseTask):
 
@@ -81,6 +83,7 @@ class ChatBotTask(BaseTask):
             raise Exception('chat_id or chat_memory should be provided')
 
         try:
+            self._on_holding_message(chat_id, table_name)
             self._on_message(message, chat_id, chat_memory, table_name)
         except (SystemExit, KeyboardInterrupt):
             raise
@@ -88,6 +91,28 @@ class ChatBotTask(BaseTask):
             error = traceback.format_exc()
             logger.error(error)
             self.set_error(str(error))
+
+    def _on_holding_message(self, chat_id: str, table_name: str = None):
+        """
+        Send a message to hold the user's attention while the bot is processing the request.
+        This message will not be saved in the chat memory.
+
+        Args:
+            chat_id (str): The ID of the chat.
+            table_name (str): The name of the table.
+        """
+        response_message = ChatBotMessage(
+            ChatBotMessage.Type.DIRECT,
+            HOLDING_MESSAGE,
+            # In Slack direct messages are treated as channels themselves.
+            user=self.bot_params['bot_username'],
+            destination=chat_id,
+            sent_at=dt.datetime.now()
+        )
+
+        # send to chat adapter
+        self.chat_pooling.send_message(response_message, table_name=table_name)
+        logger.debug(f'>>chatbot {chat_id} out: {response_message.text}')
 
     def _on_message(self, message: ChatBotMessage, chat_id, chat_memory, table_name=None):
         # add question to history


### PR DESCRIPTION
## Description

This PR updates the chat-bot logic to send an immediate response upon receiving a message. This quick reply aims to engage the user and maintain their attention while the full response is being generated.

Fixes https://linear.app/mindsdb/issue/BE-264/give-the-perception-of-immediate-response-for-the-user-by-giving-the
Fixes https://linear.app/mindsdb/issue/BE-268/give-the-perception-of-immediate-response-for-the-user-by-giving-the

## Type of change

- [X] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

Slack Chat-bot:
![image](https://github.com/user-attachments/assets/940bb287-3f12-4f81-ab38-1741c9e63c0d)

MS Teams Chat-bot:
![image](https://github.com/user-attachments/assets/f6d857a4-354e-4900-b336-0c6325c55a4b)

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.