### PR TITLE
Adding new user and session id into traces for langfuse

### DIFF
--- a/mindsdb/api/http/initialize.py
+++ b/mindsdb/api/http/initialize.py
@@ -300,17 +300,17 @@ def initialize_app(config, no_studio):
 
         try:
             email_confirmed = int(request.headers.get('email-confirmed', 1))
-        except Exception as e:
+        except Exception:
             email_confirmed = 1
 
         try:
             user_id = int(request.headers.get('user-id', 0))
-        except Exception as e:
+        except Exception:
             user_id = 0
 
         try:
             session_id = request.cookies.get('session')
-        except Exception as e:
+        except Exception:
             session_id = "unknown"
 
         if company_id is not None:

--- a/mindsdb/api/http/initialize.py
+++ b/mindsdb/api/http/initialize.py
@@ -300,8 +300,18 @@ def initialize_app(config, no_studio):
 
         try:
             email_confirmed = int(request.headers.get('email-confirmed', 1))
-        except ValueError:
+        except Exception as e:
             email_confirmed = 1
+
+        try:
+            user_id = int(request.headers.get('user-id', 0))
+        except Exception as e:
+            user_id = 0
+
+        try:
+            session_id = request.cookies.get('session')
+        except Exception as e:
+            session_id = "unknown"
 
         if company_id is not None:
             try:
@@ -323,6 +333,8 @@ def initialize_app(config, no_studio):
         else:
             user_class = 0
 
+        ctx.user_id = user_id
+        ctx.session_id = session_id
         ctx.company_id = company_id
         ctx.user_class = user_class
         ctx.email_confirmed = email_confirmed

--- a/mindsdb/utilities/context.py
+++ b/mindsdb/utilities/context.py
@@ -15,7 +15,9 @@ class Context:
 
     def set_default(self) -> None:
         self._storage.set({
+            'user_id': None,
             'company_id': None,
+            'session_id': "",
             'user_class': 0,
             'profiling': {
                 'level': 0,

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -43,7 +43,7 @@ langchain-community==0.0.27
 langchain-openai==0.1.6
 langchain-text-splitters==0.0.1
 langchain-nvidia-ai-endpoints==0.1.7
-langfuse==2.35.0
+langfuse==2.53.3  # Latest as of November 4, 2024
 lark
 prometheus-client==0.20.0
 transformers >= 4.42.4


### PR DESCRIPTION
This PR embeds more data into langfuse traces for the purpose of following along a specific user's journey/session.

Need to handoff this data via the gateway first into the headers for this to work, there's a similarly named branch in mindsdb which uses this. Is backwards compatible as well so won't break if done in a weird order.

Paired PR on Gateway: https://github.com/mindsdb/mindsdb_gateway/pull/966