### PR TITLE
Option to return all handlers' schemas

### DIFF
--- a/mindsdb/integrations/handlers/postgres_handler/postgres_handler.py
+++ b/mindsdb/integrations/handlers/postgres_handler/postgres_handler.py
@@ -251,14 +251,17 @@ class PostgresHandler(DatabaseHandler):
         logger.debug(f"Executing SQL query: {query_str}")
         return self.native_query(query_str, params)
 
-    def get_tables(self) -> Response:
+    def get_tables(self, all: bool = False) -> Response:
         """
         Retrieves a list of all non-system tables and views in the current schema of the PostgreSQL database.
 
         Returns:
             Response: A response object containing the list of tables and views, formatted as per the `Response` class.
         """
-        query = """
+        all_filter = 'and table_schema = current_schema()'
+        if all is True:
+            all_filter = ''
+        query = f"""
             SELECT
                 table_schema,
                 table_name,
@@ -268,7 +271,7 @@ class PostgresHandler(DatabaseHandler):
             WHERE
                 table_schema NOT IN ('information_schema', 'pg_catalog')
                 and table_type in ('BASE TABLE', 'VIEW')
-                and table_schema = current_schema()
+                {all_filter}
         """
         return self.native_query(query)
 


### PR DESCRIPTION
## Description

For `GET /tree` added a path option to enable output all database schemas (not only default).
Name of the options is `all_schemas`, may be changed later.

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



