### PR TITLE
Optimize join tables from different databases: executor

### DIFF
--- a/mindsdb/api/executor/sql_query/steps/join_step.py
+++ b/mindsdb/api/executor/sql_query/steps/join_step.py
@@ -3,7 +3,7 @@ import copy
 import numpy as np
 
 from mindsdb_sql.parser.ast import (
-    Identifier,
+    Identifier, BinaryOperation, Constant
 )
 from mindsdb_sql.planner.steps import (
     JoinStep,
@@ -74,7 +74,11 @@ class JoinStepCall(BaseStepCall):
                     return Identifier(parts=['table_b', col_name])
 
             if step.query.condition is None:
-                raise NotSupportedYet('Unable to join table without condition')
+                # prevent memory overflow
+                if len(left_data) * len(right_data) < 10 ** 7:
+                    step.query.condition = BinaryOperation(op='=', args=[Constant(0), Constant(0)])
+                else:
+                    raise NotSupportedYet('Unable to join table without condition')
 
             condition = copy.deepcopy(step.query.condition)
             query_traversal(condition, adapt_condition)

--- a/mindsdb/api/executor/sql_query/steps/subselect_step.py
+++ b/mindsdb/api/executor/sql_query/steps/subselect_step.py
@@ -3,8 +3,11 @@ from collections import defaultdict
 from mindsdb_sql.parser.ast import (
     Identifier,
     Select,
-    Star
+    Star,
+    Constant,
+    Parameter
 )
+from mindsdb_sql.planner.step_result import Result
 from mindsdb_sql.planner.steps import SubSelectStep, QueryStep
 from mindsdb_sql.planner.utils import query_traversal
 
@@ -41,6 +44,9 @@ class SubSelectStepCall(BaseStepCall):
             def f_all_cols(node, **kwargs):
                 if isinstance(node, Identifier):
                     query_cols.add(node.parts[-1])
+                elif isinstance(node, Result):
+                    prev_result = self.steps_data[node.step_num]
+                    return Constant(prev_result.get_column_values(col_idx=0)[0])
 
             query_traversal(query.where, f_all_cols)
 
@@ -49,6 +55,15 @@ class SubSelectStepCall(BaseStepCall):
             for col_name in query_cols:
                 if col_name not in result_cols:
                     result.add_column(Column(col_name))
+
+        # inject previous step values
+        if isinstance(query, Select):
+
+            def inject_values(node, **kwargs):
+                if isinstance(node, Parameter) and isinstance(node.value, Result):
+                    prev_result = self.steps_data[node.value.step_num]
+                    return Constant(prev_result.get_column_values(col_idx=0)[0])
+            query_traversal(query, inject_values)
 
         df = result.to_df()
         res = query_df(df, query, session=self.session)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -17,7 +17,7 @@ redis >=5.0.0, < 6.0.0
 walrus==0.9.3
 flask-compress >= 1.0.0
 appdirs >= 1.0.0
-mindsdb-sql ~= 0.20.0
+mindsdb-sql ~= 0.21.0
 pydantic >= 2.7.0
 mindsdb-evaluator >= 0.0.7, < 0.1.0
 checksumdir >= 1.2.0

--- a/tests/unit/executor/test_base_queires.py
+++ b/tests/unit/executor/test_base_queires.py
@@ -180,6 +180,30 @@ class TestSelect(BaseExecutorDummyML):
         sql = calls[0][0][0].to_string()
         assert sql.strip() == 'SELECT * FROM tbl2 AS t2 WHERE c IN (2, 1)'
 
+    @patch('mindsdb.integrations.handlers.postgres_handler.Handler')
+    def test_implicit_join(self, data_handler):
+        df1 = pd.DataFrame([
+            {'a': 1, 'c': 1},
+            {'a': 3, 'c': 2},
+        ])
+        df2 = pd.DataFrame([
+            {'a': 6, 'c': 1},
+            {'a': 4, 'c': 2},
+            {'a': 2, 'c': 3},
+        ])
+
+        self.set_data('tbl1', df1)
+        self.set_handler(data_handler, name='pg', tables={'tbl2': df2})
+
+        # --- test join table-table ---
+        ret = self.run_sql('''
+            SELECT * FROM dummy_data.tbl1 as t1, pg.tbl2 as t2
+            where t1.c=t2.c
+        ''')
+
+        # must be 2 rows
+        assert len(ret) == 2
+
     def test_complex_queries(self):
 
         # -- set up data --

--- a/tests/unit/executor/test_base_queires.py
+++ b/tests/unit/executor/test_base_queires.py
@@ -150,6 +150,36 @@ class TestSelect(BaseExecutorDummyML):
 
         assert row['t3a'] == 6
 
+    @patch('mindsdb.integrations.handlers.postgres_handler.Handler')
+    def test_joins_different_db(self, data_handler):
+        df1 = pd.DataFrame([
+            {'a': 1, 'c': 1},
+            {'a': 3, 'c': 2},
+        ])
+        df2 = pd.DataFrame([
+            {'a': 6, 'c': 1},
+            {'a': 4, 'c': 2},
+            {'a': 2, 'c': 3},
+        ])
+
+        self.set_data('tbl1', df1)
+        self.set_handler(data_handler, name='pg', tables={'tbl2': df2})
+
+        # --- test join table-table ---
+        ret = self.run_sql('''
+            SELECT *
+              FROM dummy_data.tbl1 as t1
+              JOIN pg.tbl2 as t2 on t1.c=t2.c
+        ''')
+
+        # must be 2 rows
+        assert len(ret) == 2
+
+        # second table is called with filter
+        calls = data_handler().query.call_args_list
+        sql = calls[0][0][0].to_string()
+        assert sql.strip() == 'SELECT * FROM tbl2 AS t2 WHERE c IN (2, 1)'
+
     def test_complex_queries(self):
 
         # -- set up data --


### PR DESCRIPTION
## Description

Updates:

Subselect step is used to get value from previous step data.
```sql
select distinct <column> from <step data1>
```
Next step is fetching data using these values as filter
```sql
select * from db2.table2 where <column> in (<ids from previous step>)
```

Side fix: 
If join is without condition:
- add `0=0` filter (multiply rows)
- but use limitation. If expected number of rows is exceed limit - raise exception

Dependent on https://github.com/mindsdb/mindsdb_sql/pull/412

Fixes #issue_number

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



