### PR TITLE
Fix pgvector metadata column

### DIFF
--- a/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
+++ b/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
@@ -16,7 +16,8 @@ from mindsdb.integrations.libs.response import RESPONSE_TYPE, HandlerResponse as
 from mindsdb.integrations.libs.vectordatabase_handler import (
     FilterCondition,
     VectorStoreHandler,
-    DistanceFunction
+    DistanceFunction,
+    TableField
 )
 from mindsdb.utilities import log
 from mindsdb.utilities.profiler import profiler
@@ -398,6 +399,9 @@ class PgVectorHandler(VectorStoreHandler, PostgresHandler):
             update_columns=update_columns,
             where=where
         )
+
+        if TableField.METADATA.value in data.columns:
+            data = data.astype({TableField.METADATA.value: str})
 
         transposed_data = []
         for _, record in data.iterrows():


### PR DESCRIPTION
fix: cannot adapt type 'dict' using placeholder '%s' (format: AUTO)

## Description

Fixes:
- convert metadata to string 

Fixes error: psycopg.ProgrammingError: cannot adapt type 'dict' using placeholder '%s' (format: AUTO)
 

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



