### PR TITLE
Fix types in 'create table' 

### DIFF
--- a/mindsdb/api/executor/datahub/datanodes/integration_datanode.py
+++ b/mindsdb/api/executor/datahub/datanodes/integration_datanode.py
@@ -109,13 +109,20 @@ class IntegrationDataNode(DataNode):
         if columns is None:
             columns = []
 
-            for col in result_set.columns:
+            df = result_set.get_raw_df()
+
+            for idx, col in enumerate(result_set.columns):
+                dtype = col.type
                 # assume this is pandas type
                 column_type = Text
-                if isinstance(col.type, np_dtype):
-                    if pd_types.is_integer_dtype(col.type):
+                if isinstance(dtype, np_dtype):
+                    if pd_types.is_object_dtype(dtype):
+                        # try to infer
+                        dtype = df[idx].infer_objects().dtype
+
+                    if pd_types.is_integer_dtype(dtype):
                         column_type = Integer
-                    elif pd_types.is_numeric_dtype(col.type):
+                    elif pd_types.is_numeric_dtype(dtype):
                         column_type = Float
 
                 columns.append(

--- a/mindsdb/api/executor/datahub/datanodes/integration_datanode.py
+++ b/mindsdb/api/executor/datahub/datanodes/integration_datanode.py
@@ -164,11 +164,12 @@ class IntegrationDataNode(DataNode):
         for col_idx, col in enumerate(result_set.columns):
             column_type = table_columns_meta[col.alias]
 
-            type_name = 'str'
             if column_type == Integer:
                 type_name = 'int'
             elif column_type == Float:
                 type_name = 'float'
+            else:
+                continue
 
             try:
                 result_set.set_col_type(col_idx, type_name)

--- a/mindsdb/api/executor/datahub/datanodes/project_datanode.py
+++ b/mindsdb/api/executor/datahub/datanodes/project_datanode.py
@@ -133,6 +133,8 @@ class ProjectDataNode(DataNode):
                 if result['success'] is False:
                     raise Exception(f"Cant execute view query: {view_meta['query_ast']}")
                 df = result['result']
+                # remove duplicated columns
+                df = df.loc[:, ~df.columns.duplicated()]
 
                 df = query_df(df, query, session=session)
 

--- a/mindsdb/api/executor/sql_query/result_set.py
+++ b/mindsdb/api/executor/sql_query/result_set.py
@@ -246,7 +246,8 @@ class ResultSet:
             return df.to_records(index=False).tolist()
 
         # slower but keep timestamp type
-        return self._df.to_dict('split')['data']
+        df = self._df.replace({np.nan: None})
+        return df.to_dict('split')['data']
 
     def get_column_values(self, col_idx):
         # get by column index


### PR DESCRIPTION
## Description

Updates:

Fixes in create table logic:

- try to infer values in result: 
   - if column has floats and None, it is object dtype. It will be converted float dtype with to float and nan values
- convert nan to None in export from resultset
- don't convert None to string (otherwise it inserts 'None' strings to table)
- create view from query with duplicated columns:
  - remove duplicated columns in view result
  - at the moment they are visible with `_1` suffix

Fixes #issue_number

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



