### PR TITLE
DOCS: Fix typos on multiple pages on the Docs site

### DIFF
--- a/docs/integrations/ai-engines/replicate-audio.mdx
+++ b/docs/integrations/ai-engines/replicate-audio.mdx
@@ -126,7 +126,7 @@ USING
 
 Above predicted url will work , therefore use [this](./assets/generated_audio.wav).
 
-This is just an one model used in this example there are more with vast variation and usescases.
+This is just an one model used in this example there are more with vast variation and use cases.
 Also there is no limit to imagination, how can you use this.
 
 - IMPORTANT NOTE: PREDICTED **URL** will only work for **24 hours** after prediction.

--- a/docs/integrations/ai-engines/replicate-img2text.mdx
+++ b/docs/integrations/ai-engines/replicate-img2text.mdx
@@ -130,7 +130,7 @@ OUTPUT
 The image feature and text feature has a cosine similarity of 0.3615. | https://images.unsplash.com/photo-1686847266385-a32745169de4 | Bird having horse Riding |
 +-----------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------+--------------------------+
 ```
-This is just an one model used in this example there are more with vast variation and usescases.
+This is just an one model used in this example there are more with vast variation and use cases.
 Also there is no limit to imagination, how can you use this.
 
  Note: Replicate provides only a few free predictions, so choose your predictions wisely. Don't let the machines have all the fun, save some for yourself! 😉

--- a/docs/integrations/ai-engines/replicate-llm.mdx
+++ b/docs/integrations/ai-engines/replicate-llm.mdx
@@ -99,7 +99,7 @@ USING
 | You bring us laughter and joy each day                       |                                        |  
 | And we'll never have to pay                                  |                                        |  
 |                                                              |                                        |  
-| The licence is open, the code is there                       |                                        |  
+| The license is open, the code is there                       |                                        |  
 | For all to see and share in cheer                            |                                        |  
 | You bring us together, from far and wide                     |                                        |  
 | To work on projects, side by side                            |                                        |  

--- a/docs/integrations/ai-engines/twelvelabs.mdx
+++ b/docs/integrations/ai-engines/twelvelabs.mdx
@@ -1,6 +1,6 @@
 ---
-title: TweleveLabs (Video Semantic Search)
-sidebarTitle: TweleveLabs
+title: TwelveLabs (Video Semantic Search)
+sidebarTitle: TwelveLabs
 ---
 
 In this section, we present how to connect Twelve Labs API to MindsDB.
@@ -20,7 +20,7 @@ Before proceeding, ensure the following prerequisites are met:
 
 The first step to use this handler is to create an ML Engine. The required argument to create the engine is:
 
-* `twelve_labs_api_key` - The TweleveLabs api key. 
+* `twelve_labs_api_key` - The TwelveLabs api key. 
 
 Once you have the API key you can establish a connection by executing the following SQL command:
 

--- a/docs/integrations/app-integrations/dockerhub.mdx
+++ b/docs/integrations/app-integrations/dockerhub.mdx
@@ -33,7 +33,7 @@ Read about creating an account [here](https://hub.docker.com/).
 Here is how to connect to Docker Hub using MindsDB:
 
 ```sql
-CREATE DATABASE dockerhub_datasouce
+CREATE DATABASE dockerhub_datasource
 WITH ENGINE = 'dockerhub',
 PARAMETERS = {
   "username": "username",
@@ -46,7 +46,7 @@ PARAMETERS = {
 Now, you can query Docker Hub as follows:
 
 ```sql
-SELECT * FROM dockerhub_datasouce.repo_images_summary WHERE namespace="docker" AND repository="trusted-registry-nginx";
+SELECT * FROM dockerhub_datasource.repo_images_summary WHERE namespace="docker" AND repository="trusted-registry-nginx";
 ```
 
 <Tip>

--- a/docs/integrations/app-integrations/youtube.mdx
+++ b/docs/integrations/app-integrations/youtube.mdx
@@ -20,7 +20,7 @@ Before proceeding, ensure the following prerequisites are met:
 There are two ways you can connect YouTube to MindsDB:
 
 1. Limited permissions: This option provides MindsDB with read-only access to YouTube, including viewing comments data.
-2. Elevated permissions: This optiona provides MindsDB with full access to YouTube, including viewing comments data and posting replies to comments.
+2. Elevated permissions: This option provides MindsDB with full access to YouTube, including viewing comments data and posting replies to comments.
 
 ### Option 1: Limited permissions
 


### PR DESCRIPTION
## Description

This PR fixes typos on the following pages.

- https://docs.mindsdb.com/integrations/ai-engines/replicate-audio
- https://docs.mindsdb.com/integrations/ai-engines/replicate-img2text
- https://docs.mindsdb.com/integrations/ai-engines/replicate-llm
- https://docs.mindsdb.com/integrations/ai-engines/twelvelabs#twelevelabs-video-semantic-search
- https://docs.mindsdb.com/integrations/app-integrations/dockerhub
- https://docs.mindsdb.com/integrations/app-integrations/youtube

## Type of change

- [x] Minor Docs Typo Fix

## Verification Process

To ensure the changes are working as expected:

Please visit the pages listed above and check for the typo corrections.

## Checklist:

- [x] This PR follows MindsDB Contributing Guidelines.


