### PR TITLE
Pass user info to chatbot model

### DIFF
--- a/mindsdb/interfaces/chatbot/chatbot_controller.py
+++ b/mindsdb/interfaces/chatbot/chatbot_controller.py
@@ -228,7 +228,7 @@ class ChatBotController:
             raise ValueError('Need to provide either "model_name" or "agent_name" when creating a chatbot')
         if agent_name is not None:
             agent = self.agents_controller.get_agent(agent_name, project_name)
-            model_name = agent.model_name,
+            model_name = agent.model_name
             if agent is None:
                 raise ValueError(f"Agent with name doesn't exist: {agent_name}")
             agent_id = agent.id

--- a/mindsdb/interfaces/chatbot/chatbot_controller.py
+++ b/mindsdb/interfaces/chatbot/chatbot_controller.py
@@ -24,7 +24,7 @@ class ChatBotController:
         self.project_controller = project_controller
         self.agents_controller = agents_controller
 
-    def get_chatbot(self, chatbot_name: str, project_name: str = 'mindsdb') -> db.ChatBots:
+    def get_chatbot(self, chatbot_name: str, project_name: str = 'mindsdb') -> dict:
         '''
         Gets a chatbot by name.
 
@@ -51,7 +51,7 @@ class ChatBotController:
 
         return self._get_chatbot(query, project)
 
-    def get_chatbot_by_id(self, chatbot_id: int) -> db.ChatBots:
+    def get_chatbot_by_id(self, chatbot_id: int) -> dict:
         '''
         Gets a chatbot by id.
 
@@ -74,7 +74,7 @@ class ChatBotController:
 
         return self._get_chatbot(query)
 
-    def _get_chatbot(self, query, project: db.Project = None) -> db.ChatBots:
+    def _get_chatbot(self, query, project: db.Project = None) -> dict:
         '''
         Gets a chatbot by query.
 

--- a/mindsdb/interfaces/chatbot/chatbot_controller.py
+++ b/mindsdb/interfaces/chatbot/chatbot_controller.py
@@ -99,6 +99,7 @@ class ChatBotController:
 
         agent = self.agents_controller.get_agent_by_id(bot.agent_id)
         agent_obj = agent.as_dict() if agent is not None else None
+
         bot_obj = {
             'id': bot.id,
             'name': bot.name,
@@ -227,17 +228,19 @@ class ChatBotController:
             raise ValueError('Need to provide either "model_name" or "agent_name" when creating a chatbot')
         if agent_name is not None:
             agent = self.agents_controller.get_agent(agent_name, project_name)
+            model_name = agent.model_name,
             if agent is None:
                 raise ValueError(f"Agent with name doesn't exist: {agent_name}")
+            agent_id = agent.id
         else:
             # Create a new agent with the given model name.
-            agent = self.agents_controller.add_agent(name, project_name, model_name, [])
+            agent_id = None
 
         bot = db.ChatBots(
             name=name,
             project_id=project.id,
-            agent_id=agent.id,
-            model_name=agent.model_name,
+            agent_id=agent_id,
+            model_name=model_name,
             database_id=database_id,
             params=params,
         )

--- a/mindsdb/interfaces/chatbot/chatbot_task.py
+++ b/mindsdb/interfaces/chatbot/chatbot_task.py
@@ -34,6 +34,9 @@ class ChatBotTask(BaseTask):
         self.project_name = db.Project.query.get(bot_record.project_id).name
         self.project_datanode = self.session.datahub.get(self.project_name)
 
+        # get chat handler info
+        self.bot_params = bot_record.params or {}
+
         self.agent_id = bot_record.agent_id
         if self.agent_id is not None:
             self.bot_executor_cls = AgentExecutor
@@ -47,9 +50,6 @@ class ChatBotTask(BaseTask):
         self.chat_handler = self.session.integration_controller.get_data_handler(database_name)
         if not isinstance(self.chat_handler, APIChatHandler):
             raise Exception(f"Can't use chat database: {database_name}")
-
-        # get chat handler info
-        self.bot_params = bot_record.params or {}
 
         chat_params = self.chat_handler.get_chat_config()
         polling = chat_params['polling']['type']

--- a/mindsdb/interfaces/chatbot/model_executor.py
+++ b/mindsdb/interfaces/chatbot/model_executor.py
@@ -1,9 +1,11 @@
+from typing import List
 import datetime as dt
 import pandas as pd
 
 from mindsdb.interfaces.storage import db
 
 from .types import BotException
+from .types import ChatBotMessage
 
 
 class ModelExecutor:
@@ -30,7 +32,7 @@ class ModelExecutor:
         # redefined prompt
         self.prompt = None
 
-    def call(self, history, functions):
+    def call(self, history: List[ChatBotMessage], functions):
         model_info = self.model_info
 
         if model_info['mode'] != 'conversational':
@@ -62,15 +64,12 @@ class ModelExecutor:
                 params=params
             )
 
-        elif model_info['engine'] == 'llama_index':
+        else:
             predictions = self.chat_task.project_datanode.predict(
                 model_name=model_info['model_name'],
                 df=pd.DataFrame(messages),
                 params={'prompt': self.prompt}
             )
-
-        else:
-            raise BotException('Not supported')
 
         output_col = model_info['output']
         model_output = predictions.iloc[-1][output_col]

--- a/mindsdb/interfaces/model/model_controller.py
+++ b/mindsdb/interfaces/model/model_controller.py
@@ -129,6 +129,7 @@ class ModelController():
             version=version,
             name=name,
             ml_handler_name=ml_handler_name,
+            except_absent=True,
             project_name=project_name)
         data = self.get_reduced_model_data(predictor_record=model_record)
         integration_record = db.Integration.query.get(model_record.integration_id)


### PR DESCRIPTION
## Description

Updates:

- enable using chatbot with model instead of agent
- user info is passed to chatbot model, for now it only user name which can be user id (for example in slack handler)


Demo:
https://www.loom.com/share/7bd4bff67e4a40f4b61af532f59aef68

Fixes https://linear.app/mindsdb/issue/BE-463/send-user-info-alongside-chatbot-answer
Fixes https://linear.app/mindsdb/issue/BE-462/cant-drop-chatbot

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)


## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



