### PR TITLE
Use Correct Document Class for File Splitting

### DIFF
--- a/mindsdb/interfaces/knowledge_base/preprocessing/document_loader.py
+++ b/mindsdb/interfaces/knowledge_base/preprocessing/document_loader.py
@@ -1,5 +1,6 @@
 import os
 from typing import List, Iterator
+from langchain_core.documents import Document as LangchainDocument
 from langchain_text_splitters import MarkdownHeaderTextSplitter, RecursiveCharacterTextSplitter
 import pandas as pd
 
@@ -91,8 +92,8 @@ class DocumentLoader:
 
         for _, row in websites_df.iterrows():
             # Create a document with HTML extension for proper splitting
-            doc = Document(
-                content=row['text_content'],
+            doc = LangchainDocument(
+                page_content=row['text_content'],
                 metadata={
                     'extension': '.html',
                     'url': row['url']
@@ -156,8 +157,8 @@ class DocumentLoader:
 
             # Split content using recursive splitter
             if content:
-                doc = Document(
-                    content=content,
+                doc = LangchainDocument(
+                    page_content=content,
                     metadata=metadata
                 )
                 # Use FileSplitter with default recursive splitter


### PR DESCRIPTION
## Description

Loading & splitting queries & web pages was broken because we were creating the wrong `Document` class. The `file_splitter` assumes the `Document` has `page_content` ([reference code](https://github.com/mindsdb/mindsdb/blob/42d7c48f116cf588f42c320d72f5a190be26d45f/mindsdb/integrations/utilities/rag/splitters/file_splitter.py#L74)), so we should use Langchain's `Document` class.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



