### PR TITLE
Solved LAST keyword issue

### DIFF
--- a/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
@@ -265,7 +265,7 @@ class ChromaDBHandler(VectorStoreHandler):
                     id_filters.append(condition.value)
                 elif condition.op == FilterOperator.IN:
                     id_filters.extend(condition.value)
-        
+
         if id_filters == []:
             id_filters = None
 
@@ -317,7 +317,7 @@ class ChromaDBHandler(VectorStoreHandler):
         # always include distance
         if distances is not None:
             payload[TableField.DISTANCE.value] = distances
-            
+
         # casting embedding to otherwise pandas give error due to multidimensionality
         payload['embeddings'] = [str(i) for i in payload['embeddings']]
         return pd.DataFrame(payload)

--- a/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
@@ -265,6 +265,9 @@ class ChromaDBHandler(VectorStoreHandler):
                     id_filters.append(condition.value)
                 elif condition.op == FilterOperator.IN:
                     id_filters.extend(condition.value)
+        
+        if id_filters == []:
+            id_filters = None
 
         if vector_filter is not None:
             # similarity search
@@ -314,6 +317,9 @@ class ChromaDBHandler(VectorStoreHandler):
         # always include distance
         if distances is not None:
             payload[TableField.DISTANCE.value] = distances
+            
+        # casting embedding to otherwise pandas give error due to multidimensionality
+        payload['embeddings'] = [str(i) for i in payload['embeddings']]
         return pd.DataFrame(payload)
 
     def insert(self, table_name: str, data: pd.DataFrame):

--- a/mindsdb/integrations/handlers/druid_handler/druid_handler.py
+++ b/mindsdb/integrations/handlers/druid_handler/druid_handler.py
@@ -147,7 +147,7 @@ class DruidHandler(DatabaseHandler):
                 connection.commit()
                 response = Response(RESPONSE_TYPE.OK)
         except Exception as e:
-            logger.error(f'Error running query: {query} on Pinot!')
+            logger.error(f'Error running query: {query} on D!')
             response = Response(
                 RESPONSE_TYPE.ERROR,
                 error_message=str(e)


### PR DESCRIPTION
## Description


- The LAST keyword was not functioning as expected due to a issue with the ChromaDB handler. The root cause was that the `id_filters` parameter passed to the `collection.get()` function was an empty array, which resulted in empty results being returned. After updating the id_filters with the appropriate conditions, it was set to None when empty, allowing the query to proceed and return all records as intended.


- When converting the results to a Pandas DataFrame, an error occurred due to the embeddings column containing 2-dimensional data. To resolve this, the embeddings were typecasted to strings before conversion, ensuring that the DataFrame could be created without errors.


Fixes #10069

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [x] I have attached a brief loom video or screenshots showcasing the new functionality or change.
![image](https://github.com/user-attachments/assets/66e2acae-485a-48a1-8a92-0790c002b6e2)

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



