### PR TITLE
Remove unneeded setup-python calls in workflows

### DIFF
--- a/.github/workflows/build_deploy_prod.yml
+++ b/.github/workflows/build_deploy_prod.yml
@@ -26,10 +26,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: FranzDiebold/github-env-vars-action@v2
-      - name: Set up Python
-        uses: actions/setup-python@v5.1.0
-        with:
-          python-version: ${{ vars.CI_PYTHON_VERSION }}
       - name: Check Version
         run: |
           PYTHONPATH=./ python tests/scripts/check_version.py ${{ env.CI_REF_NAME }} ${{ github.event.release.prerelease }}
@@ -42,10 +38,6 @@ jobs:
     if: github.actor != 'mindsdbadmin'
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5.1.0
-        with:
-          python-version: ${{ vars.CI_PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           uv pip install -r requirements/requirements-dev.txt

--- a/.github/workflows/matrix_includes.json
+++ b/.github/workflows/matrix_includes.json
@@ -1,11 +1,11 @@
 [
   {
-    "runs_on": "ubuntu-latest",
+    "runs_on": "mdb-dev",
     "python-version": "3.10",
     "runOnBranch": "refs/heads/main"
   },
   {
-    "runs_on": "ubuntu-latest",
+    "runs_on": "mdb-dev",
     "python-version": "3.9",
     "runOnBranch": "always"
   }

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -74,7 +74,7 @@ jobs:
         if: ${{ needs.changes.outputs.not-docs == 'true' }}
         run: |
           # We don't need to install mindsdb itself here because these are just static code checks
-          uv pip install -r requirements/requirements-dev.txt
+          uv pip install --prefix $(python -m site --user-base) -r requirements/requirements-dev.txt
 
           python tests/scripts/check_requirements.py
 
@@ -119,7 +119,7 @@ jobs:
         if: ${{ needs.changes.outputs.not-docs == 'true' }}
         run: |
           # Install dev requirements and build our pip package
-          uv pip install -r requirements/requirements-dev.txt
+          uv pip install --prefix $(python -m site --user-base) -r requirements/requirements-dev.txt
           python setup.py sdist
 
           # Install from the pip package

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -46,12 +46,6 @@ jobs:
       - name: Checkout
         if: ${{ needs.changes.outputs.not-docs == 'true' }}
         uses: actions/checkout@v4
-      - name: Set up Python
-        if: ${{ needs.changes.outputs.not-docs == 'true' }}
-        uses: actions/setup-python@v5.1.0
-        with:
-          # I can't work out how to use vars.CI_PYTHON_VERSION for forks here in a nice way, so we have to hardcode it for forks
-          python-version: ${{ vars.CI_PYTHON_VERSION || '3.10' }}
 
       # Checks the codebase for print() statements and fails if any are found
       # We should be using loggers instead


### PR DESCRIPTION
Python has been added to our runners, so we can remove some `setup-python` calls to speed things up.