### PR TITLE
Fixed the OpenAI Integration's Logic for Setting the Base API Parameter

### DIFF
--- a/mindsdb/integrations/handlers/openai_handler/openai_handler.py
+++ b/mindsdb/integrations/handlers/openai_handler/openai_handler.py
@@ -198,7 +198,7 @@ class OpenAIHandler(BaseMLEngine):
         engine_storage = kwargs['handler_storage']
         connection_args = engine_storage.get_connection_args()
         api_key = get_api_key('openai', args, engine_storage=engine_storage)
-        api_base = connection_args.get('api_base') or args.get('api_base') or os.environ.get('OPENAI_API_BASE', OPENAI_API_BASE)
+        api_base = args.get('api_base') or connection_args.get('api_base') or os.environ.get('OPENAI_API_BASE', OPENAI_API_BASE)
         org = args.get('api_organization')
         client = OpenAIHandler._get_client(api_key=api_key, base_url=api_base, org=org)
         OpenAIHandler._check_client_connection(client)
@@ -223,7 +223,7 @@ class OpenAIHandler(BaseMLEngine):
         try:
             api_key = get_api_key(self.api_key_name, args, self.engine_storage)
             connection_args = self.engine_storage.get_connection_args()
-            api_base = connection_args.get('api_base') or self.api_base or args.get('api_base') or os.environ.get('OPENAI_API_BASE', OPENAI_API_BASE)
+            api_base = args.get('api_base') or connection_args.get('api_base') or os.environ.get('OPENAI_API_BASE') or self.api_base
             available_models = get_available_models(api_key, api_base)
 
             if not args.get('mode'):
@@ -264,10 +264,11 @@ class OpenAIHandler(BaseMLEngine):
         connection_args = self.engine_storage.get_connection_args()
 
         args['api_base'] = (pred_args.get('api_base')
-                            or self.api_base
-                            or connection_args.get('api_base')
                             or args.get('api_base')
-                            or os.environ.get('OPENAI_API_BASE', OPENAI_API_BASE))
+                            or connection_args.get('api_base')
+                            or os.environ.get('OPENAI_API_BASE')
+                            or self.api_base)
+
         if pred_args.get('api_organization'):
             args['api_organization'] = pred_args['api_organization']
         df = df.reset_index(drop=True)


### PR DESCRIPTION
## Description

This PR enables the use of custom base APIs with the OpenAI integration by re-organizing the logic for setting the `api_base` parameter. Additionally, this change prioritizes the `base_api` parameter set during model creation before that which is set when creating the ML engine.

Fixes https://github.com/mindsdb/mindsdb/issues/10126

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added - N/A