### PR TITLE
Mysql server: use old version for small responses

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
+++ b/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
@@ -320,10 +320,12 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
     def send_query_answer(self, answer: SQLAnswer):
         if answer.type == RESPONSE_TYPE.TABLE:
             packages = []
-            if len(answer.data) < 1000:
-                packages += self.get_tabel_packets(columns=answer.columns, data=answer.data.to_lists())
-            else:
+
+            if len(answer.data) > 1000:
+                # for big responses leverage pandas map function to convert data to packages
                 self.send_tabel_packets(columns=answer.columns, data=answer.data)
+            else:
+                packages += self.get_tabel_packets(columns=answer.columns, data=answer.data.to_lists())
 
             if answer.status is not None:
                 packages.append(self.last_packet(status=answer.status))

--- a/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
+++ b/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
@@ -319,9 +319,12 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
 
     def send_query_answer(self, answer: SQLAnswer):
         if answer.type == RESPONSE_TYPE.TABLE:
-            self.send_tabel_packets(columns=answer.columns, data=answer.data)
-
             packages = []
+            if len(answer.data) < 1000:
+                packages += self.get_tabel_packets(columns=answer.columns, data=answer.data.to_lists())
+            else:
+                self.send_tabel_packets(columns=answer.columns, data=answer.data)
+
             if answer.status is not None:
                 packages.append(self.last_packet(status=answer.status))
             else:


### PR DESCRIPTION
## Description

For small responses old logic works a bit faster because it doesn't use pandas apply function

Continue of #9974

Fixes https://linear.app/mindsdb/issue/BE-360/tpc-h-benchmarks-improvements

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



