### PR TITLE
Enabled Slack Chat-bots to Respond in Threads

### DIFF
--- a/mindsdb/integrations/handlers/slack_handler/slack_handler.py
+++ b/mindsdb/integrations/handlers/slack_handler/slack_handler.py
@@ -237,7 +237,8 @@ class SlackMessagesTable(APIResource):
             try:
                 response = client.chat_postMessage(
                     channel=params['channel_id'],
-                    text=params['text']
+                    text=params['text'],
+                    thread_ts=params.get('thread_ts', None)
                 )
             except SlackApiError as e:
                 raise Exception(f"Error posting message to Slack channel '{params['channel']}': {e.response['error']}")
@@ -397,7 +398,7 @@ class SlackHandler(APIChatHandler):
             },
             'chat_table': {
                 'name': 'messages',
-                'chat_id_col': 'channel_id',
+                'chat_id_col': ['channel_id', 'thread_ts'],
                 'username_col': 'user',
                 'text_col': 'text',
                 'time_col': 'thread_ts',
@@ -449,11 +450,13 @@ class SlackHandler(APIChatHandler):
 
             key = {
                 'channel_id': payload_event['channel'],
+                'thread_ts': payload_event.get('thread_ts', None)
             }
             row = {
                 'text': payload_event['text'],
                 'user': payload_event['user'],
                 'channel_id': payload_event['channel'],
+                'thread_ts': payload_event.get('thread_ts', None),
                 'created_at': dt.datetime.fromtimestamp(float(payload_event['ts'])).strftime('%Y-%m-%d %H:%M:%S')
             }
 

--- a/mindsdb/interfaces/chatbot/memory.py
+++ b/mindsdb/interfaces/chatbot/memory.py
@@ -58,7 +58,12 @@ class BaseMemory:
 
     def add_to_history(self, chat_id, chat_message):
 
-        self._add_to_history(chat_id, chat_message)
+        # If the chat_id is a tuple, convert it to a string when storing the message in the database.
+        self._add_to_history(
+            str(chat_id) if isinstance(chat_id, tuple) else chat_id,
+            chat_message
+        )
+
         if chat_id in self._cache:
             del self._cache[chat_id]
 
@@ -69,9 +74,14 @@ class BaseMemory:
 
         else:
             if table_name is None:
-                history = self._get_chat_history(chat_id)
+                history = self._get_chat_history(
+                    str(chat_id) if isinstance(chat_id, tuple) else chat_id
+                )
             else:
-                history = self._get_chat_history(chat_id, table_name)
+                history = self._get_chat_history(
+                    str(chat_id) if isinstance(chat_id, tuple) else chat_id,
+                    table_name
+                )
             self._cache[key] = history
 
         history = self._apply_hiding(chat_id, history)

--- a/mindsdb/interfaces/chatbot/polling.py
+++ b/mindsdb/interfaces/chatbot/polling.py
@@ -147,16 +147,15 @@ class RealtimePolling(BasePolling):
         row.update(key)
 
         t_params = self.params["chat_table"]
+        chat_id = tuple(row[key] for key in t_params["chat_id_col"]) if isinstance(t_params["chat_id_col"], list) else row[t_params["chat_id_col"]]
 
         message = ChatBotMessage(
             ChatBotMessage.Type.DIRECT,
             row[t_params["text_col"]],
             # In Slack direct messages are treated as channels themselves.
             row[t_params["username_col"]],
-            row[t_params["chat_id_col"]],
+            chat_id,
         )
-
-        chat_id = row[t_params["chat_id_col"]]
 
         self.chat_task.on_message(message, chat_id=chat_id)
 


### PR DESCRIPTION
## Description

This PR enables Slack chat-bots to respond directly within a thread when a user posts a message in that thread. In order to achieve this, a new column called `thread_ds` (used to distinguish between threads in a conversation) has been introduced as an additional ID. With this, the memory for conversations in threads will be maintained separately. 

A few changes were also required to be made to the chat interfaces to allow multiple chat ID cols to be supported.

Fixes https://linear.app/mindsdb/issue/BE-514/slack-threads-support

## Type of change

- [X] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

In a main channel:
![image](https://github.com/user-attachments/assets/bb7337d4-a816-4ae2-80cf-fec237828ec4)

In a thread within a channel:
![image](https://github.com/user-attachments/assets/3e7cff86-3662-44b9-b3c8-286ad500b3e4)

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added - N/A