### PR TITLE
Add auto-heal to auto-restart unhealthy containers in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,19 @@
 services:
 
+  # Auto-restarts containers that are unhealthy
+  autoheal:
+    container_name: autoheal
+    image: willfarrell/autoheal
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    <<: &autoRestartOnFailure
+      deploy:
+        restart_policy:
+          condition: on-failure
+          max_attempts: 10
+
   mindsdb:
+    <<: *autoRestartOnFailure
     image: mindsdb/mindsdb:devel
    
     depends_on:
@@ -57,6 +70,7 @@ services:
       retries: 100
 
   jaeger:
+    <<: *autoRestartOnFailure
     image: jaegertracing/all-in-one:1.62.0
     ports:
       - "16686:16686"
@@ -66,6 +80,7 @@ services:
       COLLECTOR_ZIPKIN_HOST_PORT: ":9411"
 
   langfuse:
+    <<: *autoRestartOnFailure
     image: langfuse/langfuse:2.87.0
     restart: always
     depends_on:
@@ -95,6 +110,7 @@ services:
       - LANGFUSE_INIT_USER_PASSWORD=password # User password
 
   postgres:
+    <<: *autoRestartOnFailure
     image: postgres:16.4
     restart: always
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,12 @@ services:
       - "4318:4318"
     environment:
       COLLECTOR_ZIPKIN_HOST_PORT: ":9411"
+    healthcheck:
+      test: ["CMD-SHELL", "/go/bin/all-in-one-linux status"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+      
 
   langfuse:
     <<: *autoRestartOnFailure


### PR DESCRIPTION
## Description

Auto-restarts containers that are unhealthy in our docker-compose.
Also adds definitions to all containers that restarts the container if it _exits_ on error

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



