### PR TITLE
Enabled Slack Chat-bots to Respond in Threads

### DIFF
--- a/mindsdb/integrations/handlers/slack_handler/slack_handler.py
+++ b/mindsdb/integrations/handlers/slack_handler/slack_handler.py
@@ -462,6 +462,9 @@ class SlackHandler(APIChatHandler):
         users = SlackUsersTable(self)
         self._register_table('users', users)
 
+        threads = SlackThreadsTable(self)
+        self._register_table('threads', threads)
+
         self._socket_mode_client = None
 
     def get_chat_config(self):

--- a/mindsdb/integrations/handlers/slack_handler/slack_handler.py
+++ b/mindsdb/integrations/handlers/slack_handler/slack_handler.py
@@ -574,7 +574,6 @@ class SlackHandler(APIChatHandler):
             row = {
                 'text': payload_event['text'],
                 'user': payload_event['user'],
-                'channel_id': payload_event['channel'],
                 'created_at': dt.datetime.fromtimestamp(float(payload_event['ts'])).strftime('%Y-%m-%d %H:%M:%S')
             }
 
@@ -582,7 +581,6 @@ class SlackHandler(APIChatHandler):
             # This message should be handled via the threads table.
             if 'thread_ts' in payload_event:
                 key['thread_ts'] = payload_event['thread_ts']
-                row['thread_ts'] = payload_event['thread_ts']
 
             callback(row, key)
 

--- a/mindsdb/integrations/handlers/slack_handler/slack_handler.py
+++ b/mindsdb/integrations/handlers/slack_handler/slack_handler.py
@@ -415,6 +415,31 @@ class SlackThreadsTable(APIResource):
         result['channel_name'] = channel['name'] if 'name' in channel else None
 
         return result
+    
+    def insert(self, query):
+        """
+        Inserts a message into a thread in a Slack conversation.
+        """
+        client = self.handler.connect()
+    
+        # Get column names and values from the query.
+        columns = [col.name for col in query.columns]
+        for row in query.values:
+            params = dict(zip(columns, row))
+
+            # Check if required parameters are provided.
+            if 'channel_id' not in params or 'text' not in params or 'thread_ts' not in params:
+                raise Exception("To insert data into Slack, you need to provide the 'channel_id', 'text', and 'thread_ts' parameters.")
+
+            # Post message to Slack thread.
+            try:
+                response = client.chat_postMessage(
+                    channel=params['channel_id'],
+                    text=params['text'],
+                    thread_ts=params['thread_ts']
+                )
+            except SlackApiError as e:
+                raise Exception(f"Error posting message to Slack channel '{params['channel']}': {e.response['error']}")
 
     def get_columns(self) -> List[str]:
         return [

--- a/mindsdb/integrations/handlers/slack_handler/slack_handler.py
+++ b/mindsdb/integrations/handlers/slack_handler/slack_handler.py
@@ -410,7 +410,7 @@ class SlackThreadsTable(APIResource):
         # Remove null rows from the result.
         result = result[result['text'].notnull()]
 
-        # Add the selected channel to the dataframe
+        # Add the selected channel to the DataFrame.
         result['channel_id'] = params['channel']
         result['channel_name'] = channel['name'] if 'name' in channel else None
 
@@ -419,10 +419,18 @@ class SlackThreadsTable(APIResource):
     def get_columns(self) -> List[str]:
         return [
             "channel_id",
-            "channel",
+            "channel_name",
             "type",
             "user",
-            "text"
+            "text",
+            "ts",
+            "client_msg_id",
+            "thread_ts",
+            "parent_user_id",
+            "reply_count",
+            "reply_users_count",
+            "latest_reply",
+            "reply_users"
         ]
 
 

--- a/mindsdb/interfaces/chatbot/chatbot_task.py
+++ b/mindsdb/interfaces/chatbot/chatbot_task.py
@@ -59,6 +59,7 @@ class ChatBotTask(BaseTask):
             self.memory = HandlerMemory(self, chat_params)
 
         elif polling == 'realtime':
+            chat_params = chat_params['tables'] if 'tables' in chat_params else [chat_params]
             self.chat_pooling = RealtimePolling(self, chat_params)
             self.memory = DBMemory(self, chat_params)
 

--- a/mindsdb/interfaces/chatbot/memory.py
+++ b/mindsdb/interfaces/chatbot/memory.py
@@ -58,7 +58,11 @@ class BaseMemory:
 
     def add_to_history(self, chat_id, chat_message):
 
-        self._add_to_history(chat_id, chat_message)
+        # If the chat_id is a tuple, convert it to a string when storing the message in the database.
+        self._add_to_history(
+            str(chat_id) if isinstance(chat_id, tuple) else chat_id,
+            chat_message
+        )
         if chat_id in self._cache:
             del self._cache[chat_id]
 
@@ -69,9 +73,14 @@ class BaseMemory:
 
         else:
             if table_name is None:
-                history = self._get_chat_history(chat_id)
+                history = self._get_chat_history(
+                    str(chat_id) if isinstance(chat_id, tuple) else chat_id
+                )
             else:
-                history = self._get_chat_history(chat_id, table_name)
+                history = self._get_chat_history(
+                    str(chat_id) if isinstance(chat_id, tuple) else chat_id,
+                    table_name
+                )
             self._cache[key] = history
 
         history = self._apply_hiding(chat_id, history)

--- a/mindsdb/interfaces/chatbot/memory.py
+++ b/mindsdb/interfaces/chatbot/memory.py
@@ -73,15 +73,10 @@ class BaseMemory:
             history = self._cache[key]
 
         else:
-            if table_name is None:
-                history = self._get_chat_history(
-                    str(chat_id) if isinstance(chat_id, tuple) else chat_id
-                )
-            else:
-                history = self._get_chat_history(
-                    str(chat_id) if isinstance(chat_id, tuple) else chat_id,
-                    table_name
-                )
+            history = self._get_chat_history(
+                str(chat_id) if isinstance(chat_id, tuple) else chat_id,
+                table_name
+            )
             self._cache[key] = history
 
         history = self._apply_hiding(chat_id, history)

--- a/mindsdb/interfaces/chatbot/memory.py
+++ b/mindsdb/interfaces/chatbot/memory.py
@@ -87,10 +87,10 @@ class BaseMemory:
         history = self._apply_hiding(chat_id, history)
         return history
 
-    def _add_to_history(self, chat_id, chat_message):
+    def _add_to_history(self, chat_id, chat_message, table_name=None):
         raise NotImplementedError
 
-    def _get_chat_history(self, chat_id):
+    def _get_chat_history(self, chat_id, table_name=None):
         raise NotImplementedError
 
 

--- a/mindsdb/interfaces/chatbot/memory.py
+++ b/mindsdb/interfaces/chatbot/memory.py
@@ -56,12 +56,13 @@ class BaseMemory:
     def set_mode(self, chat_id, mode):
         self._modes[chat_id] = mode
 
-    def add_to_history(self, chat_id, chat_message):
+    def add_to_history(self, chat_id, chat_message, table_name=None):
 
         # If the chat_id is a tuple, convert it to a string when storing the message in the database.
         self._add_to_history(
             str(chat_id) if isinstance(chat_id, tuple) else chat_id,
-            chat_message
+            chat_message,
+            table_name=table_name
         )
         if chat_id in self._cache:
             del self._cache[chat_id]
@@ -98,7 +99,7 @@ class HandlerMemory(BaseMemory):
     Uses handler's database to store and retrieve messages
     '''
 
-    def _add_to_history(self, chat_id, chat_message):
+    def _add_to_history(self, chat_id, chat_message, table_name=None):
         # do nothing. sent message will be stored by handler db
         pass
 
@@ -155,25 +156,28 @@ class DBMemory(BaseMemory):
     uses mindsdb database to store messages
     '''
 
-    def _add_to_history(self, chat_id, message):
-
+    def _add_to_history(self, chat_id, message, table_name=None):
         chat_bot_id = self.chat_task.bot_id
+        destination = str((chat_id, table_name)) if table_name else chat_id
+
         message = db.ChatBotsHistory(
             chat_bot_id=chat_bot_id,
             type=message.type.name,
             text=message.text,
             user=message.user,
-            destination=chat_id,
+            destination=destination,
         )
         db.session.add(message)
         db.session.commit()
 
-    def _get_chat_history(self, chat_id):
+    def _get_chat_history(self, chat_id, table_name=None):
         chat_bot_id = self.chat_task.bot_id
+        destination = str((chat_id, table_name)) if table_name else chat_id
+
         query = db.ChatBotsHistory.query\
             .filter(
                 db.ChatBotsHistory.chat_bot_id == chat_bot_id,
-                db.ChatBotsHistory.destination == chat_id
+                db.ChatBotsHistory.destination == destination
             )\
             .order_by(db.ChatBotsHistory.sent_at.desc())\
             .limit(self.MAX_DEPTH)
@@ -203,16 +207,13 @@ class ChatMemory:
         self.cached = False
 
     def get_history(self, cached=True):
-        if self.table_name:
-            result = self.memory.get_chat_history(self.chat_id, self.table_name, cached=cached and self.cached)
-        else:
-            result = self.memory.get_chat_history(self.chat_id, cached=cached and self.cached)
+        result = self.memory.get_chat_history(self.chat_id, self.table_name, cached=cached and self.cached)
 
         self.cached = True
         return result
 
     def add_to_history(self, message):
-        self.memory.add_to_history(self.chat_id, message)
+        self.memory.add_to_history(self.chat_id, message, table_name=self.table_name)
 
     def get_mode(self):
         return self.memory.get_mode(self.chat_id)

--- a/mindsdb/interfaces/chatbot/polling.py
+++ b/mindsdb/interfaces/chatbot/polling.py
@@ -179,7 +179,6 @@ class RealtimePolling(BasePolling):
         )
 
     def run(self, stop_event):
-        # t_params = self.params["chat_table"]
         self.chat_task.chat_handler.subscribe(
             stop_event,
             self._callback

--- a/mindsdb/interfaces/chatbot/polling.py
+++ b/mindsdb/interfaces/chatbot/polling.py
@@ -146,7 +146,22 @@ class RealtimePolling(BasePolling):
 
         row.update(key)
 
-        t_params = self.params["chat_table"]
+        # If more than one set of parameters is present, multiple tables are supported.
+        if len(self.params) > 1:
+            # Identify the table relevant to this event based on the key.
+            event_keys = list(key.keys())
+            for param in self.params:
+                table_keys = [param["chat_table"]["chat_id_col"]] if isinstance(param["chat_table"]["chat_id_col"], str) else param["chat_table"]["chat_id_col"]
+
+                if sorted(event_keys) == sorted(table_keys):
+                    t_params = param["chat_table"]
+                    break
+
+        # Otherwise, only a single table is supported. Use the first set of parameters.
+        else:
+            t_params = self.params[0]
+
+        # Get the chat ID from the row based on the chat ID column(s).
         chat_id = tuple(row[key] for key in t_params["chat_id_col"]) if isinstance(t_params["chat_id_col"], list) else row[t_params["chat_id_col"]]
 
         message = ChatBotMessage(
@@ -157,12 +172,17 @@ class RealtimePolling(BasePolling):
             chat_id,
         )
 
-        self.chat_task.on_message(message, chat_id=chat_id)
+        self.chat_task.on_message(
+            message,
+            chat_id=chat_id,
+            table_name=t_params["name"],
+        )
 
     def run(self, stop_event):
-        t_params = self.params["chat_table"]
+        # t_params = self.params["chat_table"]
         self.chat_task.chat_handler.subscribe(
-            stop_event, self._callback, t_params["name"]
+            stop_event,
+            self._callback
         )
 
     # def send_message(self, message: ChatBotMessage):

--- a/mindsdb/interfaces/chatbot/polling.py
+++ b/mindsdb/interfaces/chatbot/polling.py
@@ -147,16 +147,15 @@ class RealtimePolling(BasePolling):
         row.update(key)
 
         t_params = self.params["chat_table"]
+        chat_id = tuple(row[key] for key in t_params["chat_id_col"]) if isinstance(t_params["chat_id_col"], list) else row[t_params["chat_id_col"]]
 
         message = ChatBotMessage(
             ChatBotMessage.Type.DIRECT,
             row[t_params["text_col"]],
             # In Slack direct messages are treated as channels themselves.
             row[t_params["username_col"]],
-            row[t_params["chat_id_col"]],
+            chat_id,
         )
-
-        chat_id = row[t_params["chat_id_col"]]
 
         self.chat_task.on_message(message, chat_id=chat_id)
 


### PR DESCRIPTION
## Description

This PR enables Slack chat-bots to respond directly within a thread when a user posts a message in that thread. 

In order to achieve this, a new tables called 'threads' has been introduced to the Slack handler, which will handle all operations related to threads.

A few changes were also required to be made to the chat interfaces to allow multiple chat ID columns and multiple tables to be supported.

Fixes https://linear.app/mindsdb/issue/BE-514/slack-threads-support

**There's a slight limitation here in how the bot handles the memory (previous messages) from the thread until it is first mentioned.** @ZoranPandovski Shall I handle this in another PR?

## Type of change

- [X] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

https://www.loom.com/share/e11f6ce62b3e4d639f71476f0c609270?sid=6fcc7827-8be9-43c9-ba14-53f6aa31c116

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added - N/A