### PR TITLE
Use Unique IDs For Preprocessed Document Chunks

### DIFF
--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -148,12 +148,7 @@ class KnowledgeBaseTable:
 
     def insert_documents(self, documents: List[Document]):
         """Process and insert documents with preprocessing if configured"""
-        if self.document_preprocessor:
-            chunks = self.document_preprocessor.process_documents(documents)
-            df = pd.DataFrame([chunk.model_dump() for chunk in chunks])
-        else:
-            # No preprocessing, convert directly to dataframe
-            df = pd.DataFrame([doc.model_dump() for doc in documents])
+        df = pd.DataFrame([doc.model_dump() for doc in documents])
 
         self.insert(df)
 

--- a/mindsdb/interfaces/knowledge_base/preprocessing/document_preprocessor.py
+++ b/mindsdb/interfaces/knowledge_base/preprocessing/document_preprocessor.py
@@ -1,4 +1,5 @@
 from typing import List, Dict, Optional, Any
+from uuid import uuid4
 import pandas as pd
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
@@ -133,11 +134,14 @@ Please give a short succinct context to situate this chunk within the overall do
                 context = self._generate_context(chunk_doc.content, doc.content)
                 processed_content = f"{context}\n\n{chunk_doc.content}"
 
+                # Need a unique ID for each document. Can track source ID in metadata.
+                metadata = chunk_doc.metadata or doc.metadata or {}
+                metadata['doc_id'] = doc.id
                 processed_chunks.append(ProcessedChunk(
-                    id=doc.id,
+                    id=uuid4().hex,
                     content=processed_content,
                     embeddings=doc.embeddings,
-                    metadata=chunk_doc.metadata or doc.metadata
+                    metadata=metadata
                 ))
 
         return processed_chunks
@@ -177,11 +181,14 @@ class TextChunkingPreprocessor(DocumentPreprocessor):
             chunk_docs = self._split_document(doc)
 
             for chunk_doc in chunk_docs:
+                # Need a unique ID for each document. Can track source ID in metadata.
+                metadata = chunk_doc.metadata or doc.metadata or {}
+                metadata['doc_id'] = doc.id
                 processed_chunks.append(ProcessedChunk(
-                    id=doc.id,
+                    id=uuid4().hex,
                     content=chunk_doc.content,
                     embeddings=doc.embeddings,
-                    metadata=chunk_doc.metadata or doc.metadata
+                    metadata=metadata
                 ))
 
         return processed_chunks


### PR DESCRIPTION
## Description

If we use the same ID for every document chunk, our underlying Vector DB implementation will [drop the duplicates, leaving us with no content](https://github.com/mindsdb/mindsdb/blob/main/mindsdb/integrations/libs/vectordatabase_handler.py#L290).

Also, we should not preprocess documents _twice_ when calling `insert_documents`.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



