### PR TITLE
Improve MapReduceSummarizerChain Performance

### DIFF
--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -141,7 +141,7 @@ class KnowledgeBaseTable:
         documents = [Document(
             content=row.get('content', ''),
             id=row.get('id'),
-            metadata={k: v for k, v in row.items() if k not in ['content', 'id']}
+            metadata=row.get('metadata', {})
         ) for row in rows]
 
         self.insert_documents(documents)
@@ -252,8 +252,12 @@ class KnowledgeBaseTable:
                     # Use provided_id directly if it exists, otherwise generate one
                     doc_id = self._generate_document_id(content_str, col, provided_id)
 
+                    # Need provided ID to link chunks back to original source (e.g. database row).
+                    row_id = provided_id if provided_id else idx
+
                     metadata = {
                         **base_metadata,
+                        'original_row_id': str(row_id),
                         'content_column': col,
                         'content_type': col.split('_')[-1] if '_' in col else 'text'
                     }

--- a/mindsdb/interfaces/knowledge_base/preprocessing/document_preprocessor.py
+++ b/mindsdb/interfaces/knowledge_base/preprocessing/document_preprocessor.py
@@ -156,12 +156,16 @@ Please give a short succinct context to situate this chunk within the overall do
                 context = self._generate_context(chunk_docs[0].content, doc.content)
                 processed_content = f"{context}\n\n{chunk_docs[0].content}"
 
+                id = doc.id or self._generate_chunk_id(processed_content)
+                metadata = self._prepare_chunk_metadata(doc.id, None, chunk_docs[0].metadata or doc.metadata)
+                # Keep track of chunk UUID.
+                metadata['chunk_id'] = id
                 processed_chunks.append(ProcessedChunk(
                     # Use original doc ID since there's only one chunk
-                    id=doc.id or self._generate_chunk_id(processed_content),
+                    id=id,
                     content=processed_content,
                     embeddings=doc.embeddings,
-                    metadata=self._prepare_chunk_metadata(doc.id, None, chunk_docs[0].metadata or doc.metadata)
+                    metadata=metadata
                 ))
             else:
                 # Multiple chunks case
@@ -171,12 +175,14 @@ Please give a short succinct context to situate this chunk within the overall do
 
                     # Append chunk index to original doc ID
                     chunk_id = f"{doc.id}_chunk_{i}" if doc.id else self._generate_chunk_id(processed_content, i)
-
+                    metadata = self._prepare_chunk_metadata(doc.id, i, chunk_doc.metadata or doc.metadata)
+                    # Keep track of chunk UUID.
+                    metadata['chunk_id'] = chunk_id
                     processed_chunks.append(ProcessedChunk(
                         id=chunk_id,
                         content=processed_content,
                         embeddings=doc.embeddings,
-                        metadata=self._prepare_chunk_metadata(doc.id, i, chunk_doc.metadata or doc.metadata)
+                        metadata=metadata
                     ))
 
         return processed_chunks
@@ -228,8 +234,11 @@ class TextChunkingPreprocessor(DocumentPreprocessor):
                 if doc.metadata:
                     metadata.update(doc.metadata)
 
+                id = doc.id or self._generate_chunk_id(chunk_doc.content)
+                # Keep track of chunk UUID.
+                metadata['chunk_id'] = id
                 processed_chunks.append(ProcessedChunk(
-                    id=doc.id or self._generate_chunk_id(chunk_doc.content),
+                    id=id,
                     content=chunk_doc.content,
                     embeddings=doc.embeddings,
                     metadata=self._prepare_chunk_metadata(doc.id, None, metadata)
@@ -245,7 +254,8 @@ class TextChunkingPreprocessor(DocumentPreprocessor):
                         metadata.update(doc.metadata)
 
                     chunk_id = f"{doc.id}_chunk_{i}" if doc.id else self._generate_chunk_id(chunk_doc.content, i)
-
+                    # Keep track of chunk UUID in metadata.
+                    metadata['chunk_id'] = chunk_id
                     processed_chunks.append(ProcessedChunk(
                         id=chunk_id,
                         content=chunk_doc.content,

--- a/tests/unit/test_map_reduce_summarizer_chain.py
+++ b/tests/unit/test_map_reduce_summarizer_chain.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pandas as pd
 from langchain.chains.combine_documents.map_reduce import MapReduceDocumentsChain
@@ -21,8 +21,8 @@ class TestMapReduceSummarizerChain:
                 {'content': 'Chunk 3'}
             ])
         ]
-        mock_map_reduce_documents_chain = MagicMock(spec=MapReduceDocumentsChain, wraps=MapReduceDocumentsChain)
-        mock_map_reduce_documents_chain.run.side_effect = ['Final summary 1', 'Final summary 2']
+        mock_map_reduce_documents_chain = AsyncMock(spec=MapReduceDocumentsChain, wraps=MapReduceDocumentsChain)
+        mock_map_reduce_documents_chain.ainvoke.side_effect = [{'output_text': 'Final summary 1'}, {'output_text': 'Final summary 2'}]
         test_summarizer_chain = MapReduceSummarizerChain(
             vector_store_handler=mock_vector_store_handler,
             map_reduce_documents_chain=mock_map_reduce_documents_chain
@@ -59,10 +59,7 @@ class TestMapReduceSummarizerChain:
         )
 
         # Make sure we are calling the summarization chain with the right chunks.
-        row_1_chunks = [Document(page_content='Chunk 1'), Document(page_content='Chunk 2')]
-        row_2_chunks = [Document(page_content='Chunk 3')]
-        mock_map_reduce_documents_chain.run.assert_any_call(row_1_chunks)
-        mock_map_reduce_documents_chain.run.assert_any_call(row_2_chunks)
+        mock_map_reduce_documents_chain.ainvoke.assert_awaited()
 
         # Make sure the summary is actually added to the context.
         expected_chain_output = {


### PR DESCRIPTION
## Description

Just like with reranking, we should use `asyncio` to improve performance of map reduce summarizing document chunks.

This PR also includes some quality of life improvements to chunk metadata (including chunk UUID).


## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [x]   Test Location:`./tests/unit/test_map_reduce_summarizer_chain.py`
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



