### PR TITLE
fix:  Broken Link(for slack) syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,4 +145,4 @@ Generated with [contributors-img](https://contributors-img.web.app).
 
 ## 🔔 Subscribe for Updates
 
-Join our [Slack community](https://mindsdb.com/j
+Join our [Slack community](https://mindsdb.com/joincommunity)


### PR DESCRIPTION
In the Readme.md file.

.Before: 
Join our [Slack community](https://mindsdb.com/j

After: 
Join our [Slack community](https://mindsdb.com/joincommunity)



