### PR TITLE
Add `max_restart_interval_seconds` config option

### DIFF
--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -155,8 +155,8 @@ class Config():
                     "host": api_host,
                     "port": "47334",
                     "restart_on_failure": True,
-                    "max_restart_count": 0,
-                    "max_restart_interval_seconds": 0
+                    "max_restart_count": 1,
+                    "max_restart_interval_seconds": 60
                 },
                 "mysql": {
                     "host": api_host,
@@ -165,8 +165,8 @@ class Config():
                     "database": "mindsdb",
                     "ssl": True,
                     "restart_on_failure": True,
-                    "max_restart_count": 0,
-                    "max_restart_interval_seconds": 0
+                    "max_restart_count": 1,
+                    "max_restart_interval_seconds": 60
                 },
                 "mongodb": {
                     "host": api_host,

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -155,7 +155,8 @@ class Config():
                     "host": api_host,
                     "port": "47334",
                     "restart_on_failure": True,
-                    "max_restart_count": 0
+                    "max_restart_count": 0,
+                    "max_restart_interval_seconds": 0
                 },
                 "mysql": {
                     "host": api_host,
@@ -164,7 +165,8 @@ class Config():
                     "database": "mindsdb",
                     "ssl": True,
                     "restart_on_failure": True,
-                    "max_restart_count": 0
+                    "max_restart_count": 0,
+                    "max_restart_interval_seconds": 0
                 },
                 "mongodb": {
                     "host": api_host,

--- a/mindsdb/utilities/fs.py
+++ b/mindsdb/utilities/fs.py
@@ -1,7 +1,7 @@
 import os
+import time
 import tempfile
 import threading
-import time
 from pathlib import Path
 from typing import Optional, List, Tuple
 
@@ -60,12 +60,10 @@ def _get_process_mark_id(unified: bool = False) -> str:
 
 
 def create_process_mark(folder="learn"):
-    mark = None
-    if os.name == "posix":
-        p = Path(tempfile.gettempdir()).joinpath(f"mindsdb/processes/{folder}/")
-        p.mkdir(parents=True, exist_ok=True)
-        mark = _get_process_mark_id()
-        p.joinpath(mark).touch()
+    p = Path(tempfile.gettempdir()).joinpath(f"mindsdb/processes/{folder}/")
+    p.mkdir(parents=True, exist_ok=True)
+    mark = _get_process_mark_id()
+    p.joinpath(mark).touch()
     return mark
 
 
@@ -79,8 +77,6 @@ def set_process_mark(folder: str, mark: str) -> None:
     Returns:
         str: process mark
     """
-    if os.name != "posix":
-        return
     p = Path(tempfile.gettempdir()).joinpath(f"mindsdb/processes/{folder}/")
     p.mkdir(parents=True, exist_ok=True)
     mark = f"{os.getpid()}-{threading.get_native_id()}-{mark}"
@@ -91,21 +87,17 @@ def set_process_mark(folder: str, mark: str) -> None:
 def delete_process_mark(folder: str = "learn", mark: Optional[str] = None):
     if mark is None:
         mark = _get_process_mark_id()
-    if os.name == "posix":
-        p = (
-            Path(tempfile.gettempdir())
-            .joinpath(f"mindsdb/processes/{folder}/")
-            .joinpath(mark)
-        )
-        if p.exists():
-            p.unlink()
+    p = (
+        Path(tempfile.gettempdir())
+        .joinpath(f"mindsdb/processes/{folder}/")
+        .joinpath(mark)
+    )
+    if p.exists():
+        p.unlink()
 
 
 def clean_process_marks():
     """delete all existing processes marks"""
-    if os.name != "posix":
-        return
-
     logger.debug("Deleting PIDs..")
     p = Path(tempfile.gettempdir()).joinpath("mindsdb/processes/")
     if p.exists() is False:
@@ -143,9 +135,6 @@ def clean_unlinked_process_marks() -> List[int]:
         List[int]: list with ids of unexisting processes
     """
     deleted_pids = []
-
-    if os.name != "posix":
-        return deleted_pids
 
     for file, process_id, thread_id in get_processes_dir_files_generator():
         try:


### PR DESCRIPTION
## Description

 - added config option `max_restart_interval_seconds` that define interval for `max_restart_count`. If it is exceeded, no new restarts will occur. '0' means no limit.
 - `process_marks` now works on windows. This means that if the training process fails, the model will be marked as 'error' on Windows as well.

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



