### PR TITLE
Snowflake fixes for TPC benchmarks

### DIFF
--- a/mindsdb/integrations/handlers/snowflake_handler/snowflake_handler.py
+++ b/mindsdb/integrations/handlers/snowflake_handler/snowflake_handler.py
@@ -132,9 +132,17 @@ class SnowflakeHandler(DatabaseHandler):
             try:
                 cur.execute(query)
                 try:
+
+                    try:
+                        batches_iter = cur.fetch_pandas_batches()
+                    except ValueError:
+                        # duplicated columns raises ValueError
+                        raise NotSupportedError()
+
                     batches = []
                     memory_estimation_check_done = False
-                    for batch_df in cur.fetch_pandas_batches():
+
+                    for batch_df in batches_iter:
                         batches.append(batch_df)
                         # region check the size of first batch (if it is big enough) to get an estimate of the full
                         # dataset size. If i does not fit in memory - raise an error.

--- a/mindsdb/utilities/render/sqlalchemy_render.py
+++ b/mindsdb/utilities/render/sqlalchemy_render.py
@@ -33,9 +33,15 @@ class INTERVAL(ColumnElement):
 @compiles(INTERVAL)
 def _compile_interval(element, compiler, **kw):
     items = element.info.split(' ', maxsplit=1)
-    # quote first element
-    items[0] = f"'{items[0]}'"
-    return "INTERVAL " + " ".join(items)
+    if compiler.dialect.driver in ['snowflake']:
+        # quote all
+        args = " ".join(map(str, items))
+        args = f"'{args}'"
+    else:
+        # quote first element
+        items[0] = f"'{items[0]}'"
+        args = " ".join(items)
+    return "INTERVAL " + args
 
 
 class SqlalchemyRender:

--- a/mindsdb/utilities/render/sqlalchemy_render.py
+++ b/mindsdb/utilities/render/sqlalchemy_render.py
@@ -2,6 +2,7 @@ import re
 import datetime as dt
 
 import sqlalchemy as sa
+from sqlalchemy.sql import operators
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import aliased
@@ -65,6 +66,7 @@ class SqlalchemyRender:
         # remove double percent signs
         # https://docs.sqlalchemy.org/en/14/faq/sqlexpressions.html#why-are-percent-signs-being-doubled-up-when-stringifying-sql-statements
         self.dialect = dialect(paramstyle="named")
+        self.dialect.div_is_floordiv = False
 
         if dialect_name == 'mssql':
             # update version to MS_2008_VERSION for supports_multivalues_insert
@@ -166,25 +168,26 @@ class SqlalchemyRender:
                 alias = str(t.op)
             col = fnc.label(alias)
         elif isinstance(t, ast.BinaryOperation):
-            methods = {
-                "+": "__add__",
-                "-": "__sub__",
-                "*": "__mul__",
-                "%": "__mod__",
-                "=": "__eq__",
-                "!=": "__ne__",
-                "<>": "__ne__",
-                ">": "__gt__",
-                "<": "__lt__",
-                ">=": "__ge__",
-                "<=": "__le__",
-                "is": "is_",
-                "is not": "is_not",
-                "like": "like",
-                "not like": "notlike",
-                "in": "in_",
-                "not in": "notin_",
-                "||": "concat",
+            ops = {
+                "+": operators.add,
+                "-": operators.sub,
+                "*": operators.mul,
+                "/": operators.truediv,
+                "%": operators.mod,
+                "=": operators.eq,
+                "!=": operators.ne,
+                "<>": operators.ne,
+                ">": operators.gt,
+                "<": operators.lt,
+                ">=": operators.ge,
+                "<=": operators.le,
+                "is": operators.is_,
+                "is not": operators.is_not,
+                "like": operators.like_op,
+                "not like": operators.not_like_op,
+                "in": operators.in_op,
+                "not in": operators.not_in_op,
+                "||": operators.concat_op,
             }
             functions = {
                 "and": sa.and_,
@@ -199,14 +202,18 @@ class SqlalchemyRender:
                 if isinstance(arg1, sa.sql.selectable.ColumnClause):
                     raise NotImplementedError(f'Required list argument for: {op}')
 
-            method = methods.get(op)
-            if op == '/':
-                # sqlalchemy adds cast for __truediv__ and round for __floordiv__
-                col = sa.text(f'{arg0.compile(dialect=self.dialect)} / {arg1.compile(dialect=self.dialect)}')
-            elif method is not None:
-                sa_op = getattr(arg0, method)
+            sa_op = ops.get(op)
 
-                col = sa_op(arg1)
+            if sa_op is not None:
+                if isinstance(arg0, sa.TextClause):
+                    # text doesn't have operate method, reverse operator
+                    col = arg1.reverse_operate(sa_op, arg0)
+                elif isinstance(arg1, sa.TextClause):
+                    # both args are text, return text
+                    col = sa.text(f'{arg0.compile(dialect=self.dialect)} {op} {arg1.compile(dialect=self.dialect)}')
+                else:
+                    col = arg0.operate(sa_op, arg1)
+
             elif t.op.lower() in functions:
                 func = functions[t.op.lower()]
                 col = func(arg0, arg1)

--- a/tests/unit/render/test_sqlalchemyrender.py
+++ b/tests/unit/render/test_sqlalchemyrender.py
@@ -79,7 +79,7 @@ class TestRender:
 
     def test_extra_cast_in_division(self):
         sql = """
-           select a / b from table1
+           select a / b as col1 from table1
         """
 
         query = parse_sql(sql)
@@ -97,3 +97,12 @@ class TestRender:
         query = Select(targets=[Identifier('table')])
         rendered = SqlalchemyRender('postgres').get_string(query, with_failback=False)
         assert rendered == 'SELECT "table"'
+
+    def test_div(self):
+
+        sql0 = 'select 1 / 2 - (9 / 4 - 1) * 3 as x'
+        query = parse_sql(sql0)
+
+        sql = SqlalchemyRender('postgres').get_string(query, with_failback=False)
+
+        assert sql.lower() == sql0


### PR DESCRIPTION
## Description

**Fixes:**
Fix snowflake handler:
- fetch_pandas fails if columns names are duplicated 
- if such error appears: switch to simple fetch

Fix render:
- fix render of 'interval' for snowflake
  - it accepts format: interval '1 day'
- TextClause doesn't have operate method, if it is first argument: try to use reverse_operate (and apply operator to second argument)
- disable truediv in render
  -  truediv adds cast to 'div' operation

Fixes https://linear.app/mindsdb/issue/BE-475/snowflake-passes-100percent-of-tpc-ds
Fixes https://linear.app/mindsdb/issue/BE-474/snowflake-passes-100percent-of-tpc-h



## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



