### PR TITLE
Fix: Table not found for column (don't check alias of a query) 

### DIFF
--- a/mindsdb/api/executor/sql_query/steps/subselect_step.py
+++ b/mindsdb/api/executor/sql_query/steps/subselect_step.py
@@ -101,6 +101,12 @@ class QueryStepCall(BaseStepCall):
             if col.table_name != col.table_alias:
                 tbl_idx[col.table_alias].append(name)
 
+        # get aliases of first level
+        aliases = []
+        for col in query.targets:
+            if col.alias is not None:
+                aliases.append(col.alias.parts[0])
+
         # analyze condition and change name of columns
         def check_fields(node, is_target=None, **kwargs):
 
@@ -121,6 +127,9 @@ class QueryStepCall(BaseStepCall):
 
                 if len(node.parts) == 1:
                     key = col_name
+                    if key in aliases:
+                        # key is defined as alias
+                        return
                 else:
                     table_name = node.parts[-2]
                     key = (table_name, col_name)

--- a/mindsdb/api/executor/sql_query/steps/subselect_step.py
+++ b/mindsdb/api/executor/sql_query/steps/subselect_step.py
@@ -126,6 +126,10 @@ class QueryStepCall(BaseStepCall):
                     key = (table_name, col_name)
 
                 if key not in col_idx:
+                    if len(node.parts) == 1:
+                        # it can be local alias of a query
+                        return
+
                     raise KeyColumnDoesNotExist(f'Table not found for column: {key}')
 
                 new_name = col_idx[key]

--- a/tests/unit/executor/test_base_queires.py
+++ b/tests/unit/executor/test_base_queires.py
@@ -182,13 +182,13 @@ class TestSelect(BaseExecutorDummyML):
 
         # --- using alias in order
         ret = self.run_sql('''
-            SELECT t1.a + t2.a col1, min(t1.a) col2
+            SELECT t1.a + t2.a col1, min(t1.a) c
               FROM dummy_data.tbl1 as t1
               JOIN pg.tbl2 as t2 on t1.c=t2.c
             group by col1
-            order by col2
+            order by c
         ''')
-        assert ret['col2'][0] == 1
+        assert ret['c'][0] == 1  # alias is the same as column
         assert ret['col1'][0] == 7
 
     @patch('mindsdb.integrations.handlers.postgres_handler.Handler')

--- a/tests/unit/executor/test_base_queires.py
+++ b/tests/unit/executor/test_base_queires.py
@@ -180,6 +180,17 @@ class TestSelect(BaseExecutorDummyML):
         sql = calls[0][0][0].to_string()
         assert sql.strip() == 'SELECT * FROM tbl2 AS t2 WHERE c IN (2, 1)'
 
+        # --- using alias in order
+        ret = self.run_sql('''
+            SELECT t1.a + t2.a col1, min(t1.a) col2
+              FROM dummy_data.tbl1 as t1
+              JOIN pg.tbl2 as t2 on t1.c=t2.c
+            group by col1
+            order by col2
+        ''')
+        assert ret['col2'][0] == 1
+        assert ret['col1'][0] == 7
+
     @patch('mindsdb.integrations.handlers.postgres_handler.Handler')
     def test_implicit_join(self, data_handler):
         df1 = pd.DataFrame([


### PR DESCRIPTION
## Description

Fix: 
- Skip checking 'single-path' identifiers, they could be aliases defined inside of a query

Example of query which had error:
```sql
SELECT t1.a + t2.b  col1
  FROM db1.tbl1 as t1
  JOIN db2.tbl2 as t2 
order by col1
```
col1 is an alias defined in query. Don't try to check it as a column of used tables.
Also col1 could exist in tbl1 table, but if it is defined as alias it will be skipped

Fixes https://linear.app/mindsdb/issue/BE-549/check-positional-indexes-for-sql

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



