### PR TITLE
Make HTTP session lifetime configurable via env vars

### DIFF
--- a/mindsdb/api/http/initialize.py
+++ b/mindsdb/api/http/initialize.py
@@ -302,7 +302,7 @@ def initialize_app(config, no_studio):
             and check_auth() is False
         ):
             return http_error(
-                HTTPStatus.UNAUTHORIZED, 'Forbidden',
+                HTTPStatus.UNAUTHORIZED, 'Unauthorized',
                 'Authorization is required to complete the request'
             )
         # endregion
@@ -384,21 +384,7 @@ def initialize_flask(config, init_static_thread, no_studio):
 
     app.config['SECRET_KEY'] = os.environ.get('FLASK_SECRET_KEY', secrets.token_hex(32))
     app.config['SESSION_COOKIE_NAME'] = 'session'
-
-    # region permanent session lifetime
-    permanent_session_lifetime = datetime.timedelta(days=31)
-    for env_name in ('MINDSDB_HTTP_PERMANENT_SESSION_LIFETIME', 'FLASK_PERMANENT_SESSION_LIFETIME'):
-        env_value = os.environ.get(env_name)
-        if isinstance(env_value, str):
-            try:
-                permanent_session_lifetime = int(env_value)
-            except Exception:
-                logger.warning(f'Can\'t cast env var {env_name} value to int: {env_value}')
-                continue
-            break
-    app.config['PERMANENT_SESSION_LIFETIME'] = permanent_session_lifetime
-    # endregion
-
+    app.config['PERMANENT_SESSION_LIFETIME'] = config['auth']['http_permanent_session_lifetime']
     app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 60
     app.config['SWAGGER_HOST'] = 'http://localhost:8000/mindsdb'
     app.json = CustomJSONProvider()

--- a/mindsdb/api/http/initialize.py
+++ b/mindsdb/api/http/initialize.py
@@ -302,7 +302,7 @@ def initialize_app(config, no_studio):
             and check_auth() is False
         ):
             return http_error(
-                403, 'Forbidden',
+                HTTPStatus.UNAUTHORIZED, 'Forbidden',
                 'Authorization is required to complete the request'
             )
         # endregion
@@ -384,7 +384,21 @@ def initialize_flask(config, init_static_thread, no_studio):
 
     app.config['SECRET_KEY'] = os.environ.get('FLASK_SECRET_KEY', secrets.token_hex(32))
     app.config['SESSION_COOKIE_NAME'] = 'session'
-    app.config['PERMANENT_SESSION_LIFETIME'] = datetime.timedelta(days=31)
+
+    # region permanent session lifetime
+    permanent_session_lifetime = datetime.timedelta(days=31)
+    for env_name in ('MINDSDB_HTTP_PERMANENT_SESSION_LIFETIME', 'FLASK_PERMANENT_SESSION_LIFETIME'):
+        env_value = os.environ.get(env_name)
+        if isinstance(env_value, str):
+            try:
+                permanent_session_lifetime = int(env_value)
+            except Exception:
+                logger.warning(f'Can\'t cast env var {env_name} value to int: {env_value}')
+                continue
+            break
+    app.config['PERMANENT_SESSION_LIFETIME'] = permanent_session_lifetime
+    # endregion
+
     app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 60
     app.config['SWAGGER_HOST'] = 'http://localhost:8000/mindsdb'
     app.json = CustomJSONProvider()

--- a/mindsdb/api/http/initialize.py
+++ b/mindsdb/api/http/initialize.py
@@ -1,5 +1,4 @@
 import os
-import datetime
 import secrets
 import mimetypes
 import threading

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -1,9 +1,14 @@
 import os
 import json
+import datetime
 from copy import deepcopy
 from pathlib import Path
 
+from mindsdb.utilities import log
 from mindsdb.utilities.fs import create_directory, get_or_create_data_dir
+
+
+logger = log.getLogger(__name__)
 
 
 def _merge_key_recursive(target_dict, source_dict, key):
@@ -127,6 +132,19 @@ class Config():
             self._override_config['auth']['username'] = http_username
             self._override_config['auth']['password'] = http_password
 
+        # region permanent session lifetime
+        permanent_session_lifetime = datetime.timedelta(days=31)
+        for env_name in ('MINDSDB_HTTP_PERMANENT_SESSION_LIFETIME', 'FLASK_PERMANENT_SESSION_LIFETIME'):
+            env_value = os.environ.get(env_name)
+            if isinstance(env_value, str):
+                try:
+                    permanent_session_lifetime = int(env_value)
+                except Exception:
+                    logger.warning(f'Can\'t cast env var {env_name} value to int: {env_value}')
+                    continue
+                break
+        # endregion
+
         api_host = "127.0.0.1" if not self.use_docker_env else "0.0.0.0"
         self._default_config = {
             'permanent_storage': {
@@ -136,6 +154,7 @@ class Config():
             'paths': paths,
             'auth': {
                 'http_auth_enabled': False,
+                "http_permanent_session_lifetime": permanent_session_lifetime
             },
             "log": {
                 "level": {


### PR DESCRIPTION
## Description

Added ability to change default HTTP session lifetime (31 day) if set one of env vars to value in seconds:
 - MINDSDB_HTTP_PERMANENT_SESSION_LIFETIME
 - FLASK_PERMANENT_SESSION_LIFETIME

Added config option with same meaning:
`config['auth']['http_permanent_session_lifetime']`

[Doc issue](https://github.com/mindsdb/mindsdb/issues/10260)

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



