### PR TITLE
Added Unit Tests for Slack Tables and Fixed a Few Bugs

### DIFF
--- a/mindsdb/integrations/handlers/slack_handler/slack_tables.py
+++ b/mindsdb/integrations/handlers/slack_handler/slack_tables.py
@@ -375,7 +375,7 @@ class SlackMessagesTable(APIResource):
             # Handle the column'ts'.
             elif arg1 =='ts':
                 if op == '=':
-                    params[arg1] = float(arg2)
+                    params[arg1] = str(arg2)
                 else:
                     raise ValueError(f"Unsupported operator '{op}' for column '{arg1}'")
 
@@ -396,7 +396,7 @@ class SlackMessagesTable(APIResource):
         try:
             client.chat_update(
                 channel=params['channel'],
-                ts=str(params['ts']),
+                ts=params['ts'],
                 text=params['text'].strip()
             )
         except SlackApiError as slack_error:

--- a/mindsdb/integrations/handlers/slack_handler/slack_tables.py
+++ b/mindsdb/integrations/handlers/slack_handler/slack_tables.py
@@ -287,10 +287,10 @@ class SlackMessagesTable(APIResource):
 
                     messages = messages[:limit]
             # Otherwise, use the provided limit or a default limit of 999.
-                else:
-                    params['limit'] = limit if limit else 999
-                    response = client.conversations_history(**params)
-                    messages = response['messages']
+            else:
+                params['limit'] = limit if limit else 999
+                response = client.conversations_history(**params)
+                messages = response['messages']
         except SlackApiError as slack_error:
             logger.error(f"Error getting messages: {slack_error.response['error']}")
             raise
@@ -567,10 +567,10 @@ class SlackThreadsTable(APIResource):
 
                     messages = messages[:limit]
             # Otherwise, use the provided limit or a default limit of 1000.
-                else:
-                    params['limit'] = limit if limit else 1000
-                    response = client.conversations_replies(**params)
-                    messages = response['messages']
+            else:
+                params['limit'] = limit if limit else 1000
+                response = client.conversations_replies(**params)
+                messages = response['messages']
         except SlackApiError as slack_error:
             logger.error(f"Error getting messages: {slack_error.response['error']}")
             raise
@@ -687,9 +687,9 @@ class SlackUsersTable(APIResource):
 
                     users = users[:limit]
             # Otherwise, use the provided limit or a default limit of 1000.
-                else:
-                    response = client.users_list(limit=limit if limit else 1000)
-                    users = response['members']
+            else:
+                response = client.users_list(limit=limit if limit else 1000)
+                users = response['members']
         except SlackApiError as slack_error:
             logger.error(f"Error getting users: {slack_error.response['error']}")
             raise

--- a/mindsdb/integrations/handlers/slack_handler/slack_tables.py
+++ b/mindsdb/integrations/handlers/slack_handler/slack_tables.py
@@ -373,7 +373,7 @@ class SlackMessagesTable(APIResource):
                     raise ValueError(f"Channel '{arg2}' not found")
 
             # Handle the column'ts'.
-            elif arg1 =='ts':
+            elif arg1 == 'ts':
                 if op == '=':
                     params[arg1] = str(arg2)
                 else:
@@ -381,7 +381,7 @@ class SlackMessagesTable(APIResource):
 
             else:
                 raise ValueError(f"Unsupported column '{arg1}'")
-            
+
         # Extract the update columns and values.
         for col, val in query.update_columns.items():
             if col == 'text':

--- a/mindsdb/integrations/handlers/slack_handler/slack_tables.py
+++ b/mindsdb/integrations/handlers/slack_handler/slack_tables.py
@@ -360,6 +360,7 @@ class SlackMessagesTable(APIResource):
 
         # Build the parameters for the call to the Slack API.
         params = {}
+        # Extract the parameters from the conditions.
         for op, arg1, arg2 in conditions:
             # Handle the column 'channel_id'.
             if arg1 == 'channel_id':
@@ -371,15 +372,22 @@ class SlackMessagesTable(APIResource):
                     logger.error(f"Error getting channel '{arg2}': {slack_error.response['error']}")
                     raise ValueError(f"Channel '{arg2}' not found")
 
-            # Handle the columns 'text' and 'ts'.
-            if arg1 in ['text', 'ts']:
+            # Handle the column'ts'.
+            elif arg1 =='ts':
                 if op == '=':
-                    params[arg1] = arg2
+                    params[arg1] = float(arg2)
                 else:
                     raise ValueError(f"Unsupported operator '{op}' for column '{arg1}'")
 
             else:
                 raise ValueError(f"Unsupported column '{arg1}'")
+            
+        # Extract the update columns and values.
+        for col, val in query.update_columns.items():
+            if col == 'text':
+                params[col] = str(val).strip("'")
+            else:
+                raise ValueError(f"Unsupported column '{col}'")
 
         # Check if required parameters are provided.
         if 'channel' not in params or 'ts' not in params or 'text' not in params:

--- a/mindsdb/integrations/handlers/slack_handler/slack_tables.py
+++ b/mindsdb/integrations/handlers/slack_handler/slack_tables.py
@@ -436,7 +436,7 @@ class SlackMessagesTable(APIResource):
                     raise ValueError(f"Channel '{arg2}' not found")
 
             # Handle the columns 'ts'.
-            if arg1 == 'ts':
+            elif arg1 == 'ts':
                 if op == '=':
                     params['ts'] = float(arg2)
                 else:

--- a/tests/unit/handlers/test_slack.py
+++ b/tests/unit/handlers/test_slack.py
@@ -656,13 +656,13 @@ class TestSlackConversationsTable(SlackAPIResourceTestSetup, unittest.TestCase):
 class TestSlackMessagesTable(SlackAPIResourceTestSetup, unittest.TestCase):
     def create_resource(self):
         return SlackMessagesTable(self.handler)
-    
+
     def _get_expected_df_for_conv_history_1(self):
         """
         Returns the expected DataFrame for a single call to the `conversations_history` method.
         """
         mock_response_conv_history = deepcopy(MOCK_RESPONSE_CONV_HISTORY_1)
-        
+
         expected_df_conv_history = pd.DataFrame(mock_response_conv_history['messages'], columns=self.resource.get_columns())
         expected_df_conv_history['created_at'] = pd.to_datetime(expected_df_conv_history['ts'].astype(float), unit='s').dt.strftime('%Y-%m-%d %H:%M:%S')
 
@@ -670,7 +670,7 @@ class TestSlackMessagesTable(SlackAPIResourceTestSetup, unittest.TestCase):
         expected_df_conv_history['channel_id'] = MOCK_RESPONSE_CONV_INFO_1['channel']['id']
 
         return expected_df_conv_history
-    
+
     def _get_expected_df_for_conv_history_2(self):
         """
         Returns the expected DataFrame for multiple(2) calls to the `conversations_history` method.
@@ -718,7 +718,7 @@ class TestSlackMessagesTable(SlackAPIResourceTestSetup, unittest.TestCase):
         Tests the `list` method of the SlackMessagesTable class to ensure it correctly fetches the messages of a specific conversation with a limit less than 999.
         """
         self.mock_connect.return_value.conversations_history.return_value = deepcopy(MOCK_SLACK_RESPONSE_CONV_HISTORY_1)
-                                                                                     
+
         self.mock_connect.return_value.conversations_info.return_value = deepcopy(MOCK_SLACK_RESPONSE_CONV_INFO_1)
 
         response = self.resource.list(
@@ -750,7 +750,7 @@ class TestSlackMessagesTable(SlackAPIResourceTestSetup, unittest.TestCase):
             deepcopy(MOCK_SLACK_RESPONSE_CONV_HISTORY_1),
             deepcopy(MOCK_SLACK_RESPONSE_CONV_HISTORY_2)
         ]
-                                                                                     
+
         self.mock_connect.return_value.conversations_info.return_value = deepcopy(MOCK_SLACK_RESPONSE_CONV_INFO_1)
 
         response = self.resource.list(
@@ -1055,20 +1055,20 @@ class TestSlackMessagesTable(SlackAPIResourceTestSetup, unittest.TestCase):
 class TestSlackThreadsTable(SlackAPIResourceTestSetup, unittest.TestCase):
     def create_resource(self):
         return SlackThreadsTable(self.handler)
-    
+
     def _get_expected_df_for_conv_replies_1(self):
         """
         Returns the expected DataFrame for a single call to the `conversations_replies` method.
         """
         mock_response_conv_replies = deepcopy(MOCK_RESPONSE_CONV_REPLIES_1)
-        
+
         expected_df_conv_replies = pd.DataFrame(mock_response_conv_replies['messages'], columns=self.resource.get_columns())
 
         expected_df_conv_replies['channel_name'] = MOCK_RESPONSE_CONV_INFO_1['channel']['name']
         expected_df_conv_replies['channel_id'] = MOCK_RESPONSE_CONV_INFO_1['channel']['id']
 
         return expected_df_conv_replies
-    
+
     def _get_expected_df_for_conv_replies_2(self):
         """
         Returns the expected DataFrame for multiple(2) calls to the `conversations_replies` method.
@@ -1082,7 +1082,7 @@ class TestSlackThreadsTable(SlackAPIResourceTestSetup, unittest.TestCase):
         expected_df_conv_replies_2['channel_id'] = MOCK_RESPONSE_CONV_INFO_1['channel']['id']
 
         return pd.concat([expected_df_conv_replies_1, expected_df_conv_replies_2], ignore_index=True)
-    
+
     def test_list_with_channel_id_thread_ts_and_no_limit(self):
         """
         Tests the `list` method of the SlackThreadsTable class to ensure it correctly fetches the replies of a specific thread without any limit.
@@ -1111,7 +1111,7 @@ class TestSlackThreadsTable(SlackAPIResourceTestSetup, unittest.TestCase):
             ts='1482960137.003543',
             limit=1000
         )
-    
+
         assert isinstance(response, pd.DataFrame)
         expected_df = self._get_expected_df_for_conv_replies_1()
         pd.testing.assert_frame_equal(response, expected_df)
@@ -1217,7 +1217,7 @@ class TestSlackThreadsTable(SlackAPIResourceTestSetup, unittest.TestCase):
                     )
                 ]
             )
-            
+
     def test_list_without_thread_ts(self):
         """
         Tests the `list` method raises a ValueError when the `thread_ts` column is not included in the conditions.
@@ -1331,17 +1331,17 @@ class TestSlackThreadsTable(SlackAPIResourceTestSetup, unittest.TestCase):
 class TestSlackUsersTable(SlackAPIResourceTestSetup, unittest.TestCase):
     def create_resource(self):
         return SlackUsersTable(self.handler)
-    
+
     def _get_expected_df_for_users_list_1(self):
         """
         Returns the expected DataFrame for a single call to the `users_list` method.
         """
         mock_response_users_list = deepcopy(MOCK_RESPONSE_USERS_LIST_1)
-        
+
         expected_df_users_list = pd.DataFrame(mock_response_users_list['members'], columns=self.resource.get_columns())
 
         return expected_df_users_list
-    
+
     def _get_expected_df_for_users_list_2(self):
         """
         Returns the expected DataFrame for multiple(2) calls to the `users_list` method.
@@ -1352,7 +1352,7 @@ class TestSlackUsersTable(SlackAPIResourceTestSetup, unittest.TestCase):
         expected_df_users_list_2 = pd.DataFrame(mock_response_users_list_2['members'], columns=self.resource.get_columns())
 
         return pd.concat([expected_df_users_list_1, expected_df_users_list_2], ignore_index=True)
-    
+
     def test_list_with_no_limit(self):
         """
         Tests the `list` method of the SlackUsersTable class to ensure it correctly fetches the details of all users without any limit.

--- a/tests/unit/handlers/test_slack.py
+++ b/tests/unit/handlers/test_slack.py
@@ -210,7 +210,7 @@ class TestSlackHandler(BaseAPIChatHandlerTest, unittest.TestCase):
         pass
 
 
-class TestSlackConversationsTable(BaseAPIResourceTestSetup, unittest.TestCase):
+class SlackAPIResourceTestSetup(BaseAPIResourceTestSetup):
     @property
     def dummy_connection_data(self):
         return OrderedDict(
@@ -224,6 +224,8 @@ class TestSlackConversationsTable(BaseAPIResourceTestSetup, unittest.TestCase):
     def create_patcher(self):
         return patch('mindsdb.integrations.handlers.slack_handler.slack_handler.WebClient')
 
+
+class TestSlackConversationsTable(SlackAPIResourceTestSetup, unittest.TestCase):
     def create_resource(self):
         return SlackConversationsTable(self.handler)
 

--- a/tests/unit/handlers/test_slack.py
+++ b/tests/unit/handlers/test_slack.py
@@ -265,6 +265,127 @@ MOCK_SLACK_RESPONSE_CONV_REPLIES_2 = SlackResponse(
     data=deepcopy(MOCK_RESPONSE_CONV_REPLIES_2)
 )
 
+# Mock response for the first call to the `users.info` method.
+MOCK_RESPONSE_USERS_LIST_1 = {
+    "ok": True,
+    "members": [
+        {
+            "id": "W012A3CDE",
+            "team_id": "T012AB3C4",
+            "name": "spengler",
+            "deleted": False,
+            "color": "9f69e7",
+            "real_name": "spengler",
+            "tz": "America/Los_Angeles",
+            "tz_label": "Pacific Daylight Time",
+            "tz_offset": -25200,
+            "profile": {
+                "avatar_hash": "ge3b51ca72de",
+                "status_text": "Print is dead",
+                "status_emoji": ":books:",
+                "real_name": "Egon Spengler",
+                "display_name": "spengler",
+                "real_name_normalized": "Egon Spengler",
+                "display_name_normalized": "spengler",
+                "email": "spengler@ghostbusters.example.com",
+                "image_24": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                "image_32": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                "image_48": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                "image_72": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                "image_192": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                "image_512": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                "team": "T012AB3C4"
+            },
+            "is_admin": True,
+            "is_owner": False,
+            "is_primary_owner": False,
+            "is_restricted": False,
+            "is_ultra_restricted": False,
+            "is_bot": False,
+            "updated": 1502138686,
+            "is_app_user": False,
+            "has_2fa": False
+        }
+    ],
+    "cache_ts": 1498777272,
+    "response_metadata": {
+        "next_cursor": "dXNlcjpVMEc5V0ZYTlo="
+    }
+}
+
+# Mock SlackResponse object for the first call to the `users.info` method.
+MOCK_SLACK_RESPONSE_USERS_LIST_1 = SlackResponse(
+    client=MagicMock(),
+    http_verb="GET",
+    api_url="https://slack.com/api/users.list",
+    req_args=MagicMock(),
+    headers=MagicMock(),
+    status_code=200,
+    data=deepcopy(MOCK_RESPONSE_USERS_LIST_1)
+)
+
+# Mock response for the second call to the `users.info` method.
+MOCK_RESPONSE_USERS_LIST_2 = {
+    "ok": True,
+    "members": [
+        {
+            "id": "W07QCRPA4",
+            "team_id": "T0G9PQBBK",
+            "name": "glinda",
+            "deleted": False,
+            "color": "9f69e7",
+            "real_name": "Glinda Southgood",
+            "tz": "America/Los_Angeles",
+            "tz_label": "Pacific Daylight Time",
+            "tz_offset": -25200,
+            "profile": {
+                "avatar_hash": "8fbdd10b41c6",
+                "image_24": "https://a.slack-edge.com...png",
+                "image_32": "https://a.slack-edge.com...png",
+                "image_48": "https://a.slack-edge.com...png",
+                "image_72": "https://a.slack-edge.com...png",
+                "image_192": "https://a.slack-edge.com...png",
+                "image_512": "https://a.slack-edge.com...png",
+                "image_1024": "https://a.slack-edge.com...png",
+                "image_original": "https://a.slack-edge.com...png",
+                "first_name": "Glinda",
+                "last_name": "Southgood",
+                "title": "Glinda the Good",
+                "phone": "",
+                "skype": "",
+                "real_name": "Glinda Southgood",
+                "real_name_normalized": "Glinda Southgood",
+                "display_name": "Glinda the Fairly Good",
+                "display_name_normalized": "Glinda the Fairly Good",
+                "email": "glenda@south.oz.coven"
+            },
+            "is_admin": True,
+            "is_owner": False,
+            "is_primary_owner": False,
+            "is_restricted": False,
+            "is_ultra_restricted": False,
+            "is_bot": False,
+            "updated": 1480527098,
+            "has_2fa": False
+        }
+    ],
+    "cache_ts": 1498777272,
+    "response_metadata": {
+        "next_cursor": ""
+    }
+}
+
+# Mock SlackResponse object for the second call to the `users.info` method.
+MOCK_SLACK_RESPONSE_USERS_LIST_2 = SlackResponse(
+    client=MagicMock(),
+    http_verb="GET",
+    api_url="https://slack.com/api/users.list",
+    req_args=MagicMock(),
+    headers=MagicMock(),
+    status_code=200,
+    data=deepcopy(MOCK_RESPONSE_USERS_LIST_2)
+)
+
 
 class TestSlackHandler(BaseAPIChatHandlerTest, unittest.TestCase):
 
@@ -1142,6 +1263,144 @@ class TestSlackThreadsTable(SlackAPIResourceTestSetup, unittest.TestCase):
             thread_ts='1482960137.003543',
             text='Hello, World!'
         )
+
+    def test_insert_without_channel_id(self):
+        """
+        Tests the `insert` method raises a ValueError when the `channel_id` column is not included in the columns.
+        """
+        with self.assertRaises(ValueError):
+            self.resource.insert(
+                query=Insert(
+                    table='threads',
+                    columns=[
+                        'thread_ts',
+                        'text'
+                    ],
+                    values=[
+                        [
+                            '1482960137.003543',
+                            'Hello, World!'
+                        ]
+                    ]
+                )
+            )
+
+    def test_insert_without_thread_ts(self):
+        """
+        Tests the `insert` method raises a ValueError when the `thread_ts` column is not included in the columns.
+        """
+        with self.assertRaises(ValueError):
+            self.resource.insert(
+                query=Insert(
+                    table='threads',
+                    columns=[
+                        'channel_id',
+                        'text'
+                    ],
+                    values=[
+                        [
+                            'C012AB3CD',
+                            'Hello, World!'
+                        ]
+                    ]
+                )
+            )
+
+    def test_insert_without_text(self):
+        """
+        Tests the `insert` method raises a ValueError when the `text` column is not included in the columns.
+        """
+        with self.assertRaises(ValueError):
+            self.resource.insert(
+                query=Insert(
+                    table='threads',
+                    columns=[
+                        'channel_id',
+                        'thread_ts'
+                    ],
+                    values=[
+                        [
+                            'C012AB3CD',
+                            '1482960137.003543'
+                        ]
+                    ]
+                )
+            )
+
+
+class TestSlackUsersTable(SlackAPIResourceTestSetup, unittest.TestCase):
+    def create_resource(self):
+        return SlackUsersTable(self.handler)
+    
+    def _get_expected_df_for_users_list_1(self):
+        """
+        Returns the expected DataFrame for a single call to the `users_list` method.
+        """
+        mock_response_users_list = deepcopy(MOCK_RESPONSE_USERS_LIST_1)
+        
+        expected_df_users_list = pd.DataFrame(mock_response_users_list['members'], columns=self.resource.get_columns())
+
+        return expected_df_users_list
+    
+    def _get_expected_df_for_users_list_2(self):
+        """
+        Returns the expected DataFrame for multiple(2) calls to the `users_list` method.
+        """
+        mock_response_users_list_2 = deepcopy(MOCK_RESPONSE_USERS_LIST_2)
+
+        expected_df_users_list_1 = self._get_expected_df_for_users_list_1()
+        expected_df_users_list_2 = pd.DataFrame(mock_response_users_list_2['members'], columns=self.resource.get_columns())
+
+        return pd.concat([expected_df_users_list_1, expected_df_users_list_2], ignore_index=True)
+    
+    def test_list_with_no_limit(self):
+        """
+        Tests the `list` method of the SlackUsersTable class to ensure it correctly fetches the details of all users without any limit.
+        """
+        self.mock_connect.return_value.users_list.return_value = deepcopy(MOCK_SLACK_RESPONSE_USERS_LIST_1)
+
+        response = self.resource.list()
+
+        self.assertEqual(self.mock_connect.return_value.users_list.call_count, 1)
+        self.mock_connect.return_value.users_list.assert_any_call(limit=1000)
+
+        assert isinstance(response, pd.DataFrame)
+        expected_df = self._get_expected_df_for_users_list_1()
+        pd.testing.assert_frame_equal(response, expected_df)
+
+    def test_list_with_limit_less_than_1000(self):
+        """
+        Tests the `list` method of the SlackUsersTable class to ensure it correctly fetches the details of all users with a limit less than 1000.
+        """
+        self.mock_connect.return_value.users_list.return_value = deepcopy(MOCK_SLACK_RESPONSE_USERS_LIST_1)
+
+        response = self.resource.list(limit=999)
+
+        self.assertEqual(self.mock_connect.return_value.users_list.call_count, 1)
+        self.mock_connect.return_value.users_list.assert_any_call(limit=999)
+
+        assert isinstance(response, pd.DataFrame)
+        expected_df = self._get_expected_df_for_users_list_1()
+        pd.testing.assert_frame_equal(response, expected_df)
+
+    def test_list_with_limit_more_than_1000(self):
+        """
+        Tests the `list` method of the SlackUsersTable class to ensure it correctly fetches the details of all users with a limit more than 1000.
+        """
+        self.mock_connect.return_value.users_list.side_effect = [
+            deepcopy(MOCK_SLACK_RESPONSE_USERS_LIST_1),
+            deepcopy(MOCK_SLACK_RESPONSE_USERS_LIST_2)
+        ]
+
+        response = self.resource.list(limit=1001)
+
+        self.assertEqual(self.mock_connect.return_value.users_list.call_count, 2)
+        self.mock_connect.return_value.users_list.assert_any_call()
+        self.mock_connect.return_value.users_list.assert_any_call(cursor=MOCK_RESPONSE_USERS_LIST_1['response_metadata']['next_cursor'])
+
+        assert isinstance(response, pd.DataFrame)
+        expected_df = self._get_expected_df_for_users_list_2()
+        pd.testing.assert_frame_equal(response, expected_df)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

This PR adds unit tests for the other 'APIResource' class implementations of the Slack integration and resolves some bugs discovered in the process.

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [X]   Test Location: `tests/unit/handlers/test_slack.py` for unit tests.
 - [X]   Verification Steps: Run the above test module.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.