### PR TITLE
Add User Input to Map Reduce Summarizer Chain

### DIFF
--- a/mindsdb/integrations/utilities/rag/pipelines/rag.py
+++ b/mindsdb/integrations/utilities/rag/pipelines/rag.py
@@ -7,7 +7,7 @@ from langchain.retrievers import ContextualCompressionRetriever
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnableParallel, RunnablePassthrough, RunnableSerializable
 
-from mindsdb.integrations.utilities.rag.chains.map_reduce_summarizer_chain import create_map_reduce_documents_chain, MapReduceSummarizerChain
+from mindsdb.integrations.utilities.rag.chains.map_reduce_summarizer_chain import MapReduceSummarizerChain
 from mindsdb.integrations.utilities.rag.retrievers.auto_retriever import AutoRetriever
 from mindsdb.integrations.utilities.rag.retrievers.multi_vector_retriever import MultiVectorRetriever
 from mindsdb.integrations.utilities.rag.rerankers.reranker_compressor import LLMReranker
@@ -55,11 +55,10 @@ class LangChainRAGPipeline:
         self.vector_store_config = vector_store_config
         knowledge_base_table = self.vector_store_config.kb_table if self.vector_store_config is not None else None
         if summarization_config is not None and knowledge_base_table is not None:
-            map_reduce_documents_chain = create_map_reduce_documents_chain(summarization_config)
             self.summarizer = MapReduceSummarizerChain(
                 vector_store_handler=knowledge_base_table.get_vector_db(),
                 table_name=knowledge_base_table.get_vector_db_table_name(),
-                map_reduce_documents_chain=map_reduce_documents_chain
+                summarization_config=summarization_config
             )
 
     def with_returned_sources(self) -> RunnableSerializable:

--- a/mindsdb/integrations/utilities/rag/settings.py
+++ b/mindsdb/integrations/utilities/rag/settings.py
@@ -68,12 +68,18 @@ Answer:'''
 
 DEFAULT_MAP_PROMPT_TEMPLATE = '''The following is a set of documents
 {docs}
-Based on this list of docs, please identify the main themes
+Based on this list of docs, please summarize based on the user input.
+
+User input: {input}
+
 Helpful Answer:'''
 
 DEFAULT_REDUCE_PROMPT_TEMPLATE = '''The following is set of summaries:
 {docs}
-Take these and distill it into a final, consolidated summary of the main themes.
+Take these and distill it into a final, consolidated summary related to the user input.
+
+User input: {input}
+
 Helpful Answer:'''
 
 

--- a/tests/unit/test_map_reduce_summarizer_chain.py
+++ b/tests/unit/test_map_reduce_summarizer_chain.py
@@ -6,6 +6,7 @@ from langchain_core.documents import Document
 
 from mindsdb.integrations.libs.vectordatabase_handler import VectorStoreHandler
 from mindsdb.integrations.utilities.rag.chains.map_reduce_summarizer_chain import MapReduceSummarizerChain
+from mindsdb.integrations.utilities.rag.settings import SummarizationConfig
 from mindsdb.integrations.utilities.sql_utils import FilterCondition, FilterOperator
 
 
@@ -25,7 +26,8 @@ class TestMapReduceSummarizerChain:
         mock_map_reduce_documents_chain.ainvoke.side_effect = [{'output_text': 'Final summary 1'}, {'output_text': 'Final summary 2'}]
         test_summarizer_chain = MapReduceSummarizerChain(
             vector_store_handler=mock_vector_store_handler,
-            map_reduce_documents_chain=mock_map_reduce_documents_chain
+            map_reduce_documents_chain=mock_map_reduce_documents_chain,
+            summarization_config=SummarizationConfig()
         )
 
         chain_input = {
@@ -41,7 +43,7 @@ class TestMapReduceSummarizerChain:
         # Make sure we select from the vector store correctly.
         mock_vector_store_handler.select.assert_any_call(
             'embeddings',
-            columns=['content'],
+            columns=['content', 'metadata'],
             conditions=[FilterCondition(
                 "metadata->>'original_row_id'",
                 FilterOperator.EQUAL,
@@ -50,7 +52,7 @@ class TestMapReduceSummarizerChain:
         )
         mock_vector_store_handler.select.assert_any_call(
             'embeddings',
-            columns=['content'],
+            columns=['content', 'metadata'],
             conditions=[FilterCondition(
                 "metadata->>'original_row_id'",
                 FilterOperator.EQUAL,


### PR DESCRIPTION
## Description

This PR introduces a few improvements to our `MapReduceSummarizerChain`:
- Add user input as context to map & reduce prompts to get context aware summaries of documents
- Reconstruct documents from chunks in order so context is more cohesive

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [x]   Test Location: `./tests/unit/test_map_reduce_summarizer_chain.py`
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



