### PR TITLE
Don't Register Vectors for PGVector on Every Query

### DIFF
--- a/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
+++ b/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
@@ -36,6 +36,7 @@ class PgVectorHandler(VectorStoreHandler, PostgresHandler):
 
         super().__init__(name=name, **kwargs)
         self._is_shared_db = False
+        self._is_vector_registered = False
         self.connect()
 
     def _make_connection_args(self):
@@ -77,6 +78,8 @@ class PgVectorHandler(VectorStoreHandler, PostgresHandler):
         Handles the connection to a PostgreSQL database instance.
         """
         self.connection = super().connect()
+        if self._is_vector_registered:
+            return self.connection
 
         with self.connection.cursor() as cur:
             try:
@@ -93,6 +96,7 @@ class PgVectorHandler(VectorStoreHandler, PostgresHandler):
 
         # register vector type with psycopg2 connection
         register_vector(self.connection)
+        self._is_vector_registered = True
 
         return self.connection
 

--- a/mindsdb/integrations/utilities/rag/chains/map_reduce_summarizer_chain.py
+++ b/mindsdb/integrations/utilities/rag/chains/map_reduce_summarizer_chain.py
@@ -170,6 +170,8 @@ class MapReduceSummarizerChain(Chain):
         inputs: Dict[str, Any],
         run_manager: Optional[CallbackManagerForChainRun] = None
     ) -> Dict[str, Any]:
+        # Explicitly connect to make sure vectors are registered.
+        _ = self.vector_store_handler.connect()
         logger.debug(f"Processing inputs with keys: {list(inputs.keys())}")
         context_chunks = inputs.get(self.context_key, [])
         logger.debug(f"Found {len(context_chunks)} context chunks")


### PR DESCRIPTION
## Description

If we try to execute many native queries concurrently, our underlying connection will try to call `register_vector` many times concurrently, which can cause transaction issues.

Fixes ML-227

## Type of change


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



