### PR TITLE
docs - update no file size limit

### DIFF
--- a/docs/integrations/files/csv-xlsx-xls.mdx
+++ b/docs/integrations/files/csv-xlsx-xls.mdx
@@ -3,7 +3,7 @@ title: Upload CSV, XLSX, XLS files to MindsDB
 sidebarTitle: CSV, XLSX, XLS
 ---
 
-You can upload CSV, XLSX, and XLS files of any size to MindsDB that runs locally via [Docker](/setup/self-hosted/docker) or [pip](/contribute/install). Note that this limit is imposed when uploading a file via MindsDB SQL Editor. If you [upload a file via APIs](https://docs.mindsdb.com/rest/files/upload), this limit does not persist.
+You can upload CSV, XLSX, and XLS files of any size to MindsDB that runs locally via [Docker](/setup/self-hosted/docker) or [pip](/contribute/install).
 
 CSV, XLSX, XLS files are stored in the form of a table inside MindsDB.
 

--- a/docs/integrations/files/csv-xlsx-xls.mdx
+++ b/docs/integrations/files/csv-xlsx-xls.mdx
@@ -3,7 +3,7 @@ title: Upload CSV, XLSX, XLS files to MindsDB
 sidebarTitle: CSV, XLSX, XLS
 ---
 
-You can upload CSV, XLSX, and XLS files of up to 500MB in size to MindsDB. Note that this limit is imposed when uploading a file via MindsDB SQL Editor. If you [upload a file via APIs](https://docs.mindsdb.com/rest/files/upload), this limit does not persist.
+You can upload CSV, XLSX, and XLS files of any size to MindsDB that runs locally via [Docker](/setup/self-hosted/docker) or [pip](/contribute/install). Note that this limit is imposed when uploading a file via MindsDB SQL Editor. If you [upload a file via APIs](https://docs.mindsdb.com/rest/files/upload), this limit does not persist.
 
 CSV, XLSX, XLS files are stored in the form of a table inside MindsDB.
 

--- a/docs/integrations/files/json.mdx
+++ b/docs/integrations/files/json.mdx
@@ -3,7 +3,7 @@ title: Upload JSON files to MindsDB
 sidebarTitle: JSON
 ---
 
-You can upload JSON files of any size to MindsDB that runs locally via [Docker](/setup/self-hosted/docker) or [pip](/contribute/install). Note that this limit is imposed when uploading a file via MindsDB SQL Editor. If you [upload a file via APIs](https://docs.mindsdb.com/rest/files/upload), this limit does not persist.
+You can upload JSON files of any size to MindsDB that runs locally via [Docker](/setup/self-hosted/docker) or [pip](/contribute/install).
 
 JSON files are converted into a table, if the JSON file structure allows for it. Otherwise, JSON files are stored similarly to text files.
 

--- a/docs/integrations/files/json.mdx
+++ b/docs/integrations/files/json.mdx
@@ -3,7 +3,7 @@ title: Upload JSON files to MindsDB
 sidebarTitle: JSON
 ---
 
-You can upload JSON files of up to 500MB in size to MindsDB. Note that this limit is imposed when uploading a file via MindsDB SQL Editor. If you [upload a file via APIs](https://docs.mindsdb.com/rest/files/upload), this limit does not persist.
+You can upload JSON files of any size to MindsDB that runs locally via [Docker](/setup/self-hosted/docker) or [pip](/contribute/install). Note that this limit is imposed when uploading a file via MindsDB SQL Editor. If you [upload a file via APIs](https://docs.mindsdb.com/rest/files/upload), this limit does not persist.
 
 JSON files are converted into a table, if the JSON file structure allows for it. Otherwise, JSON files are stored similarly to text files.
 

--- a/docs/integrations/files/parquet.mdx
+++ b/docs/integrations/files/parquet.mdx
@@ -3,7 +3,7 @@ title: Upload Parquet files to MindsDB
 sidebarTitle: Parquet
 ---
 
-You can upload Parquet files of any size to MindsDB that runs locally via [Docker](/setup/self-hosted/docker) or [pip](/contribute/install). Note that this limit is imposed when uploading a file via MindsDB SQL Editor. If you [upload a file via APIs](https://docs.mindsdb.com/rest/files/upload), this limit does not persist.
+You can upload Parquet files of any size to MindsDB that runs locally via [Docker](/setup/self-hosted/docker) or [pip](/contribute/install).
 
 Parquet files are stored in the form of a table inside MindsDB.
 

--- a/docs/integrations/files/parquet.mdx
+++ b/docs/integrations/files/parquet.mdx
@@ -3,7 +3,7 @@ title: Upload Parquet files to MindsDB
 sidebarTitle: Parquet
 ---
 
-You can upload Parquet files of up to 500MB in size to MindsDB. Note that this limit is imposed when uploading a file via MindsDB SQL Editor. If you [upload a file via APIs](https://docs.mindsdb.com/rest/files/upload), this limit does not persist.
+You can upload Parquet files of any size to MindsDB that runs locally via [Docker](/setup/self-hosted/docker) or [pip](/contribute/install). Note that this limit is imposed when uploading a file via MindsDB SQL Editor. If you [upload a file via APIs](https://docs.mindsdb.com/rest/files/upload), this limit does not persist.
 
 Parquet files are stored in the form of a table inside MindsDB.
 

--- a/docs/integrations/files/pdf.mdx
+++ b/docs/integrations/files/pdf.mdx
@@ -3,7 +3,7 @@ title: Upload PDF files to MindsDB
 sidebarTitle: PDF
 ---
 
-You can upload PDF files of any size to MindsDB that runs locally via [Docker](/setup/self-hosted/docker) or [pip](/contribute/install). Note that this limit is imposed when uploading a file via MindsDB SQL Editor. If you [upload a file via APIs](https://docs.mindsdb.com/rest/files/upload), this limit does not persist.
+You can upload PDF files of any size to MindsDB that runs locally via [Docker](/setup/self-hosted/docker) or [pip](/contribute/install).
 
 Note that MindsDB supports only searchable PDFs, as opposed to scanned PDFs. These are stored in the form of a table inside MindsDB.
 

--- a/docs/integrations/files/pdf.mdx
+++ b/docs/integrations/files/pdf.mdx
@@ -3,7 +3,7 @@ title: Upload PDF files to MindsDB
 sidebarTitle: PDF
 ---
 
-You can upload PDF files of up to 500MB in size to MindsDB. Note that this limit is imposed when uploading a file via MindsDB SQL Editor. If you [upload a file via APIs](https://docs.mindsdb.com/rest/files/upload), this limit does not persist.
+You can upload PDF files of any size to MindsDB that runs locally via [Docker](/setup/self-hosted/docker) or [pip](/contribute/install). Note that this limit is imposed when uploading a file via MindsDB SQL Editor. If you [upload a file via APIs](https://docs.mindsdb.com/rest/files/upload), this limit does not persist.
 
 Note that MindsDB supports only searchable PDFs, as opposed to scanned PDFs. These are stored in the form of a table inside MindsDB.
 

--- a/docs/integrations/files/txt.mdx
+++ b/docs/integrations/files/txt.mdx
@@ -3,7 +3,7 @@ title: Upload TXT files to MindsDB
 sidebarTitle: TXT
 ---
 
-You can upload TXT files of any size to MindsDB that runs locally via [Docker](/setup/self-hosted/docker) or [pip](/contribute/install). Note that this limit is imposed when uploading a file via MindsDB SQL Editor. If you [upload a file via APIs](https://docs.mindsdb.com/rest/files/upload), this limit does not persist.
+You can upload TXT files of any size to MindsDB that runs locally via [Docker](/setup/self-hosted/docker) or [pip](/contribute/install).
 
 TXT files are divided into chunks and stored in multiple table cells. MindsDB uses the [TextLoader from LangChain](https://api.python.langchain.com/en/latest/document_loaders/langchain_community.document_loaders.text.TextLoader.html) to load TXT files.
 

--- a/docs/integrations/files/txt.mdx
+++ b/docs/integrations/files/txt.mdx
@@ -3,7 +3,7 @@ title: Upload TXT files to MindsDB
 sidebarTitle: TXT
 ---
 
-You can upload TXT files of up to 500MB in size to MindsDB. Note that this limit is imposed when uploading a file via MindsDB SQL Editor. If you [upload a file via APIs](https://docs.mindsdb.com/rest/files/upload), this limit does not persist.
+You can upload TXT files of any size to MindsDB that runs locally via [Docker](/setup/self-hosted/docker) or [pip](/contribute/install). Note that this limit is imposed when uploading a file via MindsDB SQL Editor. If you [upload a file via APIs](https://docs.mindsdb.com/rest/files/upload), this limit does not persist.
 
 TXT files are divided into chunks and stored in multiple table cells. MindsDB uses the [TextLoader from LangChain](https://api.python.langchain.com/en/latest/document_loaders/langchain_community.document_loaders.text.TextLoader.html) to load TXT files.
 


### PR DESCRIPTION
## Description

docs - update no file size limit

as discussed with the frontend, there is no file size limit when MindsDB runs locally

Fixes #issue_number

## Type of change

- [ ] 📄 This change is a documentation update
