### PR TITLE
Enabled Copy Storage for Creating Database via API

### DIFF
--- a/mindsdb/api/http/namespaces/databases.py
+++ b/mindsdb/api/http/namespaces/databases.py
@@ -80,7 +80,7 @@ class DatabasesResource(Resource):
                     "status": "connection_error",
                     "detail": status.error_message
                 }, HTTPStatus.OK
-            
+
             if status.copy_storage:
                 storage = handler.handler_storage.export_files()
 

--- a/mindsdb/api/http/namespaces/databases.py
+++ b/mindsdb/api/http/namespaces/databases.py
@@ -61,6 +61,7 @@ class DatabasesResource(Resource):
                 f'Database with name {name} already exists.'
             )
 
+        storage = None
         if check_connection:
             try:
                 handler = session.integration_controller.create_tmp_handler(name, database['engine'], parameters)
@@ -79,8 +80,16 @@ class DatabasesResource(Resource):
                     "status": "connection_error",
                     "detail": status.error_message
                 }, HTTPStatus.OK
+            
+            if status.copy_storage:
+                storage = handler.handler_storage.export_files()
 
         new_integration_id = session.integration_controller.add(name, database['engine'], parameters)
+
+        if storage:
+            handler = session.integration_controller.get_data_handler(name, connect=False)
+            handler.handler_storage.import_files(storage)
+
         new_integration = session.database_controller.get_integration(new_integration_id)
         return new_integration, HTTPStatus.CREATED
 


### PR DESCRIPTION
## Description

This PR enables temporary storage files to be copied over when creating the integration via the `POST /databases` API. This is currently causing connections created to MS OneDrive via Minds to fail.

Fixes https://linear.app/mindsdb/issue/BE-579/enable-temp-storage-to-be-copied-when-creating-database-via-api

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.