### PR TITLE
Update sdist to build

### DIFF
--- a/.github/workflows/build_deploy_prod.yml
+++ b/.github/workflows/build_deploy_prod.yml
@@ -55,7 +55,8 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           # This uses the version string from __about__.py, which we checked matches the git tag above
-          python setup.py sdist
+          uv pip install build
+          python -m build
           twine upload dist/*
 
   # Build our docker images based on our bake file


### PR DESCRIPTION
## Description

This PR updates the PyPI deployment workflow to replace the `python setup.py sdist `with python -m build, which ensures PEP 625-compliant filenames.

Fixes https://linear.app/mindsdb/issue/BE-518/[pypi]-deprecation-notice-for-recent-source-distribution-upload-to

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update




