### PR TITLE
Allow Inserting DataFrames With Explicit NULL Values Into Tables

### DIFF
--- a/mindsdb/api/executor/sql_query/steps/insert_step.py
+++ b/mindsdb/api/executor/sql_query/steps/insert_step.py
@@ -39,7 +39,14 @@ class InsertToTableCall(BaseStepCall):
 
             records = []
             for row in step.query.values:
-                record = [v.value for v in row]
+                record = []
+                for v in row:
+                    if isinstance(v, Identifier) and v.parts[0] == 'None':
+                        # Allow explicitly inserting NULL values.
+                        record.append(None)
+                        continue
+                    # Value is a constant
+                    record.append(v.value)
                 records.append(record)
 
             data.add_raw_values(records)


### PR DESCRIPTION
## Description

To be able to batch insert rows effectively using a DataFrame, we need to support cases where some rows have `None` for a column value, and others do not.

Currently, the below code does not work as expected:

```python
doc_embeddings = con.get_database(f'{pgvector_datasource.name}')
doc_embeddings_table = doc_embeddings.tables.get('documents')
doc_df = pd.DataFrame.from_records([
    {
        'Id': 3,
        'Type': None
    }
])
doc_embeddings_table.insert(doc_df)
```

Instead, it fails with an Exception:

```mindsdb-1  |   File "/mindsdb/./mindsdb/api/executor/sql_query/sql_query.py", line 261, in execute_query
mindsdb-1  |     raise e
mindsdb-1  |   File "/mindsdb/./mindsdb/api/executor/sql_query/sql_query.py", line 256, in execute_query
mindsdb-1  |     step_result = self.execute_step(step)
mindsdb-1  |   File "/mindsdb/./mindsdb/api/executor/sql_query/sql_query.py", line 315, in execute_step
mindsdb-1  |     return handler(self, steps_data=steps_data).call(step)
mindsdb-1  |   File "/mindsdb/./mindsdb/api/executor/sql_query/steps/insert_step.py", line 42, in call
mindsdb-1  |     record = [v.value for v in row]
mindsdb-1  |   File "/mindsdb/./mindsdb/api/executor/sql_query/steps/insert_step.py", line 42, in <listcomp>
mindsdb-1  |     record = [v.value for v in row]
mindsdb-1  | AttributeError: 'Identifier' object has no attribute 'value'
```

This PR fixes the above, making it OK to explicitly insert DataFrames with Explicit `None` values.

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [x]   Verification Steps: Test inserting `None` locally into integrations

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



