### PR TITLE
Bumped `scikit-learn` to 1.5.2 to Align with Lightwood

### DIFF
--- a/mindsdb/integrations/handlers/lightwood_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/lightwood_handler/requirements.txt
@@ -1,4 +1,4 @@
-lightwood==24.12.1.0
-lightwood[extra]==24.12.1.0
-lightwood[xai]==24.12.1.0
+lightwood==24.12.3.0
+lightwood[extra]==24.12.3.0
+lightwood[xai]==24.12.3.0
 type_infer==0.0.20

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -32,7 +32,7 @@ botocore
 boto3 >= 1.34.131
 python-dateutil
 gunicorn
-scikit-learn==1.5.0
+scikit-learn==1.5.2
 protobuf==3.20.3
 hierarchicalforecast~=0.4.0
 google-auth-oauthlib


### PR DESCRIPTION
## Description

This PR updates `scikit-learn` to 1.5.2 to align with the version used for `lightwood` [here](https://github.com/mindsdb/lightwood/pull/1244).

Fixes #issue_number

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)