### PR TITLE
Convert DataFrame Types to Ints Correctly When Inserting Into Table

### DIFF
--- a/mindsdb/api/executor/sql_query/result_set.py
+++ b/mindsdb/api/executor/sql_query/result_set.py
@@ -234,7 +234,7 @@ class ResultSet:
             self._df = pd.concat([self._df, df], ignore_index=True)
 
     def add_raw_values(self, values):
-        # If some values are None, the DataFrame could have incorrect integer types, since 'NaN' is technically a float, so it will convert ints to floats automatically. 
+        # If some values are None, the DataFrame could have incorrect integer types, since 'NaN' is technically a float, so it will convert ints to floats automatically.
         df = pd.DataFrame(values).convert_dtypes(
             convert_integer=True,
             convert_floating=True,


### PR DESCRIPTION
## Description

When inserting values into a table, we first insert those values into a `DataFrame`. If those values are `ints`, and some values for that column are `None`, then they will _incorrectly_ be converted to `float`s. This is because `NaN` (`None` --> `NaN` for number cols when initializing a `DataFrame`). So after creating the `DataFrame`, we should convert the numeric types back to what they originally are supposed to be.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: 
 - [ ]   Verification Steps: Test inserting DataFrame into database table locally where some integer columns are NULL.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



