### PR TITLE
Render frame of window function

### DIFF
--- a/mindsdb/utilities/render/sqlalchemy_render.py
+++ b/mindsdb/utilities/render/sqlalchemy_render.py
@@ -270,10 +270,38 @@ class SqlalchemyRender:
                         col0 = col0.desc()
                     order_by.append(col0)
 
+            rows, range_ = None, None
+            if t.modifier is not None:
+                words = t.modifier.lower().split()
+                if words[1] == 'between' and words[4] == 'and':
+                    # frame options
+                    # rows/groups BETWEEN <> <> AND <> <>
+                    # https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.over
+                    items = []
+                    for word1, word2 in (words[2:4], words[5:7]):
+                        if word1 == 'unbounded':
+                            items.append(None)
+                        elif (word1, word2) == ('current', 'row'):
+                            items.append(0)
+                        elif word1.isdigits():
+                            val = int(word1)
+                            if word2 == 'preceding':
+                                val = -val
+                            elif word2 != 'following':
+                                continue
+                            items.append(val)
+                    if len(items) == 2:
+                        if words[0] == 'rows':
+                            rows = tuple(items)
+                        elif words[0] == 'range':
+                            range_ = tuple(items)
+
             col = sa.over(
                 func,
                 partition_by=partition,
-                order_by=order_by
+                order_by=order_by,
+                range_=range_,
+                rows=rows
             )
 
             if t.alias:

--- a/tests/unit/render/test_from_parser.py
+++ b/tests/unit/render/test_from_parser.py
@@ -80,7 +80,12 @@ def parse_sql2(sql, dialect='mindsdb'):
         query_traversal(query2, clear_target_aliases)
 
         # and compare with ast before render
-        assert query2.to_tree() == query_.to_tree()
+        repr1, repr2 = query2.to_tree(), query_.to_tree()
+        if 'unbounded preceding' in repr2:
+            # sqlalchemy changes case
+            assert repr1.lower() == repr2.lower()
+        else:
+            assert repr1 == repr2
 
     # step 2: render to different dialects
     dialects = ('postgresql', 'sqlite', 'mssql', 'oracle')


### PR DESCRIPTION
## Description

Fix: frame options were skipped by render:
- ROW_NUMBER() OVER(ORDER BY some_column **RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW**)

Fixes https://linear.app/mindsdb/issue/BE-473/redshift-passes-100percent-of-tpc-ds

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



