### PR TITLE
Fix 'extract' function in joins

### DIFF
--- a/mindsdb/integrations/utilities/query_traversal.py
+++ b/mindsdb/integrations/utilities/query_traversal.py
@@ -105,6 +105,12 @@ def query_traversal(node, callback, is_table=False, is_target=False, parent_quer
             array.append(node_out)
         node.args = array
 
+        if isinstance(node, ast.Function):
+            if node.from_arg is not None:
+                node_out = query_traversal(node.from_arg, callback, parent_query=parent_query)
+                if node_out is not None:
+                    node.from_arg = node_out
+
     elif isinstance(node, ast.WindowFunction):
         query_traversal(node.function, callback, parent_query=parent_query)
         if node.partition is not None:

--- a/tests/unit/executor/test_project_structure.py
+++ b/tests/unit/executor/test_project_structure.py
@@ -43,13 +43,14 @@ class TestProjectStructure(BaseExecutorDummyML):
 
         # use model
         ret = self.run_sql('''
-             SELECT m.*
+             SELECT m.*, extract(day from t.b) as day
                FROM dummy_data.tasks as t
                JOIN proj.task_model as m
         ''')
 
         assert len(ret) == 3
         assert ret.predicted[0] == 42
+        assert ret.day[0] == 1
 
         # -- retrain predictor with tag --
         ret = self.run_sql(


### PR DESCRIPTION
## Description

Fix query_traversal function: handle function.from_arg

It fixes error such as: `Binder Error: Referenced table "t" not found!`
For this type of query:
```sql
SELECT extract(hour from t.created_at)
FROM example_db.home_rentals as t
JOIN mindsdb.home_rentals_model as m
```

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



