### PR TITLE
Set HTTP server type and options via `config.json`

### DIFF
--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -3,8 +3,9 @@ import sys
 import json
 import argparse
 import datetime
-from copy import deepcopy
 from pathlib import Path
+from copy import deepcopy
+import multiprocessing as mp
 
 from appdirs import user_data_dir
 
@@ -170,7 +171,15 @@ class Config:
                     "port": "47334",
                     "restart_on_failure": True,
                     "max_restart_count": 1,
-                    "max_restart_interval_seconds": 60
+                    "max_restart_interval_seconds": 60,
+                    "server": {
+                        "type": "waitress",     # MINDSDB_DEFAULT_SERVER
+                        "config": {
+                            "threads": 16,
+                            "max_request_body_size": (1 << 30) * 10,    # 10GB
+                            "inbuf_overflow": (1 << 30) * 10
+                        }
+                    }
                 },
                 "mysql": {
                     "host": api_host,
@@ -234,6 +243,11 @@ class Config:
                 'handlers': {
                     'console': {},
                     'file': {}
+                }
+            },
+            "api": {
+                "http": {
+                    "server": {}
                 }
             },
             'auth': {},
@@ -304,6 +318,33 @@ class Config:
         if os.environ.get('MINDSDB_FILE_LOG_LEVEL', '') != '':
             self._env_config['logging']['handlers']['file']['level'] = os.environ['MINDSDB_FILE_LOG_LEVEL']
             self._env_config['logging']['handlers']['file']['enabled'] = True
+        # endregion
+
+        # region server type
+        server_type = os.environ.get('MINDSDB_DEFAULT_SERVER', '').lower()
+        if server_type != '':
+            if server_type == 'waitress':
+                self._env_config['api']['http']['server']['type'] = 'waitress'
+                self._default_config['api']['http']['server']['config'] = {}
+                self._env_config['api']['http']['server']['config'] = {
+                    "threads": 16,
+                    "max_request_body_size": (1 << 30) * 10,    # 10GB
+                    "inbuf_overflow": (1 << 30) * 10
+                }
+            elif server_type == 'flask':
+                self._env_config['api']['http']['server']['type'] = 'flask'
+                self._default_config['api']['http']['server']['config'] = {}
+                self._env_config['api']['http']['server']['config'] = {}
+            elif server_type == 'gunicorn':
+                self._env_config['api']['http']['server']['type'] = 'gunicorn'
+                self._default_config['api']['http']['server']['config'] = {}
+                self._env_config['api']['http']['server']['config'] = {
+                    'workers': min(mp.cpu_count(), 4),
+                    'timeout': 600,
+                    'reuse_port': True,
+                    'preload_app': True,
+                    'threads': 4
+                }
         # endregion
 
         if os.environ.get('MINDSDB_DB_CON', '') != '':

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -492,6 +492,14 @@ class Config:
                 "Use 'MINDSDB_HTTP_SERVER_TYPE' instead."
             )
 
+        for env_name in ('MINDSDB_HTTP_SERVER_TYPE', 'MINDSDB_DEFAULT_SERVER'):
+            env_value = os.environ.get(env_name, '')
+            if env_value.lower() not in ('waitress', 'flask', 'gunicorn'):
+                logger.warning(
+                    f"The value '{env_value}' of the environment variable {env_name} is not valid. "
+                    "It must be one of the following: 'waitress', 'flask', or 'gunicorn'."
+                )
+
     @property
     def cmd_args(self):
         if self._cmd_args is None:

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -322,7 +322,7 @@ class Config:
 
         # region server type
         server_type = os.environ.get('MINDSDB_HTTP_SERVER_TYPE', '').lower()
-        if server_type != '':
+        if server_type == '':
             server_type = os.environ.get('MINDSDB_DEFAULT_SERVER', '').lower()
         if server_type != '':
             if server_type == 'waitress':

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -486,9 +486,9 @@ class Config:
         if 'log' in self._config:
             logger.warning("The 'log' config option is no longer supported. Use 'logging' instead.")
 
-        if os.environ.get('MINDSDB_HTTP_SERVER_TYPE', '') != '':
+        if os.environ.get('MINDSDB_DEFAULT_SERVER', '') != '':
             logger.warning(
-                "Env variable 'MINDSDB_HTTP_SERVER_TYPE' is going to be deprecated soon. "
+                "Env variable 'MINDSDB_DEFAULT_SERVER' is going to be deprecated soon. "
                 "Use 'MINDSDB_HTTP_SERVER_TYPE' instead."
             )
 

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -173,7 +173,7 @@ class Config:
                     "max_restart_count": 1,
                     "max_restart_interval_seconds": 60,
                     "server": {
-                        "type": "waitress",     # MINDSDB_DEFAULT_SERVER
+                        "type": "waitress",     # MINDSDB_HTTP_SERVER_TYPE MINDSDB_DEFAULT_SERVER
                         "config": {
                             "threads": 16,
                             "max_request_body_size": (1 << 30) * 10,    # 10GB
@@ -321,7 +321,9 @@ class Config:
         # endregion
 
         # region server type
-        server_type = os.environ.get('MINDSDB_DEFAULT_SERVER', '').lower()
+        server_type = os.environ.get('MINDSDB_HTTP_SERVER_TYPE', '').lower()
+        if server_type != '':
+            server_type = os.environ.get('MINDSDB_DEFAULT_SERVER', '').lower()
         if server_type != '':
             if server_type == 'waitress':
                 self._env_config['api']['http']['server']['type'] = 'waitress'
@@ -483,6 +485,12 @@ class Config:
 
         if 'log' in self._config:
             logger.warning("The 'log' config option is no longer supported. Use 'logging' instead.")
+
+        if os.environ.get('MINDSDB_HTTP_SERVER_TYPE', '') != '':
+            logger.warning(
+                "Env variable 'MINDSDB_HTTP_SERVER_TYPE' is going to be deprecated soon. "
+                "Use 'MINDSDB_HTTP_SERVER_TYPE' instead."
+            )
 
     @property
     def cmd_args(self):


### PR DESCRIPTION
## Description

- env var `MINDSDB_HTTP_SERVER_TYPE` is now obsolete (but still can be used). `MINDSDB_HTTP_SERVER_TYPE` should be used instead.
- MINDSDB_HTTP_SERVER_TYPE can be: waitress (default), flask or gunicorn.
- as alternative, server type can be set in `config['api']['http']['server']['type']`
- HTTP server is now configurable. Relevant options can be set in `config['api']['http']['server']['config']`. Default options are:
 ```js
//  waitres 
{
    "threads": 16,
    "max_request_body_size": (1 << 30) * 10,    # 10GB
    "inbuf_overflow": (1 << 30) * 10
}

// flask
{}

// gunicorn
{
    'workers': min(multiprocessing.cpu_count(), 4),
    'timeout': 600,
    'reuse_port': True,
    'preload_app': True,
    'threads': 4
}
 ```
Any options that are supported by the server can be set there. Except host/port, they are configured in config['api']['http']['host'] and config['api']['http']['port'] as before


Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



