### PR TITLE
Added Fallback Sort Logic for API Resources

### DIFF
--- a/mindsdb/integrations/handlers/github_handler/github_tables.py
+++ b/mindsdb/integrations/handlers/github_handler/github_tables.py
@@ -46,6 +46,7 @@ class GithubIssuesTable(APIResource):
                 if col.column in ('created', 'updated', 'comments'):
                     issues_kwargs['sort'] = col.column
                     issues_kwargs['direction'] = 'asc' if col.ascending else 'desc'
+                    sort.applied = True
 
                     # supported only 1 column
                     break
@@ -274,6 +275,7 @@ class GithubPullRequestsTable(APIResource):
                 if col.column in ('created', 'updated', 'popularity'):
                     issues_kwargs['sort'] = col.column
                     issues_kwargs['direction'] = 'asc' if col.ascending else 'desc'
+                    sort.applied = True
 
                     # supported only 1 column
                     break
@@ -418,6 +420,7 @@ class GithubCommitsTable(APIResource):
                 if col.column in ("author", "date", "message"):
                     commits_kwargs['sort'] = col.column
                     commits_kwargs['direction'] = 'asc' if col.ascending else 'desc'
+                    sort.applied = True
 
                     # supported only 1 column
                     break

--- a/mindsdb/integrations/libs/api_handler.py
+++ b/mindsdb/integrations/libs/api_handler.py
@@ -207,12 +207,13 @@ class APIResource(APITable):
 
         result = filter_dataframe(result, filters)
 
-        sort_columns = []
-        for idx, a_sort in enumerate(sort):
-            if not a_sort.applied:
-                sort_columns.append(query.order_by[idx])
+        if sort:
+            sort_columns = []
+            for idx, a_sort in enumerate(sort):
+                if not a_sort.applied:
+                    sort_columns.append(query.order_by[idx])
 
-        result = sort_dataframe(result, sort_columns)
+            result = sort_dataframe(result, sort_columns)
 
         if limit is not None and len(result) > limit:
             result = result[:int(limit)]

--- a/mindsdb/integrations/libs/api_handler.py
+++ b/mindsdb/integrations/libs/api_handler.py
@@ -208,8 +208,8 @@ class APIResource(APITable):
         result = filter_dataframe(result, filters)
 
         sort_columns = []
-        for idx, _ in enumerate(sort):
-            if not sort.applied:
+        for idx, a_sort in enumerate(sort):
+            if not a_sort.applied:
                 sort_columns.append(query.order_by[idx])
 
         result = sort_dataframe(result, sort_columns)

--- a/mindsdb/integrations/libs/api_handler.py
+++ b/mindsdb/integrations/libs/api_handler.py
@@ -6,7 +6,7 @@ from mindsdb_sql_parser.ast import ASTNode, Select, Insert, Update, Delete, Star
 from mindsdb_sql_parser.ast.select.identifier import Identifier
 
 from mindsdb.integrations.utilities.sql_utils import (
-    extract_comparison_conditions, filter_dataframe,
+    extract_comparison_conditions, filter_dataframe, sort_dataframe,
     FilterCondition, FilterOperator, SortColumn
 )
 from mindsdb.integrations.libs.base import BaseHandler
@@ -206,6 +206,13 @@ class APIResource(APITable):
                 filters.append([cond.op.value, cond.column, cond.value])
 
         result = filter_dataframe(result, filters)
+
+        sort_columns = []
+        for idx, _ in enumerate(sort):
+            if not sort.applied:
+                sort_columns.append(query.order_by[idx])
+
+        result = sort_dataframe(result, sort_columns)
 
         if limit is not None and len(result) > limit:
             result = result[:int(limit)]

--- a/mindsdb/integrations/utilities/sql_utils.py
+++ b/mindsdb/integrations/utilities/sql_utils.py
@@ -67,6 +67,7 @@ class SortColumn:
     def __init__(self, column: str, ascending: bool = True):
         self.column = column
         self.ascending = ascending
+        self.applied = False
 
 
 def make_sql_session():


### PR DESCRIPTION
## Description

This PR adds a fallback sort mechanism for `APIResource` implementations to handle ORDER BY clauses (before LIMIT is executed).

Fixes https://linear.app/mindsdb/issue/BE-595/no-default-sort-mechanism-available-for-api-handlers

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.