### PR TITLE
Disable metrics decorator if `prometheus` not initialized

### DIFF
--- a/mindsdb/metrics/metrics.py
+++ b/mindsdb/metrics/metrics.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 import functools
 import time
+import os
 
 from prometheus_client import Histogram, Summary
 
@@ -28,6 +29,8 @@ def api_endpoint_metrics(method: str, uri: str):
     def decorator_metrics(endpoint_func):
         @functools.wraps(endpoint_func)
         def wrapper_metrics(*args, **kwargs):
+            if os.environ.get('PROMETHEUS_MULTIPROC_DIR', None) is None:
+                return endpoint_func(*args, **kwargs)
             time_before_query = time.perf_counter()
             try:
                 response = endpoint_func(*args, **kwargs)


### PR DESCRIPTION
## Description

If `prometheus` is not initialized, then it still requests many memory allocations on each quey.

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



