### PR TITLE
Reduce startup time and memory optimizations

### DIFF
--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -22,13 +22,9 @@ logger.debug("Starting MindsDB...")
 
 from mindsdb.__about__ import __version__ as mindsdb_version
 from mindsdb.utilities.config import config
-from mindsdb.api.http.start import start as start_http
-from mindsdb.api.mysql.start import start as start_mysql
-from mindsdb.api.mongo.start import start as start_mongo
-from mindsdb.api.postgres.start import start as start_postgres
-from mindsdb.interfaces.tasks.task_monitor import start as start_tasks
-from mindsdb.utilities.ml_task_queue.consumer import start as start_ml_task_queue
-from mindsdb.interfaces.jobs.scheduler import start as start_scheduler
+from mindsdb.utilities.starters import (
+    start_http, start_mysql, start_mongo, start_postgres, start_ml_task_queue, start_scheduler, start_tasks
+)
 from mindsdb.utilities.ps import is_pid_listen_port, get_child_pids
 from mindsdb.utilities.functions import get_versions_where_predictors_become_obsolete
 from mindsdb.interfaces.database.integrations import integration_controller

--- a/mindsdb/utilities/starters.py
+++ b/mindsdb/utilities/starters.py
@@ -1,0 +1,33 @@
+def start_http(*args, **kwargs):
+    from mindsdb.api.http.start import start
+    start(*args, **kwargs)
+
+
+def start_mysql(*args, **kwargs):
+    from mindsdb.api.mysql.start import start
+    start(*args, **kwargs)
+
+
+def start_mongo(*args, **kwargs):
+    from mindsdb.api.mongo.start import start
+    start(*args, **kwargs)
+
+
+def start_postgres(*args, **kwargs):
+    from mindsdb.api.postgres.start import start
+    start(*args, **kwargs)
+
+
+def start_tasks(*args, **kwargs):
+    from mindsdb.interfaces.tasks.task_monitor import start
+    start(*args, **kwargs)
+
+
+def start_ml_task_queue(*args, **kwargs):
+    from mindsdb.utilities.ml_task_queue.consumer import start
+    start(*args, **kwargs)
+
+
+def start_scheduler(*args, **kwargs):
+    from mindsdb.interfaces.jobs.scheduler import start
+    start(*args, **kwargs)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -20,7 +20,6 @@ appdirs >= 1.0.0
 mindsdb-sql-parser ~= 0.1.0
 pydantic ~= 2.7.0
 mindsdb-evaluator >= 0.0.7, < 0.1.0
-checksumdir >= 1.2.0
 duckdb == 0.9.1
 requests == 2.32.3
 pydateinfer==0.3.0


### PR DESCRIPTION
## Description

 - import `boto3` only if it is required by config. This saves memory.
 - replace 3d-part dependency `checksumdir` to buildin `filecmp`. We need only compare dirs, `filecmp` works perfectly for it (and much faster).
 - Indirect import of APIs startup functions. This saves decent amount of memory and also reduces the overall startup time significantly. Local tests shows startup time changes in average for APIs:
   - http: 12.4s->10.5s (-15%)
   - mysql: 9.1->6.5 (-29%)
   - mongodb: 9.0->6.5 (-28%)

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



