### PR TITLE
Prevent creating duplicated project names

### DIFF
--- a/mindsdb/api/executor/__init__.py
+++ b/mindsdb/api/executor/__init__.py
@@ -1,2 +1,1 @@
 
-from .sql_query.sql_query import SQLQuery, Column, ResultSet

--- a/mindsdb/api/executor/command_executor.py
+++ b/mindsdb/api/executor/command_executor.py
@@ -71,7 +71,8 @@ from mindsdb_sql_parser.ast.mindsdb import (
 import mindsdb.utilities.profiler as profiler
 
 from mindsdb.integrations.utilities.query_traversal import query_traversal
-from mindsdb.api.executor import Column, SQLQuery, ResultSet
+from mindsdb.api.executor.sql_query.result_set import Column, ResultSet
+from mindsdb.api.executor.sql_query import SQLQuery
 from mindsdb.api.executor.data_types.answer import ExecuteAnswer
 from mindsdb.api.mysql.mysql_proxy.libs.constants.mysql import (
     CHARSET_NUMBERS,

--- a/mindsdb/api/executor/data_types/answer.py
+++ b/mindsdb/api/executor/data_types/answer.py
@@ -1,5 +1,5 @@
 from typing import List
-from mindsdb.api.executor import ResultSet
+from mindsdb.api.executor.sql_query.result_set import ResultSet
 
 
 class ExecuteAnswer:

--- a/mindsdb/api/executor/datahub/datanodes/project_datanode.py
+++ b/mindsdb/api/executor/datahub/datanodes/project_datanode.py
@@ -14,7 +14,7 @@ from mindsdb_sql_parser.ast import (
 from mindsdb.utilities.exception import EntityNotExistsError
 from mindsdb.api.executor.datahub.datanodes.datanode import DataNode
 from mindsdb.api.executor.datahub.classes.tables_row import TablesRow
-from mindsdb.api.executor import SQLQuery
+from mindsdb.api.executor.sql_query import SQLQuery
 from mindsdb.api.executor.utilities.sql import query_df
 from mindsdb.interfaces.query_context.context_controller import query_context_controller
 

--- a/mindsdb/api/executor/sql_query/__init__.py
+++ b/mindsdb/api/executor/sql_query/__init__.py
@@ -1,0 +1,1 @@
+from .sql_query import SQLQuery

--- a/mindsdb/api/mysql/mysql_proxy/executor/mysql_executor.py
+++ b/mindsdb/api/mysql/mysql_proxy/executor/mysql_executor.py
@@ -2,7 +2,8 @@ from mindsdb_sql_parser import parse_sql
 from mindsdb.api.executor.planner import utils as planner_utils
 
 import mindsdb.utilities.profiler as profiler
-from mindsdb.api.executor import Column, SQLQuery
+from mindsdb.api.executor.sql_query.result_set import Column
+from mindsdb.api.executor.sql_query import SQLQuery
 from mindsdb.api.executor.command_executor import ExecuteCommands
 from mindsdb.api.mysql.mysql_proxy.utilities import ErSqlSyntaxError
 from mindsdb.utilities import log

--- a/mindsdb/api/postgres/postgres_proxy/executor/executor.py
+++ b/mindsdb/api/postgres/postgres_proxy/executor/executor.py
@@ -6,7 +6,8 @@ from mindsdb.api.executor.planner import utils as planner_utils
 from numpy import dtype as np_dtype
 from pandas.api import types as pd_types
 
-from mindsdb.api.executor import SQLQuery, Column
+from mindsdb.api.executor.sql_query import SQLQuery
+from mindsdb.api.executor.sql_query.result_set import Column
 from mindsdb.api.mysql.mysql_proxy.utilities.lightwood_dtype import dtype
 from mindsdb.api.executor.command_executor import ExecuteCommands
 from mindsdb.api.mysql.mysql_proxy.utilities import SqlApiException

--- a/mindsdb/integrations/libs/ml_handler_process/learn_process.py
+++ b/mindsdb/integrations/libs/ml_handler_process/learn_process.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm.attributes import flag_modified
 from mindsdb_sql_parser import parse_sql
 from mindsdb_sql_parser.ast import Identifier, Select, Star, NativeQuery
 
-from mindsdb.api.executor import SQLQuery
+from mindsdb.api.executor.sql_query import SQLQuery
 import mindsdb.utilities.profiler as profiler
 from mindsdb.utilities.functions import mark_process
 from mindsdb.utilities.config import Config

--- a/mindsdb/interfaces/chatbot/chatbot_controller.py
+++ b/mindsdb/interfaces/chatbot/chatbot_controller.py
@@ -4,6 +4,7 @@ from mindsdb.interfaces.agents.agents_controller import AgentsController
 from mindsdb.interfaces.chatbot.chatbot_task import ChatBotTask
 from mindsdb.interfaces.database.projects import ProjectController
 from mindsdb.interfaces.storage import db
+from mindsdb.interfaces.model.functions import get_project_records
 
 from mindsdb.utilities.context import context as ctx
 
@@ -128,16 +129,11 @@ class ChatBotController:
             all_bots (List[db.ChatBots]): List of database chatbot object
         '''
 
-        query = db.session.query(db.Project).filter_by(
-            company_id=ctx.company_id,
-            deleted_at=None
-        )
-        if project_name is not None:
-            query = query.filter_by(name=project_name)
-        project_names = {
-            i.id: i.name
-            for i in query
-        }
+        project_names = {}
+        for project in get_project_records():
+            if project_name is not None and project.name != project_name:
+                continue
+            project_names[project.id] = project.name
 
         query = db.session.query(
             db.ChatBots, db.Tasks

--- a/mindsdb/interfaces/database/projects.py
+++ b/mindsdb/interfaces/database/projects.py
@@ -34,6 +34,13 @@ class Project:
     def create(self, name: str):
         name = name.lower()
         with create_project_lock:
+            existing_record = db.Integration.query.filter(
+                sa.func.lower(db.Integration.name) == name,
+                db.Integration.company_id == ctx.company_id
+            ).first()
+            if existing_record is not None:
+                raise EntityExistsError('Database exists with this name ', name)
+
             existing_record = db.Project.query.filter(
                 (sa.func.lower(db.Project.name) == name)
                 & (db.Project.company_id == ctx.company_id)
@@ -41,13 +48,6 @@ class Project:
             ).first()
             if existing_record is not None:
                 raise EntityExistsError('Project already exists', name)
-
-            existing_record = db.Integration.query.filter(
-                sa.func.lower(db.Integration.name) == name,
-                db.Integration.company_id == ctx.company_id
-            ).first()
-            if existing_record is not None:
-                raise EntityExistsError('Database exists with this name ', name)
 
             record = db.Project(
                 name=name,

--- a/mindsdb/interfaces/database/projects.py
+++ b/mindsdb/interfaces/database/projects.py
@@ -19,19 +19,20 @@ from mindsdb.utilities.exception import EntityExistsError, EntityNotExistsError
 import mindsdb.utilities.profiler as profiler
 
 
-
 class Project:
     @staticmethod
     def from_record(db_record: db.Project):
         p = Project()
         p.record = db_record
         p.name = db_record.name
-        p.company_id = db_record.company_id
+        p.company_id = ctx.company_id
         p.id = db_record.id
         return p
 
     def create(self, name: str):
         name = name.lower()
+
+        company_id = ctx.company_id if ctx.company_id is not None else 0
 
         existing_record = db.Integration.query.filter(
             sa.func.lower(db.Integration.name) == name,
@@ -42,7 +43,7 @@ class Project:
 
         existing_record = db.Project.query.filter(
             (sa.func.lower(db.Project.name) == name)
-            & (db.Project.company_id == ctx.company_id)
+            & (db.Project.company_id == company_id)
             & (db.Project.deleted_at == sa.null())
         ).first()
         if existing_record is not None:
@@ -50,20 +51,17 @@ class Project:
 
         record = db.Project(
             name=name,
-            company_id=ctx.company_id
+            company_id=company_id
         )
 
         self.record = record
         self.name = name
-        self.company_id = ctx.company_id
+        self.company_id = company_id
 
         db.session.add(record)
         db.session.commit()
 
         self.id = record.id
-
-    def save(self):
-        db.session.commit()
 
     def delete(self):
         tables = self.get_tables()
@@ -363,8 +361,9 @@ class ProjectController:
         pass
 
     def get_list(self) -> List[Project]:
+        company_id = ctx.company_id if ctx.company_id is not None else 0
         records = db.Project.query.filter(
-            (db.Project.company_id == ctx.company_id)
+            (db.Project.company_id == company_id)
             & (db.Project.deleted_at == sa.null())
         ).order_by(db.Project.name)
 
@@ -374,7 +373,8 @@ class ProjectController:
         if id is not None and name is not None:
             raise ValueError("Both 'id' and 'name' is None")
 
-        q = db.Project.query.filter_by(company_id=ctx.company_id)
+        company_id = ctx.company_id if ctx.company_id is not None else 0
+        q = db.Project.query.filter_by(company_id=company_id)
 
         if id is not None:
             q = q.filter_by(id=id)

--- a/mindsdb/interfaces/database/projects.py
+++ b/mindsdb/interfaces/database/projects.py
@@ -19,8 +19,6 @@ from mindsdb.utilities.exception import EntityExistsError, EntityNotExistsError
 import mindsdb.utilities.profiler as profiler
 
 
-create_project_lock = Lock()
-
 
 class Project:
     @staticmethod
@@ -34,35 +32,35 @@ class Project:
 
     def create(self, name: str):
         name = name.lower()
-        with create_project_lock:
-            existing_record = db.Integration.query.filter(
-                sa.func.lower(db.Integration.name) == name,
-                db.Integration.company_id == ctx.company_id
-            ).first()
-            if existing_record is not None:
-                raise EntityExistsError('Database exists with this name ', name)
 
-            existing_record = db.Project.query.filter(
-                (sa.func.lower(db.Project.name) == name)
-                & (db.Project.company_id == ctx.company_id)
-                & (db.Project.deleted_at == sa.null())
-            ).first()
-            if existing_record is not None:
-                raise EntityExistsError('Project already exists', name)
+        existing_record = db.Integration.query.filter(
+            sa.func.lower(db.Integration.name) == name,
+            db.Integration.company_id == ctx.company_id
+        ).first()
+        if existing_record is not None:
+            raise EntityExistsError('Database exists with this name ', name)
 
-            record = db.Project(
-                name=name,
-                company_id=ctx.company_id
-            )
+        existing_record = db.Project.query.filter(
+            (sa.func.lower(db.Project.name) == name)
+            & (db.Project.company_id == ctx.company_id)
+            & (db.Project.deleted_at == sa.null())
+        ).first()
+        if existing_record is not None:
+            raise EntityExistsError('Project already exists', name)
 
-            self.record = record
-            self.name = name
-            self.company_id = ctx.company_id
+        record = db.Project(
+            name=name,
+            company_id=ctx.company_id
+        )
 
-            db.session.add(record)
-            db.session.commit()
+        self.record = record
+        self.name = name
+        self.company_id = ctx.company_id
 
-            self.id = record.id
+        db.session.add(record)
+        db.session.commit()
+
+        self.id = record.id
 
     def save(self):
         db.session.commit()

--- a/mindsdb/interfaces/database/projects.py
+++ b/mindsdb/interfaces/database/projects.py
@@ -2,7 +2,6 @@ import datetime
 from copy import deepcopy
 from typing import List, Optional
 from collections import OrderedDict
-from threading import Lock
 
 import sqlalchemy as sa
 import numpy as np

--- a/mindsdb/interfaces/database/projects.py
+++ b/mindsdb/interfaces/database/projects.py
@@ -21,6 +21,7 @@ import mindsdb.utilities.profiler as profiler
 
 create_project_lock = Lock()
 
+
 class Project:
     @staticmethod
     def from_record(db_record: db.Project):

--- a/mindsdb/interfaces/model/functions.py
+++ b/mindsdb/interfaces/model/functions.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 
 from sqlalchemy import null, func
 
@@ -41,9 +41,7 @@ def get_integration_record(name: str) -> db.Integration:
 
 @profiler.profile()
 def get_project_record(name: str) -> db.Project:
-    company_id = ctx.company_id
-    if company_id is None:
-        company_id = null()
+    company_id = ctx.company_id if ctx.company_id is not None else 0
 
     project_record = (
         db.session.query(db.Project)
@@ -54,6 +52,19 @@ def get_project_record(name: str) -> db.Project:
         ).first()
     )
     return project_record
+
+
+@profiler.profile()
+def get_project_records() -> List[db.Project]:
+    company_id = ctx.company_id if ctx.company_id is not None else 0
+
+    return (
+        db.session.query(db.Project)
+        .filter(
+            (db.Project.company_id == company_id)
+            & (db.Project.deleted_at == null())
+        ).all()
+    )
 
 
 @profiler.profile()

--- a/mindsdb/interfaces/model/model_controller.py
+++ b/mindsdb/interfaces/model/model_controller.py
@@ -14,7 +14,8 @@ import mindsdb.interfaces.storage.db as db
 from mindsdb.utilities.config import Config
 from mindsdb.interfaces.model.functions import (
     get_model_record,
-    get_model_records
+    get_model_records,
+    get_project_record
 )
 from mindsdb.interfaces.storage.json import get_json_storage
 from mindsdb.interfaces.storage.model_fs import ModelStorage
@@ -151,11 +152,7 @@ class ModelController():
     def delete_model(self, model_name: str, project_name: str = 'mindsdb', version=None):
         from mindsdb.interfaces.database.database import DatabaseController
 
-        project_record = db.Project.query.filter(
-            (func.lower(db.Project.name) == func.lower(project_name))
-            & (db.Project.company_id == ctx.company_id)
-            & (db.Project.deleted_at == null())
-        ).first()
+        project_record = get_project_record(func.lower(project_name))
         if project_record is None:
             raise Exception(f"Project '{project_name}' does not exists")
 

--- a/mindsdb/interfaces/model/model_controller.py
+++ b/mindsdb/interfaces/model/model_controller.py
@@ -7,7 +7,7 @@ from multiprocessing.pool import ThreadPool
 import pandas as pd
 from dateutil.parser import parse as parse_datetime
 
-from sqlalchemy import func, null
+from sqlalchemy import func
 import numpy as np
 
 import mindsdb.interfaces.storage.db as db

--- a/mindsdb/interfaces/storage/db.py
+++ b/mindsdb/interfaces/storage/db.py
@@ -212,7 +212,7 @@ class Project(Base):
     )
     deleted_at = Column(DateTime)
     name = Column(String, nullable=False)
-    company_id = Column(Integer)
+    company_id = Column(Integer, default=0)
     __table_args__ = (
         UniqueConstraint("name", "company_id", name="unique_project_name_company_id"),
     )

--- a/mindsdb/migrations/versions/2025-01-15_c06c35f7e8e1_project_company.py
+++ b/mindsdb/migrations/versions/2025-01-15_c06c35f7e8e1_project_company.py
@@ -21,6 +21,7 @@ depends_on = None
 
 logger = log.getLogger(__name__)
 
+
 def upgrade():
 
     """

--- a/mindsdb/migrations/versions/2025-01-15_c06c35f7e8e1_project_company.py
+++ b/mindsdb/migrations/versions/2025-01-15_c06c35f7e8e1_project_company.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 from alembic import op
 import sqlalchemy as sa
 import mindsdb.interfaces.storage.db  # noqa
+from mindsdb.utilities import log
 
 # revision identifiers, used by Alembic.
 revision = 'c06c35f7e8e1'
@@ -17,6 +18,8 @@ down_revision = 'f6dc924079fa'
 branch_labels = None
 depends_on = None
 
+
+logger = log.getLogger(__name__)
 
 def upgrade():
 
@@ -59,7 +62,7 @@ def upgrade():
                 .where(table.c.id == id)
                 .values({'name': new_name})
             )
-            print(f'Found duplicated project name: {name}, renamed to: {new_name}')
+            logger.warning(f'Found duplicated project name: {name}, renamed to: {new_name}')
 
     op.execute(
         table

--- a/mindsdb/migrations/versions/2025-01-15_c06c35f7e8e1_project_company.py
+++ b/mindsdb/migrations/versions/2025-01-15_c06c35f7e8e1_project_company.py
@@ -1,0 +1,84 @@
+"""project-company
+
+Revision ID: c06c35f7e8e1
+Revises: f6dc924079fa
+Create Date: 2025-01-15 14:14:29.295834
+
+"""
+from collections import defaultdict
+
+from alembic import op
+import sqlalchemy as sa
+import mindsdb.interfaces.storage.db  # noqa
+
+# revision identifiers, used by Alembic.
+revision = 'c06c35f7e8e1'
+down_revision = 'f6dc924079fa'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+
+    """
+    convert company_id from null to 0 to make constrain works
+    duplicated names are renamed
+    """
+
+    conn = op.get_bind()
+    table = sa.Table(
+        'project',
+        sa.MetaData(),
+        sa.Column('id', sa.Integer()),
+        sa.Column('name', sa.String()),
+        sa.Column('company_id', sa.Integer()),
+    )
+
+    data = conn.execute(
+        table
+        .select()
+        .where(table.c.company_id == sa.null())
+    ).fetchall()
+
+    names = defaultdict(list)
+    for id, name, _ in data:
+        names[name].append(id)
+
+    # get duplicated
+    for name, ids in names.items():
+        if len(ids) == 1:
+            continue
+
+        # rename all except first
+        for id in ids[1:]:
+            new_name = f'{name}__{id}'
+
+            op.execute(
+                table
+                .update()
+                .where(table.c.id == id)
+                .values({'name': new_name})
+            )
+            print(f'Found duplicated project name: {name}, renamed to: {new_name}')
+
+    op.execute(
+        table
+        .update()
+        .where(table.c.company_id == sa.null())
+        .values({'company_id': 0})
+    )
+
+
+def downgrade():
+    table = sa.Table(
+        'project',
+        sa.MetaData(),
+        sa.Column('company_id', sa.Integer())
+    )
+
+    op.execute(
+        table
+        .update()
+        .where(table.c.company_id == 0)
+        .values({'company_id': sa.null()})
+    )

--- a/tests/unit/executor/test_mongodb_server.py
+++ b/tests/unit/executor/test_mongodb_server.py
@@ -10,7 +10,7 @@ from pymongo import MongoClient
 from mindsdb_sql_parser import parse_sql
 
 from mindsdb.api.executor.data_types.answer import ExecuteAnswer
-from mindsdb.api.executor import Column, ResultSet
+from mindsdb.api.executor.sql_query.result_set import Column, ResultSet
 
 # How to run:
 #  env PYTHONPATH=./ pytest tests/unit/test_mongodb_server.py


### PR DESCRIPTION
## Description

Fixes:
- In local installation company_id=0 (instead of null) is used for projects table  
  -  With null value constrain which checks project names is not working
- Side-update: don't import SqlQuery during executor's imports

Fixes https://linear.app/mindsdb/issue/BE-569/duplicate-project-names

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



