### PR TITLE
Add Retries & Fallback to SQL Retriever

### DIFF
--- a/mindsdb/integrations/utilities/rag/pipelines/rag.py
+++ b/mindsdb/integrations/utilities/rag/pipelines/rag.py
@@ -227,12 +227,23 @@ class LangChainRAGPipeline:
             'provider': retriever_config.llm_config.provider,
             **retriever_config.llm_config.params
         })
+        vector_store_operator = VectorStoreOperator(
+            vector_store=config.vector_store,
+            documents=config.documents,
+            embedding_model=config.embedding_model,
+            vector_store_config=config.vector_store_config
+        )
+        vector_store_retriever = vector_store_operator.vector_store.as_retriever()
+        vector_store_retriever = cls._apply_search_kwargs(vector_store_retriever, config.search_kwargs, config.search_type)
         retriever = SQLRetriever(
+            fallback_retriever=vector_store_retriever,
             vector_store_handler=knowledge_base_table.get_vector_db(),
             metadata_schemas=retriever_config.metadata_schemas,
             examples=retriever_config.examples,
             embeddings_model=embeddings,
             rewrite_prompt_template=retriever_config.rewrite_prompt_template,
+            retry_prompt_template=retriever_config.query_retry_template,
+            num_retries=retriever_config.num_retries,
             sql_prompt_template=retriever_config.sql_prompt_template,
             query_checker_template=retriever_config.query_checker_template,
             embeddings_table=knowledge_base_table._kb.vector_database_table,

--- a/tests/unit/test_sql_retriever.py
+++ b/tests/unit/test_sql_retriever.py
@@ -1,16 +1,18 @@
 from unittest.mock import MagicMock
 
 import pandas as pd
+from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.outputs.generation import Generation
 from langchain_core.outputs.llm_result import LLMResult
+from langchain_core.retrievers import BaseRetriever
 from langchain_openai.chat_models.base import ChatOpenAI
 
 from mindsdb.api.executor.data_types.response_type import RESPONSE_TYPE
 from mindsdb.integrations.libs.response import HandlerResponse
 from mindsdb.integrations.libs.vectordatabase_handler import DistanceFunction, VectorStoreHandler
 from mindsdb.integrations.utilities.rag.retrievers.sql_retriever import SQLRetriever
-from mindsdb.integrations.utilities.rag.settings import DEFAULT_QUERY_CHECKER_PROMPT_TEMPLATE, DEFAULT_SEMANTIC_PROMPT_TEMPLATE, DEFAULT_SQL_PROMPT_TEMPLATE, LLMExample, ColumnSchema, MetadataSchema, SearchKwargs
+from mindsdb.integrations.utilities.rag.settings import DEFAULT_QUERY_CHECKER_PROMPT_TEMPLATE, DEFAULT_QUERY_RETRY_PROMPT_TEMPLATE, DEFAULT_SEMANTIC_PROMPT_TEMPLATE, DEFAULT_SQL_PROMPT_TEMPLATE, LLMExample, ColumnSchema, MetadataSchema, SearchKwargs
 
 
 class TestSQLRetriever:
@@ -91,12 +93,16 @@ WHERE p."PlantName" = 'Beaver Valley'
 ORDER BY v.embeddings <-> '{embeddings}' LIMIT 5;
 '''
         )
+        fallback_retriever = MagicMock(spec=BaseRetriever, wraps=BaseRetriever)
         sql_retriever = SQLRetriever(
+            fallback_retriever=fallback_retriever,
             vector_store_handler=vector_db_mock,
             metadata_schemas=all_schemas,
             examples=[example],
             embeddings_model=embeddings_mock,
             rewrite_prompt_template=DEFAULT_SEMANTIC_PROMPT_TEMPLATE,
+            retry_prompt_template=DEFAULT_QUERY_RETRY_PROMPT_TEMPLATE,
+            num_retries=2,
             sql_prompt_template=DEFAULT_SQL_PROMPT_TEMPLATE,
             query_checker_template=DEFAULT_QUERY_CHECKER_PROMPT_TEMPLATE,
             embeddings_table='test_embeddings_table',
@@ -107,6 +113,239 @@ ORDER BY v.embeddings <-> '{embeddings}' LIMIT 5;
         )
 
         docs = sql_retriever.invoke('What are Beaver Valley plant documents for nuclear fuel waste?')
+        # Make sure right doc was retrieved.
+        assert len(docs) == 1
+        assert docs[0].page_content == 'Chunk1'
+        assert docs[0].metadata == {'key1': 'value1'}
+
+    def test_retries(self):
+        llm = MagicMock(spec=ChatOpenAI, wraps=ChatOpenAI)
+        llm_result = MagicMock(spec=LLMResult, wraps=LLMResult)
+        llm_result.generations = [
+            [
+                Generation(
+                    text='''SELECT sd.*, v.*
+FROM test_source_table sd
+JOIN document_unit du ON sd."Id" = du."DocumentId"
+JOIN unit u ON du."UnitKey" = u."UnitKey"
+JOIN plant p ON u."PlantKey" = p."PlantKey"
+JOIN test_embeddings_table v ON (v."metadata"->>'original_row_id')::int = sd."Id"
+WHERE p."PlantName" = 'Beaver Valley'
+ORDER BY v.embeddings <->'''
+                )
+            ]
+        ]
+        llm.generate_prompt.return_value = llm_result
+        vector_db_mock = MagicMock(spec=VectorStoreHandler, wraps=VectorStoreHandler)
+        series = pd.Series(
+            [0, 'Chunk1', '[1.0, 2.0, 3.0]', {'key1': 'value1'}, 0, 1],
+            index=['id', 'content', 'embeddings', 'metadata', 'Id', 'Type']
+        )
+        df = pd.DataFrame([series])
+        vector_db_mock.native_query.side_effect = [
+            HandlerResponse(
+                RESPONSE_TYPE.ERROR,
+                error_message='Something went wrong I am in absolute shambles'
+            ),
+            HandlerResponse(
+                RESPONSE_TYPE.ERROR,
+                error_message='Something went wrong I am in absolute shambles'
+            ),
+            HandlerResponse(
+                RESPONSE_TYPE.TABLE,
+                data_frame=df
+            )
+        ]
+        embeddings_mock = MagicMock(spec=Embeddings, wraps=Embeddings)
+        embeddings_mock.embed_query.return_value = list(range(768))
+
+        source_schema = MetadataSchema(
+            table='test_source_table',
+            description='Contains source documents',
+            columns=[
+                ColumnSchema(name='Id', type='int', description='Unique ID as primary key of doc'),
+                ColumnSchema(name='Type', type='int', description='Document Type', values={1: 'Unknown', 2: 'Site Audit'})
+            ]
+        )
+        unit_schema = MetadataSchema(
+            table='unit',
+            description='Contains information about specific units of power plants. Several units can be part of a single plant.',
+            columns=[
+                ColumnSchema(name='UnitKey', type='int', description='Unique ID of the unit'),
+                ColumnSchema(name='PlantKey', type='int', description='ID of the plant the unit belongs to')
+            ]
+        )
+        plant_schema = MetadataSchema(
+            table='plant',
+            description='Contains information about specific power plants',
+            columns=[
+                ColumnSchema(name='PlantKey', type='int', description='The unique ID of the plant'),
+                ColumnSchema(name='PlantName', type='str', description='The name of the plant')
+            ]
+        )
+        document_unit_schema = MetadataSchema(
+            table='document_unit',
+            description='Links documents to the power plant they are relevant to',
+            columns=[
+                ColumnSchema(name='DocumentId', type='int', description='The ID of the document associated with the unit'),
+                ColumnSchema(name='UnitKey', type='int', description='The ID of the unit the documnet is associated with')
+            ]
+        )
+        all_schemas = [source_schema, unit_schema, plant_schema, document_unit_schema]
+        example = LLMExample(
+            input='Get me all documents related to the Beaver Valley plant',
+            output='''
+SELECT sd.*, v.*
+FROM test_source_table sd
+JOIN document_unit du ON sd."Id" = du."DocumentId"
+JOIN unit u ON du."UnitKey" = u."UnitKey"
+JOIN plant p ON u."PlantKey" = p."PlantKey"
+JOIN test_embeddings_table v ON (v."metadata"->>'original_row_id')::int = sd."Id"
+WHERE p."PlantName" = 'Beaver Valley'
+ORDER BY v.embeddings <-> '{embeddings}' LIMIT 5;
+'''
+        )
+        fallback_retriever = MagicMock(spec=BaseRetriever, wraps=BaseRetriever)
+        sql_retriever = SQLRetriever(
+            fallback_retriever=fallback_retriever,
+            vector_store_handler=vector_db_mock,
+            metadata_schemas=all_schemas,
+            examples=[example],
+            embeddings_model=embeddings_mock,
+            rewrite_prompt_template=DEFAULT_SEMANTIC_PROMPT_TEMPLATE,
+            retry_prompt_template=DEFAULT_QUERY_RETRY_PROMPT_TEMPLATE,
+            num_retries=3,
+            sql_prompt_template=DEFAULT_SQL_PROMPT_TEMPLATE,
+            query_checker_template=DEFAULT_QUERY_CHECKER_PROMPT_TEMPLATE,
+            embeddings_table='test_embeddings_table',
+            source_table='test_source_table',
+            distance_function=DistanceFunction.SQUARED_EUCLIDEAN_DISTANCE,
+            search_kwargs=SearchKwargs(k=5),
+            llm=llm
+        )
+
+        docs = sql_retriever.invoke('What are Beaver Valley plant documents for nuclear fuel waste?')
+        # Make sure we retried.
+        assert len(vector_db_mock.native_query.mock_calls) == 3
+        # Make sure right doc was retrieved.
+        assert len(docs) == 1
+        assert docs[0].page_content == 'Chunk1'
+        assert docs[0].metadata == {'key1': 'value1'}
+
+    def test_fallback(self):
+        llm = MagicMock(spec=ChatOpenAI, wraps=ChatOpenAI)
+        llm_result = MagicMock(spec=LLMResult, wraps=LLMResult)
+        llm_result.generations = [
+            [
+                Generation(
+                    text='''SELECT sd.*, v.*
+FROM test_source_table sd
+JOIN document_unit du ON sd."Id" = du."DocumentId"
+JOIN unit u ON du."UnitKey" = u."UnitKey"
+JOIN plant p ON u."PlantKey" = p."PlantKey"
+JOIN test_embeddings_table v ON (v."metadata"->>'original_row_id')::int = sd."Id"
+WHERE p."PlantName" = 'Beaver Valley'
+ORDER BY v.embeddings <->'''
+                )
+            ]
+        ]
+        llm.generate_prompt.return_value = llm_result
+        vector_db_mock = MagicMock(spec=VectorStoreHandler, wraps=VectorStoreHandler)
+        vector_db_mock.native_query.side_effect = [
+            HandlerResponse(
+                RESPONSE_TYPE.ERROR,
+                error_message='Something went wrong I am in absolute shambles'
+            ),
+            HandlerResponse(
+                RESPONSE_TYPE.ERROR,
+                error_message='Something went wrong I am in absolute shambles'
+            ),
+            HandlerResponse(
+                RESPONSE_TYPE.ERROR,
+                error_message='Something went wrong I am in absolute shambles'
+            ),
+        ]
+        embeddings_mock = MagicMock(spec=Embeddings, wraps=Embeddings)
+        embeddings_mock.embed_query.return_value = list(range(768))
+
+        source_schema = MetadataSchema(
+            table='test_source_table',
+            description='Contains source documents',
+            columns=[
+                ColumnSchema(name='Id', type='int', description='Unique ID as primary key of doc'),
+                ColumnSchema(name='Type', type='int', description='Document Type', values={1: 'Unknown', 2: 'Site Audit'})
+            ]
+        )
+        unit_schema = MetadataSchema(
+            table='unit',
+            description='Contains information about specific units of power plants. Several units can be part of a single plant.',
+            columns=[
+                ColumnSchema(name='UnitKey', type='int', description='Unique ID of the unit'),
+                ColumnSchema(name='PlantKey', type='int', description='ID of the plant the unit belongs to')
+            ]
+        )
+        plant_schema = MetadataSchema(
+            table='plant',
+            description='Contains information about specific power plants',
+            columns=[
+                ColumnSchema(name='PlantKey', type='int', description='The unique ID of the plant'),
+                ColumnSchema(name='PlantName', type='str', description='The name of the plant')
+            ]
+        )
+        document_unit_schema = MetadataSchema(
+            table='document_unit',
+            description='Links documents to the power plant they are relevant to',
+            columns=[
+                ColumnSchema(name='DocumentId', type='int', description='The ID of the document associated with the unit'),
+                ColumnSchema(name='UnitKey', type='int', description='The ID of the unit the documnet is associated with')
+            ]
+        )
+        all_schemas = [source_schema, unit_schema, plant_schema, document_unit_schema]
+        example = LLMExample(
+            input='Get me all documents related to the Beaver Valley plant',
+            output='''
+SELECT sd.*, v.*
+FROM test_source_table sd
+JOIN document_unit du ON sd."Id" = du."DocumentId"
+JOIN unit u ON du."UnitKey" = u."UnitKey"
+JOIN plant p ON u."PlantKey" = p."PlantKey"
+JOIN test_embeddings_table v ON (v."metadata"->>'original_row_id')::int = sd."Id"
+WHERE p."PlantName" = 'Beaver Valley'
+ORDER BY v.embeddings <-> '{embeddings}' LIMIT 5;
+'''
+        )
+        fallback_retriever = MagicMock(spec=BaseRetriever, wraps=BaseRetriever)
+        fallback_retriever._get_relevant_documents.return_value = [
+            Document(
+                page_content='Chunk1',
+                metadata={
+                    'key1': 'value1'
+                }
+            )
+        ]
+        sql_retriever = SQLRetriever(
+            fallback_retriever=fallback_retriever,
+            vector_store_handler=vector_db_mock,
+            metadata_schemas=all_schemas,
+            examples=[example],
+            embeddings_model=embeddings_mock,
+            rewrite_prompt_template=DEFAULT_SEMANTIC_PROMPT_TEMPLATE,
+            retry_prompt_template=DEFAULT_QUERY_RETRY_PROMPT_TEMPLATE,
+            num_retries=2,
+            sql_prompt_template=DEFAULT_SQL_PROMPT_TEMPLATE,
+            query_checker_template=DEFAULT_QUERY_CHECKER_PROMPT_TEMPLATE,
+            embeddings_table='test_embeddings_table',
+            source_table='test_source_table',
+            distance_function=DistanceFunction.SQUARED_EUCLIDEAN_DISTANCE,
+            search_kwargs=SearchKwargs(k=5),
+            llm=llm
+        )
+
+        docs = sql_retriever.invoke('What are Beaver Valley plant documents for nuclear fuel waste?')
+        # Make sure we retried.
+        assert len(vector_db_mock.native_query.mock_calls) == 3
+        # Make sure we falled back.
+        assert len(fallback_retriever._get_relevant_documents.mock_calls) == 1
         # Make sure right doc was retrieved.
         assert len(docs) == 1
         assert docs[0].page_content == 'Chunk1'


### PR DESCRIPTION
## Description

LLMs will not always generate correct SQL queries to be used with `pgvector` for hybrid search. In this case, we should try to correct the query `n` times, and then fallback to our default retriever if executing the corrected queries still return errors.

This way, worst case, we just use our default retriever without metadata instead of returning an error.

Related to [ML-240](https://linear.app/mindsdb/issue/ML-240/turn-on-text-to-sql-hybrid-search-cw)

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [x]   Test Location: `./tests/unit/test_sql_retriever.py`
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



