### PR TITLE
Added Reserved Keywords to SQLAlchemy Renderer

### DIFF
--- a/mindsdb/utilities/render/sqlalchemy_render.py
+++ b/mindsdb/utilities/render/sqlalchemy_render.py
@@ -24,6 +24,9 @@ for type_name in sa_type_names:
     types_map[type_name.upper()] = getattr(sa.types, type_name)
 types_map['BOOL'] = types_map['BOOLEAN']
 
+# TODO: Are there any other reserved keywords?
+RESERVED_KEYWORDS = {"COLLATION"}
+
 
 class RenderError(Exception):
     ...
@@ -100,6 +103,9 @@ class SqlalchemyRender:
                     part_lower = str(sa.column(i.lower()).compile(dialect=self.dialect))
                     if part.lower() != part_lower:
                         part = i
+
+            if part in RESERVED_KEYWORDS:
+                part = self.dialect.identifier_preparer.quote(part)
 
             parts2.append(part)
 

--- a/mindsdb/utilities/render/sqlalchemy_render.py
+++ b/mindsdb/utilities/render/sqlalchemy_render.py
@@ -25,7 +25,9 @@ for type_name in sa_type_names:
 types_map['BOOL'] = types_map['BOOLEAN']
 
 # TODO: Are there any other reserved keywords?
-RESERVED_KEYWORDS = {"COLLATION"}
+RESERVED_KEYWORDS = {
+    "mysql": {"COLLATION"}
+}
 
 
 class RenderError(Exception):
@@ -104,7 +106,7 @@ class SqlalchemyRender:
                     if part.lower() != part_lower:
                         part = i
 
-            if part in RESERVED_KEYWORDS:
+            if part in RESERVED_KEYWORDS.get(self.dialect.name, {}):
                 part = self.dialect.identifier_preparer.quote(part)
 
             parts2.append(part)


### PR DESCRIPTION
## Description

This PR checks for reserved keywords when running the SQLAlchemyRednderer. This fixes the integration tests that have been failing for a while now.

Fixes https://linear.app/mindsdb/issue/BE-607/investigate-and-fix-failing-integration-tests

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.