### PR TITLE
Use Fallback Retriever if SQL Retriever Doesn't Retrieve Documents

### DIFF
--- a/mindsdb/integrations/utilities/rag/retrievers/sql_retriever.py
+++ b/mindsdb/integrations/utilities/rag/retrievers/sql_retriever.py
@@ -169,7 +169,7 @@ Output:
             logger.info(f'SQL Retriever query {checked_sql_query} failed with error {error_msg}')
             if num_retries >= self.num_retries:
                 logger.info('Using fallback retriever in SQL retriever.')
-                return self.fallback_retriever._get_relevant_documents(retrieval_query, run_manager)
+                return self.fallback_retriever._get_relevant_documents(retrieval_query)
             query_to_retry = self._prepare_retry_query(checked_sql_query, error_msg, run_manager)
             query_to_retry_with_embeddings = query_to_retry.format(embeddings=str(embedded_query))
             # Handle LLM output that has the ```sql delimiter possibly.
@@ -185,4 +185,8 @@ Output:
                 document_row.get('content', ''),
                 metadata=document_row.get('metadata', {})
             ))
-        return retrieved_documents
+        if retrieved_documents:
+            return retrieved_documents
+        # If the SQL query constructed did not return any documents, fallback.
+        logger.info('No documents returned from SQL retriever. using fallback retriever.')
+        return self.fallback_retriever._get_relevant_documents(retrieval_query)


### PR DESCRIPTION
## Description

If SQL retriever constructs a query that returns no documents, we should fallback to our base retriever.

Fixes ML-240

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



