### PR TITLE
Fixed Use of Triggers with the Slack Integration

### DIFF
--- a/docs/mindsdb_sql/sql/create/trigger.mdx
+++ b/docs/mindsdb_sql/sql/create/trigger.mdx
@@ -106,7 +106,7 @@ ON mindsdb_slack.messages
         SELECT 'slack-bot-channel-id' AS channel_id, answer AS text
         FROM chatbot_model m
         JOIN TABLE_DELTA s
-        WHERE  s.user != 'U07J30KPAUF'
+        WHERE  s.user != 'U07J30KPAUF' AND s.channel_id = 'slack-bot-channel-id'
 );
 ```
 

--- a/mindsdb/integrations/handlers/slack_handler/slack_handler.py
+++ b/mindsdb/integrations/handlers/slack_handler/slack_handler.py
@@ -264,7 +264,7 @@ class SlackHandler(APIChatHandler):
         user_info = web_connection.auth_test().data
         return user_info['bot_id']
 
-    def subscribe(self, stop_event: threading.Event, callback: Callable, **kwargs: Any) -> None:
+    def subscribe(self, stop_event: threading.Event, callback: Callable, table_name: Text, **kwargs: Any) -> None:
         """
         Subscribes to the Slack API using the Socket Mode for real-time responses to messages.
 
@@ -274,6 +274,9 @@ class SlackHandler(APIChatHandler):
             table_name (Text): The name of the table to subscribe to.
             kwargs: Arbitrary keyword arguments.
         """
+        if table_name not in ['messages', 'threads']:
+            raise RuntimeError(f'Table {table_name} is not supported for subscription.')
+
         self._socket_connection = SocketModeClient(
             # This app-level token will be used only for establishing a connection.
             app_token=self.connection_data['app_token'],  # xapp-A111-222-xyz


### PR DESCRIPTION
## Description

This PR fixes the use of triggers with the Slack integration by re-introducing the `table_name` parameter to the `subscribe()` function of the handler.

Fixes https://linear.app/mindsdb/issue/BE-609/fix-execution-of-slack-triggers

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added - N/A
