### PR TITLE
Added Support for Defining APIs to Start via the Environment Variable MINDSDB_APIS

### DIFF
--- a/docker/mindsdb.Dockerfile
+++ b/docker/mindsdb.Dockerfile
@@ -10,7 +10,7 @@ ARG EXTRAS
 COPY . .
 # Find every FILE that is not a requirements file and delete it
 RUN find ./ -type f -not -name "requirements*.txt" -print | xargs rm -f \
-    # Find every empty directory and delete it
+# Find every empty directory and delete it
     && find ./ -type d -empty -delete
 # Copy setup.py and everything else used by setup.py
 COPY setup.py default_handlers.txt README.md ./
@@ -92,7 +92,7 @@ RUN --mount=target=/var/lib/apt,type=cache,sharing=locked \
 
 # Install dev requirements and install 'mindsdb' as an editable package
 RUN --mount=type=cache,target=/root/.cache uv pip install -r requirements/requirements-dev.txt \
-    && uv pip install --no-deps -e "."
+                                        && uv pip install --no-deps -e "."
 
 COPY docker/mindsdb_config.release.json /root/mindsdb_config.json
 
@@ -142,4 +142,4 @@ EXPOSE 47334/tcp
 EXPOSE 47335/tcp
 EXPOSE 47336/tcp
 
-ENTRYPOINT [ "bash", "-c", "python -Im mindsdb --config=/root/mindsdb_config.json" ]
+ENTRYPOINT [ "bash", "-c", "python -Im mindsdb --config=/root/mindsdb_config.json --api=http" ]

--- a/docker/mindsdb.Dockerfile
+++ b/docker/mindsdb.Dockerfile
@@ -10,7 +10,7 @@ ARG EXTRAS
 COPY . .
 # Find every FILE that is not a requirements file and delete it
 RUN find ./ -type f -not -name "requirements*.txt" -print | xargs rm -f \
-# Find every empty directory and delete it
+    # Find every empty directory and delete it
     && find ./ -type d -empty -delete
 # Copy setup.py and everything else used by setup.py
 COPY setup.py default_handlers.txt README.md ./
@@ -92,7 +92,7 @@ RUN --mount=target=/var/lib/apt,type=cache,sharing=locked \
 
 # Install dev requirements and install 'mindsdb' as an editable package
 RUN --mount=type=cache,target=/root/.cache uv pip install -r requirements/requirements-dev.txt \
-                                        && uv pip install --no-deps -e "."
+    && uv pip install --no-deps -e "."
 
 COPY docker/mindsdb_config.release.json /root/mindsdb_config.json
 
@@ -142,4 +142,4 @@ EXPOSE 47334/tcp
 EXPOSE 47335/tcp
 EXPOSE 47336/tcp
 
-ENTRYPOINT [ "bash", "-c", "python -Im mindsdb --config=/root/mindsdb_config.json --api=http" ]
+ENTRYPOINT [ "bash", "-c", "python -Im mindsdb --config=/root/mindsdb_config.json" ]

--- a/docs/setup/environment-vars.mdx
+++ b/docs/setup/environment-vars.mdx
@@ -47,6 +47,16 @@ default storage option and use different database by adding the new connection s
 export MINDSDB_DB_CON='postgresql://user:secret@localhost'
 ```
 
+## MindsDB APIs
+
+By default, MindsDB starts the http and mysql APIs. To define which APIs you want to start, you can use the `MINDSDB_APIS` environment variable.
+
+#### Example
+
+```bash
+export MINDSDB_APIS='http,mysql,postgres,mongodb'
+```
+
 ## MindsDB Server
 
 By default for the HTTP API, MindsDB uses [Waitress](https://pypi.org/project/waitress/) which is a pure-Python WSGI server. There is an option to change that 

--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -308,7 +308,7 @@ if __name__ == '__main__':
     if apis is None:  # If "--api" option is not specified, start the default APIs
         api_arr = [TrunkProcessEnum.HTTP, TrunkProcessEnum.MYSQL]
     elif apis == "":  # If "--api=" (blank) is specified, don't start any APIs
-        aapispi_arr = []
+        api_arr = []
     else:  # The user has provided a list of APIs to start
         api_arr = [TrunkProcessEnum(name) for name in apis.split(',')]
 

--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -303,12 +303,14 @@ if __name__ == '__main__':
         except Exception as e:
             logger.error(f"Error! Something went wrong during DB migrations: {e}")
 
-    if config.cmd_args.api is None:  # If "--api" option is not specified, start the default APIs
+    apis = os.getenv('MINDSDB_APIS') or config.cmd_args.api
+
+    if apis is None:  # If "--api" option is not specified, start the default APIs
         api_arr = [TrunkProcessEnum.HTTP, TrunkProcessEnum.MYSQL]
-    elif config.cmd_args.api == "":  # If "--api=" (blank) is specified, don't start any APIs
-        api_arr = []
+    elif apis == "":  # If "--api=" (blank) is specified, don't start any APIs
+        aapispi_arr = []
     else:  # The user has provided a list of APIs to start
-        api_arr = [TrunkProcessEnum(name) for name in config.cmd_args.api.split(',')]
+        api_arr = [TrunkProcessEnum(name) for name in apis.split(',')]
 
     if config.cmd_args.install_handlers is not None:
         handlers_list = [s.strip() for s in config.cmd_args.install_handlers.split(",")]


### PR DESCRIPTION
## Description

This PR allows the MindsDB APIs to be started to be defined via the environment variable `MINDSDB_APIS`. This has been added mainly to support Docker users.

The following command can be run to define the APIs to be started when using Docker:
`docker run -p 47334:47334 -p 47335:47335 --name mindsdb_container -e MINDSDB_APIS='http,mysql,mongodb' mindsdb/mindsdb`

This also updates the entrypoint to our Docker image in order to start both the HTTP and MySQL APIs.

Fixes https://linear.app/mindsdb/issue/BE-605/[docker]-define-which-apis-of-mindsdb-to-start

## Type of change

- [X] ⚡ New feature (non-breaking change which adds functionality)
 
## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [X] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.