### PR TITLE
Use PGVectorMDB Vector Store for Sparse Embeddings

### DIFF
--- a/mindsdb/integrations/utilities/rag/loaders/vector_store_loader/vector_store_loader.py
+++ b/mindsdb/integrations/utilities/rag/loaders/vector_store_loader/vector_store_loader.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 from mindsdb.integrations.utilities.rag.settings import VectorStoreType, VectorStoreConfig
 from mindsdb.integrations.utilities.rag.loaders.vector_store_loader.MDBVectorStore import MDBVectorStore
+from mindsdb.integrations.utilities.rag.loaders.vector_store_loader.pgvector import PGVectorMDB
 from mindsdb.utilities import log
 
 
@@ -28,6 +29,20 @@ class VectorStoreLoader(BaseModel):
         Loads the vector store based on the provided config and embeddings model
         :return:
         """
+        if self.config.is_sparse is not None and self.config.vector_size is not None and self.config.kb_table is not None:
+            # Only use PGVector store for sparse vectors.
+            db_handler = self.config.kb_table.get_vector_db()
+            db_args = db_handler.connection_args
+            # Assume we are always using PGVector & psycopg2.
+            connection_str = f"postgresql+psycopg2://{db_args.get('user')}:{db_args.get('password')}@{db_args.get('host')}:{db_args.get('port')}/{db_args.get('dbname', db_args.get('database'))}"
+
+            return PGVectorMDB(
+                connection_string=connection_str,
+                collection_name=self.config.kb_table._kb.vector_database_table,
+                embedding_function=self.embedding_model,
+                is_sparse=self.config.is_sparse,
+                vector_size=self.config.vector_size
+            )
         return MDBVectorStore(kb_table=self.config.kb_table)
 
 

--- a/mindsdb/interfaces/skills/retrieval_tool.py
+++ b/mindsdb/interfaces/skills/retrieval_tool.py
@@ -43,10 +43,17 @@ def build_retrieval_tool(tool: dict, pred_args: dict, skill: db.Skills):
             raise ValueError(f"Knowledge base not found: {kb_name}")
 
         kb_table = executor.session.kb_controller.get_table(kb.name, kb.project_id)
+        vector_store_config = {
+            'kb_table': kb_table
+        }
+        is_sparse = tools_config.pop('is_sparse', None)
+        vector_size = tools_config.pop('vector_size', None)
+        if is_sparse is not None:
+            vector_store_config['is_sparse'] = is_sparse
+        if vector_size is not None:
+            vector_store_config['vector_size'] = vector_size
         kb_params = {
-            'vector_store_config': {
-                'kb_table': kb_table
-            }
+            'vector_store_config': vector_store_config
         }
 
         # Get embedding model from knowledge base table


### PR DESCRIPTION
## Description

When we are using sparse embeddings, we need to actually use the `PGVectorMDB` class instead of the `MDBVectorStore` class.

Configuration example:

```python
embedding_config = EmbeddingConfig(
    provider='fastapi',
    model='sparse',
    params={
        'api_base': 'http://docker-fastapi-dynamic-batching-1:8043/v1/embeddings',
    }
)
...
...
knowledge_base_config = KnowledgeBaseConfig(
    name=...,
    description=...,
    embedding_config=embedding_config,
    vector_store_config=...,
    params={
       ...,
        'is_sparse': True,
        'vector_size': 1024
    }
)
```

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



