### PR TITLE
Updated the Documentation for Docker by Omitting the Exposure of the MySQL API's Port

### DIFF
--- a/docs/setup/self-hosted/docker.mdx
+++ b/docs/setup/self-hosted/docker.mdx
@@ -43,6 +43,14 @@ Where:
 -   `-p 47334:47334` publishes port 47334 to access MindsDB GUI and HTTP API.
 -   `mindsdb/mindsdb` is a Docker image provided by MindsDB. You can choose a different one from the list above.
 
+<Tip>
+By default, MindsDB starts only the `http` API. You can define which APIs to start by passing the `MINDSDB_APIS` environment variable with a comma-separated list when running the container as shown below. To expose the ports for the APIs, you need to add the respective ports to the command with the `-p` flag.
+
+```bash
+docker run -e MINDSDB_APIS="http,mysql,mongodb,postgres" -p 47334:47334 -p 47335:47335 -p 47336:47336 -p 55432:55432 mindsdb/mindsdb
+```
+</Tip>
+
 Once the container is created, you can use the following commands:
 
 -   `docker stop mindsdb_container` to stop the container. *Note that this may not always be necessary because when turning off the host machine, the container will also be shut down.*

--- a/docs/setup/self-hosted/docker.mdx
+++ b/docs/setup/self-hosted/docker.mdx
@@ -44,7 +44,7 @@ Where:
 -   `mindsdb/mindsdb` is a Docker image provided by MindsDB. You can choose a different one from the list above.
 
 <Tip>
-By default, MindsDB starts only the `http` API. You can define which APIs to start by passing the `MINDSDB_APIS` environment variable with a comma-separated list when running the container as shown below. To expose the ports for the APIs, you need to add the respective ports to the command with the `-p` flag.
+By default, MindsDB starts only the HTTP API. You can define which APIs to start by passing the `MINDSDB_APIS` environment variable with a comma-separated list when running the container as shown below. To expose the ports for the APIs, you need to add the respective ports to the command with the `-p` flag.
 
 ```bash
 docker run -e MINDSDB_APIS="http,mysql,mongodb,postgres" -p 47334:47334 -p 47335:47335 -p 47336:47336 -p 55432:55432 mindsdb/mindsdb

--- a/docs/setup/self-hosted/docker.mdx
+++ b/docs/setup/self-hosted/docker.mdx
@@ -49,6 +49,8 @@ By default, MindsDB starts only the HTTP API. You can define which APIs to start
 ```bash
 docker run -e MINDSDB_APIS="http,mysql,mongodb,postgres" -p 47334:47334 -p 47335:47335 -p 47336:47336 -p 55432:55432 mindsdb/mindsdb
 ```
+
+You can find more information on the environment variables supported by MindsDB [here](/setup/environment-vars)
 </Tip>
 
 Once the container is created, you can use the following commands:

--- a/docs/setup/self-hosted/docker.mdx
+++ b/docs/setup/self-hosted/docker.mdx
@@ -41,7 +41,6 @@ Where:
 -   `docker run` is a native Docker command used to spin up a container.
 -   `--name mindsdb_container` defines a name for the container.
 -   `-p 47334:47334` publishes port 47334 to access MindsDB GUI and HTTP API.
--   `-p 47335:47335` publishes port 47335 to access MindsDB MySQL API.
 -   `mindsdb/mindsdb` is a Docker image provided by MindsDB. You can choose a different one from the list above.
 
 Once the container is created, you can use the following commands:
@@ -53,7 +52,7 @@ Once the container is created, you can use the following commands:
 If you don't want to follow the logs and get the prompt back, add the `-d` flag that stands for *detach*.
 
 ```bash
-docker run --name mindsdb_container -d -p 47334:47334 -p 47335:47335 mindsdb/mindsdb
+docker run --name mindsdb_container -d -p 47334:47334 mindsdb/mindsdb
 ```
 </Tip>
 
@@ -62,7 +61,7 @@ If you want to persist your models and configurations in the host machine, run t
 
 ```bash
 mkdir mdb_data
-docker run --name mindsdb_container -p 47334:47334 -p 47335:47335 -v $(pwd)/mdb_data:/root/mdb_storage mindsdb/mindsdb
+docker run --name mindsdb_container -p 47334:47334 -v $(pwd)/mdb_data:/root/mdb_storage mindsdb/mindsdb
 ```
 
 Where `-v $(pwd)/mdb_data:/root/mdb_storage` maps the newly created folder `mdb_data` on the host machine to the `/root/mdb_storage` inside the container.
@@ -78,7 +77,7 @@ Now you can access the MindsDB editor by going to `127.0.0.1:47334` in your brow
 If you experience any issues related to MKL or your training process does not complete, please add the `MKL_SERVICE_FORCE_INTEL` environment variable, as below.
 
 ```bash
-docker run -e MKL_SERVICE_FORCE_INTEL=1 -p 47334:47334 -p 47335:47335 mindsdb/mindsdb
+docker run -e MKL_SERVICE_FORCE_INTEL=1 -p 47334:47334 mindsdb/mindsdb
 ```
 </Warning>
 
@@ -110,7 +109,7 @@ If you haven't specified a container name when spinning up a container with `doc
 If you haven't yet created a container, use this command:
 
 ```bash
-docker run --name mindsdb_container -d -p 47334:47334 -p 47335:47335 mindsdb/mindsdb
+docker run --name mindsdb_container -d -p 47334:47334 mindsdb/mindsdb
 ```
 </Tip>
 
@@ -187,7 +186,7 @@ The default configuration for MindsDB's Docker image is stored as a JSON code, a
 To override the default configuration, you can mount a config file over `/root/mindsdb_config.json`, as below.
 
 ```bash
-docker run --name mindsdb_container -d -p 47334:47334 -p 47335:47335 -v mdb_config.json:/root/mindsdb_config.json mindsdb/mindsdb
+docker run --name mindsdb_container -d -p 47334:47334 -v mdb_config.json:/root/mindsdb_config.json mindsdb/mindsdb
 ```
 
 <Tip>


### PR DESCRIPTION
## Description

This PR updates the documentation for running MindsDB via Docker by omitting the exposure of the MySQL API's port because as mentioned in the issue below, by default, only the HTTP API is started.

A tip for running the other APIs using the `MINDSDB_APIS` environment variable has also been added. 

Fixes https://linear.app/mindsdb/issue/BE-612/update-the-documentation-for-docker-by-removing-exposure-of-the-mysql

## Type of change

- [X] 📄 This is a documentation update

The use of the `MINDSDB_APIS` environment variable depends on https://github.com/mindsdb/mindsdb/pull/10354