### PR TITLE
Added Reserved Keywords to SqlalchemyRender

### DIFF
--- a/mindsdb/utilities/render/sqlalchemy_render.py
+++ b/mindsdb/utilities/render/sqlalchemy_render.py
@@ -14,6 +14,10 @@ from sqlalchemy.sql import functions as sa_fnc
 from mindsdb_sql_parser import ast
 
 
+reserved_words = {
+    "COLLATION"
+}
+
 sa_type_names = [
     key for key, val in sa.types.__dict__.items() if hasattr(val, '__module__')
     and val.__module__ in ('sqlalchemy.sql.sqltypes', 'sqlalchemy.sql.type_api')
@@ -100,6 +104,9 @@ class SqlalchemyRender:
                     part_lower = str(sa.column(i.lower()).compile(dialect=self.dialect))
                     if part.lower() != part_lower:
                         part = i
+
+                if part in reserved_words:
+                    part = self.dialect.identifier_preparer.quote(part)
 
             parts2.append(part)
 

--- a/mindsdb/utilities/render/sqlalchemy_render.py
+++ b/mindsdb/utilities/render/sqlalchemy_render.py
@@ -15,7 +15,7 @@ from mindsdb_sql_parser import ast
 
 
 RESERVED_WORDS = {
-    "COLLATION"
+    "collation"
 }
 
 sa_type_names = [
@@ -102,11 +102,8 @@ class SqlalchemyRender:
                     #   in that case use origin string
 
                     part_lower = str(sa.column(i.lower()).compile(dialect=self.dialect))
-                    if part.lower() != part_lower:
+                    if part.lower() != part_lower and i.lower() not in RESERVED_WORDS:
                         part = i
-
-                if part in RESERVED_WORDS:
-                    part = self.dialect.identifier_preparer.quote(part)
 
             parts2.append(part)
 

--- a/mindsdb/utilities/render/sqlalchemy_render.py
+++ b/mindsdb/utilities/render/sqlalchemy_render.py
@@ -14,7 +14,7 @@ from sqlalchemy.sql import functions as sa_fnc
 from mindsdb_sql_parser import ast
 
 
-reserved_words = {
+RESERVED_WORDS = {
     "COLLATION"
 }
 
@@ -105,7 +105,7 @@ class SqlalchemyRender:
                     if part.lower() != part_lower:
                         part = i
 
-                if part in reserved_words:
+                if part in RESERVED_WORDS:
                     part = self.dialect.identifier_preparer.quote(part)
 
             parts2.append(part)

--- a/tests/unit/executor/test_base_queires.py
+++ b/tests/unit/executor/test_base_queires.py
@@ -547,6 +547,13 @@ class TestSelect(BaseExecutorDummyML):
         assert ret.iloc[0, 0] == 1
         assert ret.iloc[0, 1] == 'utf8'
 
+    def test_mysql_queries(self):
+        self.run_sql('SHOW KEYS FROM `mindsdb`.`predictors`')
+
+        self.run_sql('show full columns from `predictors`')
+
+        self.run_sql('SHOW FULL TABLES FROM files')
+
 
 class TestDML(BaseExecutorDummyML):
 


### PR DESCRIPTION
## Description

This PR checks for unregistered keywords in SqlalchemyRender. This fixes the failing integration tests.

Fixes https://linear.app/mindsdb/issue/BE-607/investigate-and-fix-failing-integration-tests

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



