### PR TITLE
Refactor pgvector utilities and fix query result formatting

### DIFF
--- a/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
+++ b/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
@@ -37,8 +37,9 @@ class PgVectorHandler(VectorStoreHandler, PostgresHandler):
         super().__init__(name=name, **kwargs)
         self._is_shared_db = False
         self._is_vector_registered = False
-        self._is_sparse = kwargs.get('is_sparse', False)
-        self._vector_size = kwargs.get('vector_size', None)  # Default to None
+        # we get these from the connection args on PostgresHandler parent
+        self._is_sparse = self.connection_args.get('is_sparse', False)
+        self._vector_size = self.connection_args.get('vector_size', None) 
         if self._is_sparse and not self._vector_size:
             raise ValueError("vector_size is required when is_sparse=True")
         self.connect()


### PR DESCRIPTION

## Description

Updated query logic in pgvector loader to handle result formatting and ordering based on vector type. Adjusted `pgvector_handler` to retrieve `is_sparse` and `vector_size` from connection arguments instead of `kwargs`.

to validate I created a script to run it using agents - [here ](https://github.com/mindsdb/CW-Internal/blob/main/scripts/nrc_fermi_sparse_agent.py)



Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



