### PR TITLE
standardise op order in pgvector

### DIFF
--- a/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
+++ b/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
@@ -37,8 +37,9 @@ class PgVectorHandler(VectorStoreHandler, PostgresHandler):
         super().__init__(name=name, **kwargs)
         self._is_shared_db = False
         self._is_vector_registered = False
-        self._is_sparse = kwargs.get('is_sparse', False)
-        self._vector_size = kwargs.get('vector_size', None)  # Default to None
+        # we get these from the connection args on PostgresHandler parent
+        self._is_sparse = self.connection_args.get('is_sparse', False)
+        self._vector_size = self.connection_args.get('vector_size', None) 
         if self._is_sparse and not self._vector_size:
             raise ValueError("vector_size is required when is_sparse=True")
         self.connect()

--- a/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
+++ b/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
@@ -213,7 +213,7 @@ class PgVectorHandler(VectorStoreHandler, PostgresHandler):
                     # Use cosine similarity for dense vectors
                     distance_op = "<=>"
 
-                return f"SELECT {targets} FROM {table_name} ORDER BY embeddings {distance_op} '{search_vector}' {after_from_clause}"
+                return f"SELECT {targets} FROM {table_name} ORDER BY embeddings {distance_op} '{search_vector}' ASC {after_from_clause}"
 
             else:
                 # if filter conditions, return rows that satisfy the conditions

--- a/mindsdb/integrations/utilities/rag/loaders/vector_store_loader/pgvector.py
+++ b/mindsdb/integrations/utilities/rag/loaders/vector_store_loader/pgvector.py
@@ -71,8 +71,6 @@ class PGVectorMDB(PGVector):
                     embedding_str = embedding
                 # Use inner product for sparse vectors
                 distance_op = "<#>"
-                # For inner product, larger values are better matches
-                order_direction = "DESC"
             else:
                 # Dense vectors: expect string in JSON array format or list of floats
                 if isinstance(embedding, list):
@@ -81,15 +79,13 @@ class PGVectorMDB(PGVector):
                     embedding_str = embedding
                 # Use cosine similarity for dense vectors
                 distance_op = "<=>"
-                # For cosine similarity, smaller values are better matches
-                order_direction = "ASC"
 
             # Use SQL directly for vector comparison
             query = sa.text(
                 f"""
             SELECT t.*, t.embeddings {distance_op} '{embedding_str}' as distance
             FROM {self.collection_name} t
-            ORDER BY distance {order_direction}
+            ORDER BY distance ASC
             LIMIT {k}
             """
             )


### PR DESCRIPTION
## Description

As it is negative inner product order by asc


Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



