### PR TITLE
Render asof join render by standard render

### DIFF
--- a/mindsdb/utilities/render/sqlalchemy_render.py
+++ b/mindsdb/utilities/render/sqlalchemy_render.py
@@ -506,6 +506,8 @@ class SqlalchemyRender:
                             condition = self.to_expression(item['condition'])
 
                         join_type = item['join_type']
+                        if 'ASOF' in join_type:
+                            raise NotImplementedError(f'Unsupported join type: {join_type}')
                         method = 'join'
                         is_full = False
                         if join_type == 'LEFT JOIN':

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -17,7 +17,7 @@ redis >=5.0.0, < 6.0.0
 walrus==0.9.3
 flask-compress >= 1.0.0
 appdirs >= 1.0.0
-mindsdb-sql-parser ~= 0.1.0
+mindsdb-sql-parser ~= 0.2.0
 pydantic ~= 2.7.0
 mindsdb-evaluator >= 0.0.7, < 0.1.0
 duckdb == 0.9.1


### PR DESCRIPTION
## Description
Raise error for asof join in sqlachemy render (as it doesn't support it). It is rendered by standard render

**Examples:**
- Questdb:
![image](https://github.com/user-attachments/assets/260f4f82-71df-4c4d-9513-6aa370d8d9a2)

- Duckdb:
![image](https://github.com/user-attachments/assets/ba885648-32ca-4091-af02-f1df4b33507c)



Dependent on https://github.com/mindsdb/mindsdb_sql_parser/pull/5

Fixes:  https://linear.app/mindsdb/issue/BE-608/asof-join-support


## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



