### PR TITLE
Fixes for updated chromadb version

### DIFF
--- a/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
@@ -286,7 +286,7 @@ class ChromaDBHandler(VectorStoreHandler):
         else:
             # general get query
             result = collection.get(
-                ids=id_filters,
+                ids=id_filters or None,
                 where=filters,
                 limit=limit,
                 offset=offset,
@@ -475,7 +475,7 @@ class ChromaDBHandler(VectorStoreHandler):
         collections = self._client.list_collections()
         collections_name = pd.DataFrame(
             columns=["table_name"],
-            data=[collection.name for collection in collections],
+            data=collections,
         )
         return Response(resp_type=RESPONSE_TYPE.TABLE, data_frame=collections_name)
 

--- a/mindsdb/integrations/handlers/chromadb_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/chromadb_handler/requirements.txt
@@ -1,1 +1,1 @@
-chromadb~=0.4.8
+chromadb~=0.6.3

--- a/mindsdb/integrations/handlers/langchain_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/langchain_handler/requirements.txt
@@ -3,6 +3,6 @@ wikipedia==1.4.0
 tiktoken
 anthropic>=0.26.1
 litellm==1.44.8
-chromadb # Knowledge bases.
+chromadb~=0.6.3 # Knowledge bases.
 -r mindsdb/integrations/handlers/openai_handler/requirements.txt
 -r mindsdb/integrations/handlers/langchain_embedding_handler/requirements.txt

--- a/tests/unit/executor/test_agent.py
+++ b/tests/unit/executor/test_agent.py
@@ -263,3 +263,32 @@ class TestAgent(BaseExecutorDummyML):
             # check kb input
             args, _ = kb_select.call_args
             assert user_question in args[0].where.args[1].value
+
+    def test_kb(self):
+
+        self.run_sql(
+            '''
+                CREATE model emb_model
+                PREDICT predicted
+                using
+                  column='content',
+                  engine='dummy_ml',
+                  join_learn_process=true
+            '''
+        )
+
+        self.run_sql('create knowledge base kb_review using model=emb_model')
+
+        self.run_sql("insert into kb_review (content) values ('review')")
+
+        # selectable
+        ret = self.run_sql("select * from kb_review")
+        assert len(ret) == 1
+
+        # show tables in default chromadb
+        ret = self.run_sql("show knowledge bases")
+
+        db_name = ret.STORAGE[0].split('.')[0]
+        ret = self.run_sql(f"show tables from {db_name}")
+        # only one default collection there
+        assert len(ret) == 1


### PR DESCRIPTION
## Description

Changes:
- adapted chromadb handler for changed API to version 0.6.3
- fixed chromadb version in langchain handler
  - it is default handler and used to lead to install latest version of chromadb 
- added unit test to check queries which didn't work with knowledge base:
   - `show tables from mykb_chromadb`, the same when clicks on created default chromadb database for KB in objects tree in GUI
   - `select * from my_kb` - getting all objects from KB

Fixes https://linear.app/mindsdb/issue/BE-615/chromadb-error-in-latest-mindsdb-version-notimplementederror-in-chroma

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



