### PR TITLE
Update agents.mdx

### DIFF
--- a/docs/sdks/python/agents.mdx
+++ b/docs/sdks/python/agents.mdx
@@ -53,10 +53,10 @@ Furthermore, you can list all existing agents, get agents by name, update agents
 
 ```python
 # list all agents
-agents = agents.list()
+agents = server.agents.list()
 
 # get an agent by name
-agent = agents.get('my_agent')
+agent = server.agents.get('my_agent')
 
 # update an agent
 new_model = models.get('new_model')


### PR DESCRIPTION
## Description

Updated the list all agents and get agent examples by using the same convention as in the rest of the documentation. It should use servers.agents instead of just agents. If left as it is, it throws an error.

Please include a summary of the change and the issue it solves. 

It doesn't solve any pending issue.

## Type of change

It is just a documentation update.





