### PR TITLE
Fix: agent with skill based on view

### DIFF
--- a/mindsdb/api/executor/datahub/datanodes/datanode.py
+++ b/mindsdb/api/executor/datahub/datanodes/datanode.py
@@ -13,7 +13,7 @@ class DataNode:
     def has_table(self, tableName):
         pass
 
-    def get_table_columns(self, tableName):
+    def get_table_columns(self, tableName, schema_name=None):
         pass
 
     def query(self, query=None, native_query=None, session=None):

--- a/mindsdb/api/executor/datahub/datanodes/information_schema_datanode.py
+++ b/mindsdb/api/executor/datahub/datanodes/information_schema_datanode.py
@@ -120,7 +120,7 @@ class InformationSchemaDataNode(DataNode):
             return True
         return False
 
-    def get_table_columns(self, tableName):
+    def get_table_columns(self, tableName, schema_name=None):
         tn = tableName.upper()
         if tn in self.tables:
             return [

--- a/mindsdb/api/executor/datahub/datanodes/project_datanode.py
+++ b/mindsdb/api/executor/datahub/datanodes/project_datanode.py
@@ -52,7 +52,7 @@ class ProjectDataNode(DataNode):
         tables = self.project.get_tables()
         return table_name in tables
 
-    def get_table_columns(self, table_name):
+    def get_table_columns(self, table_name, schema_name=None):
         return [
             {'name': name}
             for name in self.project.get_columns(table_name)

--- a/mindsdb/api/executor/datahub/datanodes/project_datanode.py
+++ b/mindsdb/api/executor/datahub/datanodes/project_datanode.py
@@ -14,9 +14,6 @@ from mindsdb_sql_parser.ast import (
 from mindsdb.utilities.exception import EntityNotExistsError
 from mindsdb.api.executor.datahub.datanodes.datanode import DataNode
 from mindsdb.api.executor.datahub.classes.tables_row import TablesRow
-from mindsdb.api.executor.sql_query import SQLQuery
-from mindsdb.api.executor.utilities.sql import query_df
-from mindsdb.interfaces.query_context.context_controller import query_context_controller
 from mindsdb.utilities.partitioning import process_dataframe_in_partitions
 
 
@@ -122,28 +119,7 @@ class ProjectDataNode(DataNode):
 
             if self.project.get_view(query_table):
                 # this is the view
-
-                view_meta = self.project.query_view(query)
-
-                query_context_controller.set_context('view', view_meta['id'])
-
-                try:
-                    sqlquery = SQLQuery(
-                        view_meta['query_ast'],
-                        session=session
-                    )
-                    result = sqlquery.fetch(view='dataframe')
-
-                finally:
-                    query_context_controller.release_context('view', view_meta['id'])
-
-                if result['success'] is False:
-                    raise Exception(f"Cant execute view query: {view_meta['query_ast']}")
-                df = result['result']
-                # remove duplicated columns
-                df = df.loc[:, ~df.columns.duplicated()]
-
-                df = query_df(df, query, session=session)
+                df = self.project.query_view(query, session)
 
                 columns_info = [
                     {

--- a/mindsdb/integrations/libs/ml_handler_process/learn_process.py
+++ b/mindsdb/integrations/libs/ml_handler_process/learn_process.py
@@ -72,7 +72,7 @@ def learn_process(data_integration_ref: dict, problem_definition: dict, fetch_da
                 elif data_integration_ref['type'] == 'view':
                     project = database_controller.get_project(project_name)
                     query_ast = parse_sql(fetch_data_query)
-                    view_meta = project.query_view(query_ast)
+                    view_meta = project.get_view_meta(query_ast)
                     sqlquery = SQLQuery(view_meta['query_ast'], session=sql_session)
                 elif data_integration_ref['type'] == 'project':
                     query_ast = parse_sql(fetch_data_query)

--- a/tests/unit/executor/test_schema.py
+++ b/tests/unit/executor/test_schema.py
@@ -45,6 +45,10 @@ class TestSchema(BaseExecutorDummyML):
         df = self.run_sql('describe view v1')
         assert df.NAME[0] == 'v1' and df.QUERY[0] == 'select * from models'
 
+        # columns of view
+        ret = self.run_sql('show columns from v1')
+        assert 'NAME' in list(ret.Field)
+
         # model
         self.run_sql('''
                 CREATE model pred1


### PR DESCRIPTION
## Description

Fixes:
- added added `schema_name` param to `get_table_columns` method of other datanodes
- implemented getting columns of a view. It is done by selecting first row from view and using columns from result

Fixes https://linear.app/mindsdb/issue/BE-619/mindsdb-agent-cannot-read-data-from-a-skill-that-was-created-based-on

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



