### PR TITLE
Fix pgvector handler, work with KB

### DIFF
--- a/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
+++ b/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
@@ -373,10 +373,12 @@ class PgVectorHandler(VectorStoreHandler, PostgresHandler):
             
             # Add vector size specification only if provided
             size_spec = f"({self._vector_size})" if self._vector_size is not None else "()"
-            
+            if vector_column_type == 'vector':
+                size_spec = ''
+
             cur.execute(f"""
                 CREATE TABLE IF NOT EXISTS {table_name} (
-                    id SERIAL PRIMARY KEY,
+                    id TEXT PRIMARY KEY,
                     embeddings {vector_column_type}{size_spec},
                     content TEXT,
                     metadata JSONB

--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -713,10 +713,6 @@ class KnowledgeBaseController:
                         vector_db_params['vector_size'] = vector_size
                 vector_db_name = self._create_persistent_pgvector(vector_db_params)
 
-                # create table in vectordb before creating KB
-                self.session.datahub.get(vector_db_name).integration_handler.create_table(
-                    vector_table_name
-                )
             else:
                 # create chroma db with same name
                 vector_table_name = "default_collection"
@@ -728,6 +724,10 @@ class KnowledgeBaseController:
         else:
             vector_db_name, vector_table_name = storage.parts
 
+        # create table in vectordb before creating KB
+        self.session.datahub.get(vector_db_name).integration_handler.create_table(
+            vector_table_name
+        )
         vector_database_id = self.session.integration_controller.get(vector_db_name)['id']
 
         # Store sparse vector settings in params if specified


### PR DESCRIPTION
## Description

Fixes:
- Fix pgvector types: 
  - id type is TEXT
  - vector type is without parens
- create table for vector database when kb is created

Used  queries:
```sql
CREATE DATABASE pvec
WITH
    ENGINE = 'pgvector',
    PARAMETERS = {
    "host": "127.0.0.1",
    "port": 5432,
    "database": "vector",
    "user": "postgres"
    };

CREATE KNOWLEDGE_BASE kb20
USING
model = embedding_model_hf,
storage = pvec.kb20

insert into kb20 (content)
values ('asdf')
```


Please include a summary of the change and the issue it solves. 

Fixes #issue_number

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



