### PR TITLE
Fix issues with agents

### DIFF
--- a/mindsdb/interfaces/agents/mindsdb_database_agent.py
+++ b/mindsdb/interfaces/agents/mindsdb_database_agent.py
@@ -11,6 +11,17 @@ from mindsdb.interfaces.skills.sql_agent import SQLAgent
 logger = log.getLogger(__name__)
 
 
+def extract_essential(input: str) -> str:
+    """ Sometimes LLM include to input unnecessary data. We can't control stochastic nature of LLM, so we need to
+        'clean' input somehow. LLM prompt contains instruction to enclose input between '$START$' and '$STOP$'.
+    """
+    if '$START$' in input:
+        input = input.partition('$START$')[-1]
+    if '$STOP$' in input:
+        input = input.partition('$STOP$')[0]
+    return input.strip(' ')
+
+
 class MindsDBSQL(SQLDatabase):
     @staticmethod
     def custom_init(
@@ -51,11 +62,7 @@ class MindsDBSQL(SQLDatabase):
 
     def get_table_info_no_throw(self, table_names: Optional[List[str]] = None) -> str:
         for i in range(len(table_names)):
-            if '$START$' in table_names[i]:
-                table_names[i] = table_names[i].partition('$START$')[-1]
-            if '$END$' in table_names[i]:
-                table_names[i] = table_names[i].partition('$END$')[0]
-            table_names[i] = table_names[i].strip(' ')
+            table_names[i] = extract_essential(table_names[i])
         return self._sql_agent.get_table_info_safe(table_names)
 
     def run_no_throw(self, command: str, fetch: str = "all") -> str:

--- a/mindsdb/interfaces/agents/mindsdb_database_agent.py
+++ b/mindsdb/interfaces/agents/mindsdb_database_agent.py
@@ -66,4 +66,5 @@ class MindsDBSQL(SQLDatabase):
         return self._sql_agent.get_table_info_safe(table_names)
 
     def run_no_throw(self, command: str, fetch: str = "all") -> str:
+        command = extract_essential(command)
         return self._sql_agent.query_safe(command)

--- a/mindsdb/interfaces/skills/custom/text2sql/mindsdb_sql_toolkit.py
+++ b/mindsdb/interfaces/skills/custom/text2sql/mindsdb_sql_toolkit.py
@@ -15,20 +15,25 @@ class MindsDBSQLToolkit(SQLDatabaseToolkit):
         list_sql_database_tool = ListSQLDatabaseTool(
             name=f'sql_db_list_tables{prefix}',
             db=self.db,
-            description=(
-                "Input is an empty string, output is a comma-separated list of tables in the database. "
-                "Each table name in the list may be in one of two formats: database_name.table_name or "
-                "database_name.schema_name.table_name."
-                "If the table name is enclosed in backticks marks, then always use the table name with backticks marks in subsequent queries."
-            )
+            description=dedent("""\n
+                Input is an empty string, output is a comma-separated list of tables in the database. Each table name is escaped using backticks.
+                Each table name in the list may be in one of two formats: database_name.`table_name` or database_name.schema_name.`table_name`.
+                Table names in response to the user must be escaped using backticks.
+            """)
         )
 
         info_sql_database_tool_description = (
-            "Input: A comma-separated list of tables enclosed between the symbols $START$ and $END$. Output: Schema and sample rows for those tables. "
-            f"Ensure tables exist by calling {list_sql_database_tool.name} first. "
+            "Input: A comma-separated list of tables enclosed between the symbols $START$ and $STOP$. The tables names itself must be escaped using backticks.\n"
+            "Output: Schema and sample rows for those tables. \n"
             "Use this tool to investigate table schemas for needed columns. "
-            "Get sample data with 'SELECT * FROM table LIMIT 3' before answering questions. "
-            "Example Input: $START$ table1, table2, table3 $END$"
+            f"Ensure tables exist by calling {list_sql_database_tool.name} first. "
+            # "The names of tables, schemas, and databases must be escaped using backticks. "
+            # "Always enclose the names of tables, schemas, and databases in backticks. "
+            "Get sample data with 'SELECT * FROM `database`.`table` LIMIT 3' before answering questions. \n"
+            "Example of correct Input:\n    $START$ `database`.`table1`, `database`.`table2`, `database`.`table3` $STOP$\n"
+            "    $START$ `table1` `table2` `table3` $STOP$\n"
+            "Example of wrong Input:\n    $START$ `database.table1`, `database.table2`, `database.table3` $STOP$\n"
+            "    $START$ table1 table2 table3 $STOP$\n"
         )
         info_sql_database_tool = InfoSQLDatabaseTool(
             name=f'sql_db_schema{prefix}',
@@ -36,7 +41,7 @@ class MindsDBSQLToolkit(SQLDatabaseToolkit):
         )
 
         query_sql_database_tool_description = dedent(f"""\
-            Input: A detailed SQL query.
+            Input: A detailed and well-structured SQL query. The query must be enclosed between the symbols $START$ and $STOP$.
             Output: Database result or error message. For errors, rewrite and retry the query. For 'Unknown column' errors, use '{info_sql_database_tool.name}' to check table fields.
             This system is a highly intelligent and reliable PostgreSQL SQL skill designed to work with databases.
             Follow these instructions with utmost precision:
@@ -64,6 +69,7 @@ class MindsDBSQLToolkit(SQLDatabaseToolkit):
                  SELECT NOW() - INTERVAL 1 YEAR;
             6. Query Best Practices:
                - Always send only one query at a time.
+               - Always enclose the names of tables, schemas, and databases in backticks.
                - The input SQL query must end with a semicolon.
                - Query only necessary columns, not all.
                - Use only existing column names from correct tables.

--- a/mindsdb/interfaces/skills/skill_tool.py
+++ b/mindsdb/interfaces/skills/skill_tool.py
@@ -126,6 +126,10 @@ class SkillToolController:
 
         command_executor = self.get_command_executor()
 
+        def escape_table_name(name: str) -> str:
+            name = name.strip(' `')
+            return f'`{name}`'
+
         tables_list = []
         for skill in skills:
             database = skill.params['database']
@@ -139,17 +143,17 @@ class SkillToolController:
                 # no restrictions
                 if 'table_schema' in response.data_frame.columns:
                     for _, row in response.data_frame.iterrows():
-                        tables_list.append(f"{database}.{row['table_schema']}.{row['table_name']}")
+                        tables_list.append(f"{database}.{row['table_schema']}.{escape_table_name(row['table_name'])}")
                 else:
                     for _, row in response.data_frame.iterrows():
-                        tables_list.append(f"{database}.{row['table_name']}")
+                        tables_list.append(f"{database}.{escape_table_name(row['table_name'])}")
                 continue
             for schema_name, tables in restriction_on_tables.items():
                 for table in tables:
                     if schema_name is None:
-                        tables_list.append(f'{database}.{table}')
+                        tables_list.append(f'{database}.{escape_table_name(table)}')
                     else:
-                        tables_list.append(f'{database}.{schema_name}.{table}')
+                        tables_list.append(f'{database}.{schema_name}.{escape_table_name(table)}')
 
         sql_agent = SQLAgent(
             command_executor=command_executor,

--- a/mindsdb/interfaces/skills/sql_agent.py
+++ b/mindsdb/interfaces/skills/sql_agent.py
@@ -274,8 +274,13 @@ class SQLAgent:
         try:
             ret = self._call_engine(command)
             sample_rows = ret.data.to_lists()
+
+            def truncate_value(val):
+                str_val = str(val)
+                return str_val if len(str_val) < 100 else (str_val[:100] + '...')
+
             sample_rows = list(
-                map(lambda ls: [str(i) if len(str(i)) < 100 else str[:100] + '...' for i in ls], sample_rows))
+                map(lambda row: [truncate_value(value) for value in row], sample_rows))
             sample_rows_str = "\n" + "\n".join(["\t".join(row) for row in sample_rows])
         except Exception as e:
             logger.warning(e)


### PR DESCRIPTION
## Description

 - fixed `get_sample` for long string (>100) and not-strings in sample
 - added instruction to always escape tables names
 - added instruction to enclose the input query between $START$ and $STOP$. It should help from broken input like this:
![image](https://github.com/user-attachments/assets/16470276-c147-4649-aa4a-98cc6a797cc5)
 - query result will be send to agent as text in CSV. Otherwise agent may go crazy if any cell in response contain multi line text, or text with tabs.

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



