### PR TITLE
Fix agent snowflake sql skill: table names in upper case

### DIFF
--- a/mindsdb/interfaces/skills/skill_tool.py
+++ b/mindsdb/interfaces/skills/skill_tool.py
@@ -137,12 +137,15 @@ class SkillToolController:
                 else:
                     response = handler.get_tables()
                 # no restrictions
+                columns = [c.lower() for c in response.data_frame.columns]
+                name_idx = columns.index('table_name') if 'table_name' in columns else 0
+
                 if 'table_schema' in response.data_frame.columns:
                     for _, row in response.data_frame.iterrows():
-                        tables_list.append(f"{database}.{row['table_schema']}.{row['table_name']}")
+                        tables_list.append(f"{database}.{row['table_schema']}.{row[name_idx]}")
                 else:
-                    for _, row in response.data_frame.iterrows():
-                        tables_list.append(f"{database}.{row['table_name']}")
+                    for table_name in response.data_frame.iloc[:, name_idx]:
+                        tables_list.append(f"{database}.{table_name}")
                 continue
             for schema_name, tables in restriction_on_tables.items():
                 for table in tables:


### PR DESCRIPTION
## Description

Fix agent work with snowflake db (using sql skill)
`get_tables` method of handler can return different names of tables. For snowflake it is in uppercase "TABLE_NAME".

Update in this PR:
- lowercase all columns
- try to find `table_schema` column
  - if not exist: no schema is used
- try to find `table_name` column
  - if not exist: use first column

Fixes https://linear.app/mindsdb/issue/BE-647/minds-via-sdk-cannot-get-an-answer

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



