### PR TITLE
Set default user in MySQL API

### DIFF
--- a/mindsdb/integrations/handlers/snowflake_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/snowflake_handler/requirements.txt
@@ -1,2 +1,2 @@
-snowflake-connector-python==3.12.3
+snowflake-connector-python==3.13.1
 snowflake-sqlalchemy==1.7.0

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -142,7 +142,8 @@ class Config:
             },
             'auth': {
                 'http_auth_enabled': False,
-                "http_permanent_session_lifetime": datetime.timedelta(days=31)
+                "http_permanent_session_lifetime": datetime.timedelta(days=31),
+                "username": "mindsdb"
             },
             "logging": {
                 "handlers": {
@@ -183,7 +184,6 @@ class Config:
                 },
                 "mysql": {
                     "host": api_host,
-                    "password": "",
                     "port": "47335",
                     "database": "mindsdb",
                     "ssl": True,


### PR DESCRIPTION
## Description

This PR adds the default `mindsdb` user for the MySQL API to avoid auth errors in db clients where system user was used by default.

Fixes https://linear.app/mindsdb/issue/BE-671/mysql-cant-connect

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update


## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



