### PR TITLE
Fix single line select with subqueries

### DIFF
--- a/mindsdb/api/executor/planner/query_planner.py
+++ b/mindsdb/api/executor/planner/query_planner.py
@@ -1,5 +1,7 @@
 import copy
 
+import pandas as pd
+
 from mindsdb_sql_parser import ast
 from mindsdb_sql_parser.ast import (
     Select, Identifier, Join, Star, BinaryOperation, Constant, Union, CreateTable,
@@ -12,7 +14,7 @@ from mindsdb.api.executor.planner.query_plan import QueryPlan
 from mindsdb.api.executor.planner.steps import (
     FetchDataframeStep, ProjectStep, ApplyPredictorStep,
     ApplyPredictorRowStep, UnionStep, GetPredictorColumns, SaveToTable,
-    InsertToTable, UpdateToTable, SubSelectStep,
+    InsertToTable, UpdateToTable, SubSelectStep, QueryStep,
     DeleteStep, DataStep, CreateTableStep
 )
 from mindsdb.api.executor.planner.utils import (
@@ -746,7 +748,10 @@ class QueryPlanner:
             step = DataStep(from_table.data)
             last_step = self.plan.add_step(step)
             return self.plan_sub_select(query, last_step, add_absent_cols=True)
-
+        elif from_table is None:
+            # one line select
+            step = QueryStep(query, from_table=pd.DataFrame([None]))
+            self.plan.add_step(step)
         else:
             raise PlanningException(f'Unsupported from_table {type(from_table)}')
 

--- a/mindsdb/utilities/render/sqlalchemy_render.py
+++ b/mindsdb/utilities/render/sqlalchemy_render.py
@@ -331,11 +331,10 @@ class SqlalchemyRender:
             if t.alias:
                 raise RenderError()
         elif isinstance(t, ast.Tuple):
-            items = [
+            col = [
                 self.to_expression(i)
                 for i in t.items
             ]
-            col = sa.Tuple(items)
         elif isinstance(t, ast.Variable):
             col = sa.column(t.to_string(), is_literal=True)
         elif isinstance(t, ast.Latest):

--- a/mindsdb/utilities/render/sqlalchemy_render.py
+++ b/mindsdb/utilities/render/sqlalchemy_render.py
@@ -331,10 +331,11 @@ class SqlalchemyRender:
             if t.alias:
                 raise RenderError()
         elif isinstance(t, ast.Tuple):
-            col = [
+            items = [
                 self.to_expression(i)
                 for i in t.items
             ]
+            col = sa.Tuple(items)
         elif isinstance(t, ast.Variable):
             col = sa.column(t.to_string(), is_literal=True)
         elif isinstance(t, ast.Latest):

--- a/tests/unit/executor/test_base_queires.py
+++ b/tests/unit/executor/test_base_queires.py
@@ -387,18 +387,18 @@ class TestSelect(BaseExecutorDummyML):
         sql = '''
             select
                cast(
-                  (select COUNT(*) from pg.branch where `name` = 'asia') as FLOAT
+                  (select COUNT(*) from pg.branch where `name` in ('asia', 'africa')) as FLOAT
                )
                /
                ( select COUNT(*) from  pg.branch )
-               * 100 as asia_percentage
+               * 100 as percentage
         '''
         ret = self.run_sql(sql)
-        assert ret.iloc[0, 0] == 25
+        assert ret.iloc[0, 0] == 50
 
         sql += ' from files.empty '
         ret = self.run_sql(sql)
-        assert ret.iloc[0, 0] == 25
+        assert ret.iloc[0, 0] == 50
 
     def test_last(self):
         df = pd.DataFrame([

--- a/tests/unit/executor/test_base_queires.py
+++ b/tests/unit/executor/test_base_queires.py
@@ -362,6 +362,44 @@ class TestSelect(BaseExecutorDummyML):
 
         # TODO Correlated subqueries (not implemented)
 
+    @patch('mindsdb.integrations.handlers.postgres_handler.Handler')
+    def test_replace_suqueries(self, data_handler):
+
+        df = pd.DataFrame(
+            columns=['id', 'name'],
+            data=[
+                [1, 'asia'],
+                [2, 'europe'],
+                [3, 'africa'],
+                [3, 'australia'],
+            ]
+        )
+        self.set_handler(data_handler, name='pg', tables={'branch': df})
+
+        empty = pd.DataFrame(
+            columns=['name'],
+            data=[
+                [None],
+            ]
+        )
+        self.save_file('empty', empty)
+
+        sql = '''
+            select
+               cast(
+                  (select COUNT(*) from pg.branch where `name` = 'asia') as FLOAT
+               )
+               /
+               ( select COUNT(*) from  pg.branch )
+               * 100 as asia_percentage
+        '''
+        ret = self.run_sql(sql)
+        assert ret.iloc[0, 0] == 25
+
+        sql += ' from files.empty '
+        ret = self.run_sql(sql)
+        assert ret.iloc[0, 0] == 25
+
     def test_last(self):
         df = pd.DataFrame([
             {'a': 1, 'b': 'a'},
@@ -553,6 +591,23 @@ class TestSelect(BaseExecutorDummyML):
         self.run_sql('show full columns from `predictors`')
 
         self.run_sql('SHOW FULL TABLES FROM files')
+
+    def test_select_without_table(self):
+        test_data = (
+            ('session_user', None),
+            ('version()', '8.0.17'),
+            ('@@version_comment', '(MindsDB)'),
+            ('1', 1)
+        )
+
+        for target, response in test_data:
+            ret = self.run_sql(f'select {target}')
+            assert len(ret) == 1
+            assert ret.iloc[0, 0] == response
+
+        with pytest.raises(Exception) as exc_info:
+            self.run_sql('select $$')
+        assert 'check the manual that corresponds to your server version for the right syntax' in str(exc_info.value)
 
 
 class TestDML(BaseExecutorDummyML):


### PR DESCRIPTION
## Description

Updates:
- added `callstack` parameter for callback in `query_traversal` utility
  - it contents all parent nodes (direction: from deepest to outer)
  - it can be useful to check parent node in callback
- `answer_single_row_select` was moved from `command_executor` to `QueryStep` of the planner

Fixes: 
- Handle option `cast(<select 1> as FLOAT) / <select 2>`
  - The problem with it: it used to update only `select 2` and then skip this whole binary operation (skipping `select1` also)
- Fix render of tuple 


Fixes #issue_number

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



