### PR TITLE
Fixed Retrieval of Child Items in MS OneDrive

### DIFF
--- a/mindsdb/integrations/handlers/ms_one_drive_handler/ms_graph_api_one_drive_client.py
+++ b/mindsdb/integrations/handlers/ms_one_drive_handler/ms_graph_api_one_drive_client.py
@@ -76,15 +76,15 @@ class MSGraphAPIOneDriveClient(MSGraphAPIBaseClient):
         child_items = []
         for items in self.fetch_paginated_data(f"me/drive/items/{item_id}/children"):
             for item in items:
-                path = f"{path}/{item['name']}"
+                child_path = f"{path}/{item['name']}"
                 # If the item is a folder, get its child items.
                 if "folder" in item:
                     # Recursively get the child items of the folder.
-                    child_items.extend(self.get_child_items(item["id"], path))
+                    child_items.extend(self.get_child_items(item["id"], child_path))
 
                 else:
                     # Add the path to the item.
-                    item["path"] = path
+                    item["path"] = child_path
                     child_items.append(item)
 
         return child_items


### PR DESCRIPTION
## Description

This PR fixes the retrieval of child items (items within folders) when using the MS OneDrive integration.

Fixes https://linear.app/mindsdb/issue/BE-672/child-items-in-ms-onedrive-are-retrieved-incorrectly

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

![image](https://github.com/user-attachments/assets/a920f63e-59c1-4419-8824-924b28eed5f7)

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas - N/A
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added.



