### PR TITLE
Added API Endpoint for Validating Connection Parameters

### DIFF
--- a/mindsdb/api/http/namespaces/handlers.py
+++ b/mindsdb/api/http/namespaces/handlers.py
@@ -112,10 +112,10 @@ class InstallDependencies(Resource):
         )
 
 
-@ns_conf.route('/<handler_name>/test_connection')
+@ns_conf.route('/<handler_name>/status')
 class TestConnection(Resource):
     @ns_conf.param('handler_name', 'Handler name')
-    @api_endpoint_metrics('POST', '/handlers/handler/test_connection')
+    @api_endpoint_metrics('POST', '/handlers/handler/status')
     def post(self, handler_name):
         if 'connection_data' not in request.json:
             return http_error(

--- a/mindsdb/api/http/namespaces/handlers.py
+++ b/mindsdb/api/http/namespaces/handlers.py
@@ -125,12 +125,25 @@ class TestConnection(Resource):
             )
         
         tmp_handler = ca.integration_controller.create_tmp_handler(
-            "test_connection",  # TODO: Will this work?
+            "test_connection",
             handler_name,
             request.json['connection_data']
         )
 
-        response = tmp_handler.check_connection()
+        try:
+            response = tmp_handler.check_connection()
+        except ImportError as import_error:
+            return http_error(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                'Import error',
+                str(import_error)
+            )
+        except Exception as unknown_error:
+            return http_error(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                'Unknown error',
+                str(unknown_error)
+            )
 
         if response.success:
             return '', 200

--- a/mindsdb/api/http/namespaces/handlers.py
+++ b/mindsdb/api/http/namespaces/handlers.py
@@ -112,6 +112,36 @@ class InstallDependencies(Resource):
         )
 
 
+@ns_conf.route('/<handler_name>/test_connection')
+class TestConnection(Resource):
+    @ns_conf.param('handler_name', 'Handler name')
+    @api_endpoint_metrics('POST', '/handlers/handler/test_connection')
+    def post(self, handler_name):
+        if 'connection_data' not in request.json:
+            return http_error(
+                HTTPStatus.BAD_REQUEST,
+                'Missing parameter',
+                '"connection_data" parameter is required'
+            )
+        
+        tmp_handler = ca.integration_controller.create_tmp_handler(
+            "test_connection",  # TODO: Will this work?
+            handler_name,
+            request.json['connection_data']
+        )
+
+        response = tmp_handler.check_connection()
+
+        if response.success:
+            return '', 200
+        else:
+            return http_error(
+                HTTPStatus.BAD_REQUEST,
+                'Connection failed',
+                response.error_message
+            )
+
+
 def prepare_formdata():
     params = {}
     file_names = []

--- a/mindsdb/api/http/namespaces/handlers.py
+++ b/mindsdb/api/http/namespaces/handlers.py
@@ -123,14 +123,13 @@ class TestConnection(Resource):
                 'Missing parameter',
                 '"connection_data" parameter is required'
             )
-        
-        tmp_handler = ca.integration_controller.create_tmp_handler(
-            "test_connection",
-            handler_name,
-            request.json['connection_data']
-        )
 
         try:
+            tmp_handler = ca.integration_controller.create_tmp_handler(
+                "test_connection",
+                handler_name,
+                request.json['connection_data']
+            )
             response = tmp_handler.check_connection()
         except ImportError as import_error:
             return http_error(


### PR DESCRIPTION
## Description

This PR adds an API endpoint for the checking the validity of integration connection parameters.

Fixes https://linear.app/mindsdb/issue/BE-624/test-data-connection-details

## Type of change

- [X] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.