### PR TITLE
Bump duckdb version

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -20,7 +20,7 @@ appdirs >= 1.0.0
 mindsdb-sql-parser ~= 0.3.0
 pydantic ~= 2.7.0
 mindsdb-evaluator >= 0.0.7, < 0.1.0
-duckdb == 0.9.1
+duckdb == 1.2.0
 requests == 2.32.3
 pydateinfer==0.3.0
 dataprep_ml==24.5.1.2

--- a/tests/unit/executor/test_base_queires.py
+++ b/tests/unit/executor/test_base_queires.py
@@ -178,7 +178,11 @@ class TestSelect(BaseExecutorDummyML):
         # second table is called with filter
         calls = data_handler().query.call_args_list
         sql = calls[0][0][0].to_string()
-        assert sql.strip() == 'SELECT * FROM tbl2 AS t2 WHERE c IN (2, 1)'
+        assert sql.strip() in (
+            # duckdb's `distinct` can return in different order
+            'SELECT * FROM tbl2 AS t2 WHERE c IN (1, 2)'
+            'SELECT * FROM tbl2 AS t2 WHERE c IN (2, 1)'
+        )
 
         # --- using alias in order
         ret = self.run_sql('''

--- a/tests/unit/executor/test_executor.py
+++ b/tests/unit/executor/test_executor.py
@@ -219,14 +219,17 @@ class Test(BaseExecutorMockPredictor):
         # one key with max value of a
         assert len(data) == 2
         #  first row
-        assert data[0]['a'] == 3
-        assert data[0]['t'] == dt.datetime(2020, 1, 3)
-        assert data[0]['g'] == 'x'
-
-        # second
-        assert data[1]['a'] == 13
-        assert data[1]['t'] == dt.datetime(2021, 1, 3)
-        assert data[1]['g'] == 'y'
+        groups = [
+            ['x', 3, dt.datetime(2020, 1, 3)],
+            ['y', 13, dt.datetime(2021, 1, 3)],
+        ]
+        if data[0]['g'] == 'y':
+            # other sort order after duckdb join
+            groups.reverse()
+        for i, (group, val, date) in enumerate(groups):
+            assert data[i]['a'] == val
+            assert data[i]['t'] == date
+            assert data[i]['g'] == group
 
         # > latest ______________________
         ret = self.execute("""

--- a/tests/unit/executor/test_udf.py
+++ b/tests/unit/executor/test_udf.py
@@ -66,10 +66,10 @@ class TestBYOM(BaseExecutorDummyML):
 
         self._create_engine(name='myml', code=code,
                             type=byom_type, mode='custom_function')
-
+        # convert to explicit types, because duckdb doesn't convert it and fails
         ret = self.run_sql('''
             select myml.fibo(b) x,
-                   myml.add1(a,b) y,
+                   myml.add1(a::char,b::char) y,
                    myml.add2(a,b) z
             from pg.sample
         ''')


### PR DESCRIPTION
## Description

Updated duckdb dependency to latest version

Changes in behavior with version 0.9.1 which are adapted in unit tests:
- order is not the same in selects with join and distinct (without using order by)
- UDF requires matching of input types. In 0.9.1 they were cast automatically 

Fixes https://linear.app/mindsdb/issue/BE-694/[urgent]-duckdb-cve-2024-22682

# Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



