### PR TITLE
Bump nltk version

### DIFF
--- a/mindsdb/integrations/handlers/huggingface_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/huggingface_handler/requirements.txt
@@ -1,5 +1,5 @@
 datasets==2.16.1
 evaluate
 torch
-nltk
+nltk>=3.9
 huggingface-hub

--- a/mindsdb/integrations/handlers/huggingface_handler/requirements_cpu.txt
+++ b/mindsdb/integrations/handlers/huggingface_handler/requirements_cpu.txt
@@ -1,6 +1,6 @@
 datasets==2.16.1
 evaluate
-nltk
+nltk>=3.9
 huggingface-hub
 # Needs to be installed with `pip install --extra-index-url https://download.pytorch.org/whl/ .[huggingface_cpu]`
 torch==2.2.0+cpu

--- a/mindsdb/integrations/handlers/writer_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/writer_handler/requirements.txt
@@ -1,4 +1,4 @@
 -r mindsdb/integrations/handlers/rag_handler/requirements.txt
-nltk>=3.8.1
+nltk>=3.9
 rouge-score>=0.1.2
 scipy


### PR DESCRIPTION
## Description

This PR upgrades/pin the NLTK version in writer and hf handlers.

Fixes https://linear.app/mindsdb/issue/BE-697/[urgent]-nltk-cve-2024-39705
>Note; We may get an incompatible version warning due to pined version in Lightwood. We will bump this in Lightwood too but for now it is not breaking any functionality

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Additional Media:

![Screenshot from 2025-02-12 15-46-55](https://github.com/user-attachments/assets/8a0d7b59-daee-449a-950c-f1553962d843)




