### PR TITLE
Fix case sensitive `DELETE` of skill and database

### DIFF
--- a/mindsdb/interfaces/database/database.py
+++ b/mindsdb/interfaces/database/database.py
@@ -106,7 +106,7 @@ class DatabaseController:
                 }
 
     def exists(self, db_name: str) -> bool:
-        return db_name in self.get_dict()
+        return db_name.lower() in self.get_dict()
 
     def get_project(self, name: str):
         return self.project_controller.get(name=name)

--- a/mindsdb/interfaces/skills/skills_controller.py
+++ b/mindsdb/interfaces/skills/skills_controller.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Dict, List, Optional
 
-from sqlalchemy import null
+from sqlalchemy import null, func
 from sqlalchemy.orm.attributes import flag_modified
 
 from mindsdb.interfaces.storage import db
@@ -33,7 +33,7 @@ class SkillsController:
 
         project = self.project_controller.get(name=project_name)
         return db.Skills.query.filter(
-            db.Skills.name == skill_name,
+            func.lower(db.Skills.name) == func.lower(skill_name),
             db.Skills.project_id == project.id,
             db.Skills.deleted_at == null()
         ).first()

--- a/tests/api/http/databases_test.py
+++ b/tests/api/http/databases_test.py
@@ -19,7 +19,7 @@ def app():
         os.environ['MINDSDB_DB_CON'] = db_path
         db.init()
         migrate.migrate_to_head()
-        app = initialize_app(Config(), True, False)
+        app = initialize_app(Config(), True)
 
         yield app
     os.environ['MINDSDB_DB_CON'] = old_minds_db_con
@@ -50,6 +50,11 @@ def test_get_database(client):
         'id': mindsdb_database['id']
     }
 
+    assert mindsdb_database == expected_db
+
+    response = client.get('/api/databases/MindsDB', follow_redirects=True)
+    mindsdb_database = response.get_json()
+    mindsdb_database['name'] = mindsdb_database['name'].lower()
     assert mindsdb_database == expected_db
 
     # Get a newly created integration.


### PR DESCRIPTION
## Description

Make `DELETE /projects/mindsdb/skills/{name}`  and `DELETE /databases/{name}` case insensitive.

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



