### PR TITLE
Fix rendering of quoted alias

### DIFF
--- a/mindsdb/utilities/render/sqlalchemy_render.py
+++ b/mindsdb/utilities/render/sqlalchemy_render.py
@@ -63,6 +63,10 @@ class AttributedStr(str):
         obj.is_quoted = is_quoted
         return obj
 
+    def replace(self, *args):
+        obj = super().replace(*args)
+        return AttributedStr(obj, self.is_quoted)
+
 
 def get_is_quoted(identifier: ast.Identifier):
     quoted = getattr(identifier, 'is_quoted', [])

--- a/tests/unit/render/test_sqlalchemyrender.py
+++ b/tests/unit/render/test_sqlalchemyrender.py
@@ -118,13 +118,13 @@ class TestRender:
         assert sql.lower() == sql0
 
     def test_quoted_identifier(self):
-        sql = "SELECT `A`.*, A.`B` FROM Tbl.`Tab` AS t"
+        sql = "SELECT `A`.*, A.`B` AS `Bb`, `c` as Cc FROM Tbl.`Tab` AS `Tt`"
 
         query = parse_sql(sql)
         rendered = SqlalchemyRender('postgres').get_string(query, with_failback=False)
 
         # check queries are the same after render
-        assert rendered.replace('\n', '') == 'SELECT "A".*, A."B" FROM Tbl."Tab" AS t'
+        assert rendered.replace('\n', '') == 'SELECT "A".*, A."B" AS "Bb", "c" AS Cc FROM Tbl."Tab" AS "Tt"'
 
     def test_intersect_except(self):
         for op in ('EXCEPT', 'INTERSECT'):


### PR DESCRIPTION
## Description

Fix render of aliases for snowflake dialect: quoted alias was not quoted after render

Fixes https://linear.app/mindsdb/issue/BE-745/incorrect-sql-render-to-snowflake

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



