### PR TITLE
Converted the resource_id Column in json_storage to BigInt

### DIFF
--- a/mindsdb/migrations/versions/2025-02-14_4521dafe89ab_added_encrypted_content_to_json_storage.py
+++ b/mindsdb/migrations/versions/2025-02-14_4521dafe89ab_added_encrypted_content_to_json_storage.py
@@ -20,8 +20,10 @@ depends_on = None
 def upgrade():
     with op.batch_alter_table('json_storage', schema=None) as batch_op:
         batch_op.add_column(sa.Column('encrypted_content', sa.LargeBinary(), nullable=True))
+        batch_op.alter_column('resource_id', existing_type=sa.Integer(), type_=sa.BigInteger())
 
 
 def downgrade():
     with op.batch_alter_table('json_storage', schema=None) as batch_op:
         batch_op.drop_column('encrypted_content')
+        batch_op.alter_column('resource_id', existing_type=sa.BigInteger(), type_=sa.Integer())


### PR DESCRIPTION
## Description

This PR converts the resource_id column of the json_storage table to `BigInteger` to allow the storage of temporary integration IDs (in Postgres databases) that are generated.

Fixes https://github.com/mindsdb/mindsdb/issues/10513

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added - N/A