### PR TITLE
Add Document Name Lookup Retrieval Tool to Agent

### DIFF
--- a/mindsdb/integrations/utilities/rag/settings.py
+++ b/mindsdb/integrations/utilities/rag/settings.py
@@ -385,6 +385,46 @@ class ColumnSchema(BaseModel):
     )
 
 
+class MetadataConfig(BaseModel):
+    """Class to configure metadata for retrieval. Only supports very basic document name lookup at the moment."""
+    table: str = Field(
+        description="Source table for metadata."
+    )
+    max_document_context: int = Field(
+        # To work well with models with context window of 32768.
+        default=16384,
+        description="Truncate a document before using as context with an LLM if it exceeds this amount of tokens"
+    )
+    embeddings_table: str = Field(
+        default="embeddings",
+        description="Source table for embeddings"
+    )
+    id_column: str = Field(
+        default="Id",
+        description="Name of ID column in metadata table"
+    )
+    name_column: str = Field(
+        default="Title",
+        description="Name of column containing name or title of document"
+    )
+    name_column_index: Optional[str] = Field(
+        default=None,
+        description="Name of GIN index to use when looking up name."
+    )
+    content_column: str = Field(
+        default="content",
+        description="Name of column in embeddings table containing chunk content"
+    )
+    embeddings_metadata_column: str = Field(
+        default="metadata",
+        description="Name of column in embeddings table containing chunk metadata"
+    )
+    doc_id_key: str = Field(
+        default="original_row_id",
+        description="Metadata field that links an embedded chunk back to source document ID"
+    )
+
+
 class MetadataSchema(BaseModel):
     table: str = Field(
         description="Name of table in the database"
@@ -526,6 +566,10 @@ class RAGPipelineModel(BaseModel):
     db_connection_string: Optional[str] = Field(
         default=None,
         description="Database connection string"
+    )
+    metadata_config: Optional[MetadataConfig] = Field(
+        default=None,
+        description="Configuration for metadata to be used for retrieval"
     )
     table_name: str = Field(
         default=DEFAULT_TEST_TABLE_NAME,

--- a/mindsdb/interfaces/skills/skill_tool.py
+++ b/mindsdb/interfaces/skills/skill_tool.py
@@ -222,8 +222,8 @@ class SkillToolController:
         pred_args = {}
         pred_args['llm'] = llm
 
-        from .retrieval_tool import build_retrieval_tool
-        return build_retrieval_tool(tool, pred_args, skill)
+        from .retrieval_tool import build_retrieval_tools
+        return build_retrieval_tools(tool, pred_args, skill)
 
     def _get_rag_query_function(self, skill: db.Skills):
         session_controller = self.get_command_executor().session
@@ -295,10 +295,9 @@ class SkillToolController:
                     for skill in skills
                 ]
             elif skill_type == SkillType.RETRIEVAL:
-                tools[skill_type] = [
-                    self._make_retrieval_tools(skill, llm, embedding_model)
-                    for skill in skills
-                ]
+                tools[skill_type] = []
+                for skill in skills:
+                    tools[skill_type] += self._make_retrieval_tools(skill, llm, embedding_model)
         return tools
 
 


### PR DESCRIPTION
## Description

This PR adds a Langchain tool to lookup a document by name for retrieval.

Implementation tailored for CW use-case for now.

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [x]   Verification Steps: Spin up a local Mind and ask it to find documents

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



