### PR TITLE
Perform UNION step in duckdb

### DIFF
--- a/tests/unit/executor/test_base_queires.py
+++ b/tests/unit/executor/test_base_queires.py
@@ -296,9 +296,11 @@ class TestSelect(BaseExecutorDummyML):
         ret = self.run_sql(sql)
         assert len(ret) == 3
 
-        assert list(ret.iloc[0]) == [21, 3]
-        assert list(ret.iloc[1]) == [1, 1]
-        assert list(ret.iloc[2]) == [2, 2]
+        # union doesn't guarantee order
+        ret.sort_values(by='a', inplace=True)
+        assert list(ret.iloc[0]) == [1, 1]
+        assert list(ret.iloc[1]) == [2, 2]
+        assert list(ret.iloc[2]) == [21, 3]
 
         # -- aggregating / grouping / cases --
         case = '''


### PR DESCRIPTION
## Description

Use duckdb to handle UNION step, it speeds up union operation 
For union 3 tables per 20k records:
- the time was 30s
- tie time become 1.1s 


Fixes #issue_number

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



