### PR TITLE
PGvector handler supports sql

### DIFF
--- a/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
+++ b/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
@@ -27,7 +27,7 @@ logger = log.getLogger(__name__)
 
 
 # todo Issue #7316 add support for different indexes and search algorithms e.g. cosine similarity or L2 norm
-class PgVectorHandler(VectorStoreHandler, PostgresHandler):
+class PgVectorHandler(PostgresHandler, VectorStoreHandler):
     """This handler handles connection and execution of the PostgreSQL with pgvector extension statements."""
 
     name = "pgvector"
@@ -64,11 +64,11 @@ class PgVectorHandler(VectorStoreHandler, PostgresHandler):
             return Response(RESPONSE_TYPE.OK)
         return super().get_tables()
 
-    def native_query(self, query) -> Response:
+    def native_query(self, query, params=None) -> Response:
         # Prevent execute native queries
         if self._is_shared_db:
             return Response(RESPONSE_TYPE.OK)
-        return super().native_query(query)
+        return super().native_query(query, params=params)
 
     def raw_query(self, query, params=None) -> Response:
         resp = super().native_query(query, params)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -17,7 +17,7 @@ redis >=5.0.0, < 6.0.0
 walrus==0.9.3
 flask-compress >= 1.0.0
 appdirs >= 1.0.0
-mindsdb-sql-parser ~= 0.3.0
+mindsdb-sql-parser ~= 0.4.0
 pydantic ~= 2.7.0
 mindsdb-evaluator >= 0.0.7, < 0.1.0
 duckdb == 1.2.0


### PR DESCRIPTION
Changes:
- `query` method is inherited from postgres handler (used to be from VectorStoreHandler)

It makes pgvector handler support both:
- postgres sql operations when direct queries to this database is used
- work with knowledge base interface because KB controller used VectorStoreHandler methods to work with pgvector

Updated parser with support pgvector operators:
![image](https://github.com/user-attachments/assets/abec3652-1e08-4c27-aed6-dee0b2077c10)


Fixes https://linear.app/mindsdb/issue/BE-630/pgvector-make-enterprise-ready

Dependent on https://github.com/mindsdb/mindsdb_sql_parser/pull/8

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)


## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



