### PR TITLE
Docs: Add missing steps for activating the virtual environment in the installation guide for contributors.

### DIFF
--- a/docs/contribute/install.mdx
+++ b/docs/contribute/install.mdx
@@ -35,9 +35,17 @@ Before installing MindsDB from source, ensure that you use one of the following 
 
 4. Activate the virtual environment:
 
-   ```bash
-   source mindsdb-venv/bin/activate
-   ```
+   **Windows**:
+
+     ```bash
+     .\mindsdb-venv\Scripts\activate
+     ```
+
+   **macOS/Linux**:
+
+     ```bash
+     source mindsdb-venv/bin/activate
+     ```
 
 5. Install MindsDB with its local development dependencies:
 


### PR DESCRIPTION
## Description

Currently, in the documentation at `contribute/install#install-mindsdb-for-development`, step 4, which involves activating the virtual environment, only provides commands compatible with macOS and Linux. In this PR, I propose adding documentation for activating the virtual environment on Windows to ensure compatibility across all operating systems.

## Changes

### Before changes
![image](https://github.com/user-attachments/assets/5e50b3f9-af49-4db4-a05c-183c87ed5b55)

### After changes 
![image](https://github.com/user-attachments/assets/230996d9-3120-41e8-8b77-18ecefa8557c)

Fixes #10549

## Docs

(Please delete options that are not relevant)

- [X] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [X]   Test Location: Specify the URL or path for testing.
 - [X]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



