### PR TITLE
Change case of target in input dataframe if it mismatches

### DIFF
--- a/mindsdb/integrations/libs/ml_handler_process/learn_process.py
+++ b/mindsdb/integrations/libs/ml_handler_process/learn_process.py
@@ -111,10 +111,16 @@ def learn_process(data_integration_ref: dict, problem_definition: dict, fetch_da
             )
             handlers_cacher[predictor_record.id] = ml_handler
 
-            if not ml_handler.generative:
+            if not ml_handler.generative and target is not None:
                 if training_data_df is not None and target not in training_data_df.columns:
-                    raise Exception(
-                        f'Prediction target "{target}" not found in training dataframe: {list(training_data_df.columns)}')
+                    # is the case different? convert column case in input dataframe
+                    col_names = {c.lower(): c for c in training_data_df.columns}
+                    target_found = col_names.get(target.lower())
+                    if target_found:
+                        training_data_df.rename(columns={target_found: target}, inplace=True)
+                    else:
+                        raise Exception(
+                            f'Prediction target "{target}" not found in training dataframe: {list(training_data_df.columns)}')
 
             # create new model
             if base_model_id is None:


### PR DESCRIPTION
## Description

If cases of prediction target and columns with target in input dataframe mismatch: convert case in input dataframe

For example here model will get dataframe with `cc_employees` in lower case (even in query it is in upper-case):
```sql
CREATE MODEL call_center_model
FROM snowflake_datasource
(SELECT CC_NAME, CC_CLASS, CC_EMPLOYEES, CC_SQ_FT, CC_HOURS, CC_MANAGER, CC_DIVISION FROM TPCDS_SF100TCL.CALL_CENTER)
PREDICT cc_employees;
```

Fixes https://linear.app/mindsdb/issue/BE-625/capitalize-prediction-target-in-snowflake

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



