### PR TITLE
KB select/delete by metadata

### DIFF
--- a/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
@@ -319,6 +319,7 @@ class ChromaDBHandler(VectorStoreHandler):
             for cond in conditions:
                 if cond.column == distance_col:
                     distance_filter = cond
+                    break
 
         df = pd.DataFrame(payload)
         if distance_filter is not None:

--- a/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
@@ -210,8 +210,7 @@ class ChromaDBHandler(VectorStoreHandler):
         chroma_db_conditions = []
         for condition in metadata_conditions:
             metadata_key = condition.column.split(".")[-1]
-            if condition.key is not None:
-                metadata_key = condition.key
+
             chroma_db_conditions.append(
                 {
                     metadata_key: {

--- a/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
@@ -210,6 +210,8 @@ class ChromaDBHandler(VectorStoreHandler):
         chroma_db_conditions = []
         for condition in metadata_conditions:
             metadata_key = condition.column.split(".")[-1]
+            if condition.key is not None:
+                metadata_key = condition.key
             chroma_db_conditions.append(
                 {
                     metadata_key: {

--- a/mindsdb/integrations/libs/vectordatabase_handler.py
+++ b/mindsdb/integrations/libs/vectordatabase_handler.py
@@ -325,7 +325,7 @@ class VectorStoreHandler(BaseHandler):
         if not df_insert.empty:
             self.insert(table_name, df_insert)
 
-    def _dispatch_delete(self, query: Delete):
+    def dispatch_delete(self, query: Delete):
         """
         Dispatch delete query to the appropriate method.
         """
@@ -382,7 +382,7 @@ class VectorStoreHandler(BaseHandler):
             DropTables: self._dispatch_drop_table,
             Insert: self._dispatch_insert,
             Update: self._dispatch_update,
-            Delete: self._dispatch_delete,
+            Delete: self.dispatch_delete,
             Select: self.dispatch_select,
         }
         if type(query) in dispatch_router:

--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -106,7 +106,6 @@ class KnowledgeBaseTable:
         df = db_handler.dispatch_select(query)
 
         if df is not None:
-            df = filter_dataframe(df, outer_filters)
 
             logger.debug(f"Query returned {len(df)} rows")
             logger.debug(f"Columns in response: {df.columns.tolist()}")

--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -26,9 +26,7 @@ from mindsdb.integrations.libs.vectordatabase_handler import (
 )
 from mindsdb.integrations.utilities.rag.rag_pipeline_builder import RAG
 from mindsdb.integrations.utilities.rag.config_loader import load_rag_config
-from mindsdb.integrations.utilities.sql_utils import (
-    extract_comparison_conditions, filter_dataframe, FilterCondition, FilterOperator
-)
+
 from mindsdb.interfaces.agents.constants import DEFAULT_EMBEDDINGS_MODEL_CLASS
 from mindsdb.interfaces.agents.langchain_agent import create_chat_model, get_llm_provider
 from mindsdb.interfaces.database.projects import ProjectController
@@ -105,16 +103,7 @@ class KnowledgeBaseTable:
         db_handler = self.get_vector_db()
         logger.debug(f"Using vector db handler: {type(db_handler)}")
 
-        vector_filters, outer_filters = [], []
-        # update vector handlers, mark conditions as applied inside
-        for op, arg1, arg2 in extract_comparison_conditions(query.where):
-            condition = FilterCondition(arg1, FilterOperator(op.upper()), arg2)
-            if arg1 in (TableField.ID.value, TableField.CONTENT.value, TableField.EMBEDDINGS.value):
-                vector_filters.append(condition)
-            else:
-                outer_filters.append([op, arg1, arg2])
-
-        df = db_handler.dispatch_select(query, conditions=vector_filters)
+        df = db_handler.dispatch_select(query)
 
         if df is not None:
             df = filter_dataframe(df, outer_filters)

--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -217,7 +217,7 @@ class KnowledgeBaseTable:
 
         # send to vectordb
         db_handler = self.get_vector_db()
-        db_handler.query(query)
+        db_handler.dispatch_delete(query)
 
     def hybrid_search(
         self,

--- a/mindsdb/interfaces/knowledge_base/preprocessing/document_preprocessor.py
+++ b/mindsdb/interfaces/knowledge_base/preprocessing/document_preprocessor.py
@@ -98,7 +98,7 @@ class DocumentPreprocessor:
         provided_id: str = None,
     ) -> str:
         """Generate deterministic ID for a chunk"""
-        base_id = self._generate_deterministic_id(content, content_column, provided_id)
+        base_id = provided_id
         chunk_id = (
             f"{base_id}_chunk_{chunk_index}" if chunk_index is not None else base_id
         )


### PR DESCRIPTION
## Description

Changes:
- checked/fixed filter by metadata columns in pgvector and chroma handlers:
  - it is possible to use metadata columns in where filter (`original_row_id` is key of metadata):
    - `select * from kb3 where original_row_id='1' `
- original document id located in metadata.original_row_id
- removed duplicated columns in generated id:
   - was `4_content_content_chunk_1`
   - will be `4_content_chunk_1` 
- handle delete documents. it is also possible to use metadata columns:
  -  `delete from kb3 where original_row_id='1' `
- filter by distance moved to chromadb handler

Related to:
- https://linear.app/mindsdb/issue/PRD-51/313-soft-delete-implementation
- https://linear.app/mindsdb/issue/PRD-49/4311-basic-kb-result-format

Fixes #issue_number

Demo
https://www.loom.com/share/13e06e979a054a3d995aeb7fb3b98944

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



