### PR TITLE
Support `lateral join` and `distinct on` in render

### DIFF
--- a/mindsdb/utilities/render/sqlalchemy_render.py
+++ b/mindsdb/utilities/render/sqlalchemy_render.py
@@ -529,8 +529,11 @@ class SqlalchemyRender:
 
                 query = query.add_cte(stmt.cte(self.get_alias(alias), nesting=True))
 
-        if node.distinct:
+        if node.distinct is True:
             query = query.distinct()
+        elif isinstance(node.distinct, list):
+            columns = [self.to_expression(c) for c in node.distinct]
+            query = query.distinct(*columns)
 
         if node.from_table is not None:
             from_table = node.from_table

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -17,7 +17,7 @@ redis >=5.0.0, < 6.0.0
 walrus==0.9.3
 flask-compress >= 1.0.0
 appdirs >= 1.0.0
-mindsdb-sql-parser ~= 0.4.0
+mindsdb-sql-parser ~= 0.5.0
 pydantic ~= 2.7.0
 mindsdb-evaluator >= 0.0.7, < 0.1.0
 duckdb == 1.2.0

--- a/tests/unit/render/test_from_parser.py
+++ b/tests/unit/render/test_from_parser.py
@@ -17,8 +17,11 @@ def parse_sql2(sql, dialect='mindsdb'):
     # skip
 
     # step1: use mysql dialect and parse again
+    dialect = 'mysql'
+    if 'distinct on' in sql.lower():
+        dialect = 'postgres'
     try:
-        sql2 = SqlalchemyRender('mysql').get_string(query, with_failback=False)
+        sql2 = SqlalchemyRender(dialect).get_string(query, with_failback=False)
     except NotImplementedError:
         # skip not implemented, immediately exit
         return query


### PR DESCRIPTION
## Description

1. Added support  LATERAL JOIN in sqlalchemy render

```sql
SELECT t.name AS name, t.driver AS driver, r.*
FROM tags t INNER JOIN LATERAL
	(SELECT longitude, latitude
	FROM readings r
	WHERE r.tags_id=t.id
	ORDER BY time DESC LIMIT 1)  r ON true
WHERE t.name IS NOT NULL
AND t.fleet = 'South'
```

2. Added support `distinct on` in sqlalchemy render

```sql
SELECT DISTINCT ON (t.hostname) * FROM tags t 
```

It is required for [TSBS benchmark](https://github.com/timescale/tsbs)

Dependent on 
- https://github.com/mindsdb/mindsdb_sql_parser/pull/10
- https://github.com/mindsdb/mindsdb_sql_parser/pull/11

Fixes #issue_number

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



