### PR TITLE
Fixed the Incorrect Use of channel_id with the Conversations Table

### DIFF
--- a/docs/integrations/app-integrations/slack.mdx
+++ b/docs/integrations/app-integrations/slack.mdx
@@ -177,7 +177,7 @@ FROM slack_datasource.conversations;
 -- Retrieve a specific conversation using its ID
 SELECT * 
 FROM slack_datasource.conversations 
-WHERE channel_id = "<channel-id>";
+WHERE id = "<channel-id>";
 
 -- Retrieve a specific conversation using its name
 SELECT *

--- a/mindsdb/integrations/handlers/slack_handler/README.md
+++ b/mindsdb/integrations/handlers/slack_handler/README.md
@@ -177,7 +177,7 @@ FROM slack_datasource.conversations;
 -- Retrieve a specific conversation using its ID
 SELECT * 
 FROM slack_datasource.conversations 
-WHERE channel_id = "<channel-id>";
+WHERE id = "<channel-id>";
 
 -- Retrieve a specific conversation using its name
 SELECT *


### PR DESCRIPTION
## Description

This PR fixes the incorrect use of the `channel_id` parameter (with the conversations table) listed in the documentation.

Fixes 

## Type of change

- [X] 📄 This is a documentation update