### PR TITLE
Bump LiteLLM version

### DIFF
--- a/mindsdb/integrations/handlers/langchain_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/langchain_handler/requirements.txt
@@ -1,7 +1,7 @@
 wikipedia==1.4.0
 tiktoken
 anthropic>=0.26.1
-litellm==1.44.8
+litellm==1.63.14
 chromadb~=0.6.3 # Knowledge bases.
 -r mindsdb/integrations/handlers/openai_handler/requirements.txt
 -r mindsdb/integrations/handlers/langchain_embedding_handler/requirements.txt

--- a/mindsdb/integrations/handlers/litellm_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/litellm_handler/requirements.txt
@@ -1,2 +1,2 @@
-litellm==1.44.8
+litellm==1.63.14
 


### PR DESCRIPTION
## Description

This PR updates the LiteLLM version in both the LiteLLM handler and Langcahin.

Fixes https://github.com/mindsdb/mindsdb/security/dependabot/199, https://github.com/mindsdb/mindsdb/security/dependabot/198, https://github.com/mindsdb/mindsdb/security/dependabot/197, https://github.com/mindsdb/mindsdb/security/dependabot/196, https://github.com/mindsdb/mindsdb/security/dependabot/195, https://github.com/mindsdb/mindsdb/security/dependabot/194, https://github.com/mindsdb/mindsdb/security/dependabot/193, https://github.com/mindsdb/mindsdb/security/dependabot/192





