### PR TITLE
Fix cursor pagination in Confluence

### DIFF
--- a/mindsdb/integrations/handlers/confluence_handler/confluence_api_client.py
+++ b/mindsdb/integrations/handlers/confluence_handler/confluence_api_client.py
@@ -153,9 +153,8 @@ class ConfluenceAPIClient:
             next_params = {}
             if params:
                 next_params.update(params)
-                
             if "cursor=" in next_url:
-                #cursor= is 7 characters long
+                # cursor= is 7 characters long
                 cursor_start = next_url.find("cursor=") + 7
                 cursor_value = next_url[cursor_start:]
                 if "&" in cursor_value:
@@ -164,7 +163,6 @@ class ConfluenceAPIClient:
                 response = self._make_request("GET", url, next_params)
             else:
                 response = self._make_request("GET", next_url)
-                
             results.extend(response["results"])
 
         return results

--- a/mindsdb/integrations/handlers/confluence_handler/confluence_api_client.py
+++ b/mindsdb/integrations/handlers/confluence_handler/confluence_api_client.py
@@ -149,8 +149,22 @@ class ConfluenceAPIClient:
         results.extend(response["results"])
 
         while response["_links"].get("next"):
-            params["cursor"] = response["_links"].get("next")
-            response = self._make_request("GET", url, params)
+            next_url = response["_links"].get("next")
+            next_params = {}
+            if params:
+                next_params.update(params)
+                
+            if "cursor=" in next_url:
+                #cursor= is 7 characters long
+                cursor_start = next_url.find("cursor=") + 7
+                cursor_value = next_url[cursor_start:]
+                if "&" in cursor_value:
+                    cursor_value = cursor_value.split("&")[0]
+                next_params["cursor"] = cursor_value
+                response = self._make_request("GET", url, next_params)
+            else:
+                response = self._make_request("GET", next_url)
+                
             results.extend(response["results"])
 
         return results


### PR DESCRIPTION
## Description

We were using the entire next url as the cursor value which caused 400 error. Now we extract cursor value not a full url and create a new param dict for each request instead of modifying the original

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Additional Media:

![Screenshot from 2025-03-26 16-20-44](https://github.com/user-attachments/assets/4d6ec97e-75da-44d6-8ba0-bccc1f3cb76f)


## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



