### PR TITLE
Update default_handlers.txt

### DIFF
--- a/default_handlers.txt
+++ b/default_handlers.txt
@@ -15,6 +15,5 @@ statsforecast
 timegpt
 binance
 twitter
-minds_endpoint
 web
 langchain            # For agents & completions


### PR DESCRIPTION
Removes minds-endpoint from default installed handlers. We may consider removing the handler too in a separate PR