### PR TITLE
fix concurrency settings for deploys

### DIFF
--- a/.github/workflows/build_deploy_dev.yml
+++ b/.github/workflows/build_deploy_dev.yml
@@ -6,18 +6,15 @@ on:
     branches:
       - 'main'
 
-# Cancel any existing runs of this workflow on the same branch/pr
-# We always want to build/deploy/test a new commit over an older one
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
-
 jobs:
 
   # Looks for labels like "deploy-to-<env>" attached to a PR so we can deploy to those envs
   get-deploy-labels:
     name: Get Deploy Envs
     runs-on: mdb-dev
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-labels
+      cancel-in-progress: true
     environment:
       name: ${{ github.event.pull_request.head.repo.fork && 'manual-approval' || '' }}
     outputs:
@@ -34,9 +31,12 @@ jobs:
   # Build our docker images based on our bake file
   build:
     name: Build Docker Images
-    runs-on: mdb-dev
+    runs-on: mdb-dev\
     needs: [get-deploy-labels]
     if: needs.get-deploy-labels.outputs.deploy-envs != '[]'
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-build
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -71,6 +71,9 @@ jobs:
   run_tests:
     name: Run Integration Tests
     needs: [deploy]
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-tests
+      cancel-in-progress: true
     uses: ./.github/workflows/test_on_deploy.yml
     with:
       git-sha: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/build_deploy_dev.yml
+++ b/.github/workflows/build_deploy_dev.yml
@@ -31,7 +31,7 @@ jobs:
   # Build our docker images based on our bake file
   build:
     name: Build Docker Images
-    runs-on: mdb-dev\
+    runs-on: mdb-dev
     needs: [get-deploy-labels]
     if: needs.get-deploy-labels.outputs.deploy-envs != '[]'
     concurrency:

--- a/.github/workflows/build_deploy_prod.yml
+++ b/.github/workflows/build_deploy_prod.yml
@@ -11,11 +11,6 @@ on:
 env:
   UV_SYSTEM_PYTHON: 1
 
-# Cancel any existing runs of this workflow on the same branch/pr
-# We always want to build/deploy/test a new commit over an older one
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
 
 jobs:
   # Check that the version defined in the github release is valid
@@ -23,6 +18,9 @@ jobs:
     name: Check Code Version
     runs-on: mdb-dev
     if: github.actor != 'mindsdbadmin'
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-check-version
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
       - uses: FranzDiebold/github-env-vars-action@v2
@@ -40,6 +38,9 @@ jobs:
     runs-on: mdb-dev
     needs: check-version
     if: github.actor != 'mindsdbadmin'
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-pypi
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -66,6 +67,9 @@ jobs:
     runs-on: mdb-dev
     needs: [check-version]
     if: github.actor != 'mindsdbadmin'
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-build
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
       - name: Docker Login
@@ -101,6 +105,9 @@ jobs:
     runs-on: mdb-dev
     needs: [build]
     if: github.actor != 'mindsdbadmin'
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-extension
+      cancel-in-progress: true
     environment:
       name: prod
     steps:
@@ -119,5 +126,8 @@ jobs:
   run_tests:
     name: Run Integration Tests
     needs: [deploy]
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-tests
+      cancel-in-progress: true
     uses: ./.github/workflows/test_on_deploy.yml
     secrets: inherit

--- a/.github/workflows/build_deploy_staging.yml
+++ b/.github/workflows/build_deploy_staging.yml
@@ -7,12 +7,6 @@ on:
     types:
       - closed
 
-# Cancel any existing runs of this workflow on the same branch/pr
-# We always want to build/deploy/test a new commit over an older one
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   
   # Build our docker images based on our bake file
@@ -20,6 +14,9 @@ jobs:
     if: github.event.pull_request.merged == true
     name: Build Docker Images
     runs-on: mdb-dev
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-build
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
       - name: Pull MindsDB Github Actions
@@ -47,5 +44,8 @@ jobs:
     if: github.event.pull_request.merged == true
     name: Run Integration Tests
     needs: [deploy]
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-tests
+      cancel-in-progress: true
     uses: ./.github/workflows/test_on_deploy.yml
     secrets: inherit


### PR DESCRIPTION
## Description

Removes the workflow-wide `cancel-in-progress: true` concurrency rules so that the deployment step can have `cancel-in-progress: false` so we stop cancelling deployment part-way through.

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



