### PR TITLE
Added filtering_threshold in the query

### DIFF
--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -99,9 +99,14 @@ class KnowledgeBaseTable:
                     elif item.column == "reranking_threshold" and item.op.value == "=":
                         try:
                             reranking_threshold = float(item.value)
+                            # Validate range: must be between 0 and 1
+                            if not (0 <= reranking_threshold <= 1):
+                                raise ValueError(f"reranking_threshold must be between 0 and 1, got: {reranking_threshold}")
                             logger.debug(f"Found reranking_threshold in query: {reranking_threshold}")
-                        except (ValueError, TypeError):
-                            logger.warning(f"Invalid reranking_threshold value: {item.value}")
+                        except (ValueError, TypeError) as e:
+                            error_msg = f"Invalid reranking_threshold value: {item.value}. {str(e)}"
+                            logger.error(error_msg)
+                            raise ValueError(error_msg)
             query.where = self._filter_out_threshold_condition(query.where)
             logger.debug(f"Extracted query text: {query_text}")
 

--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -156,7 +156,7 @@ class KnowledgeBaseTable:
                 reranker_params = {"model": rerank_model}
                 # Apply custom filtering threshold if provided
                 if reranking_threshold is not None:
-                    reranker_params["reranking_threshold"] = reranking_threshold
+                    reranker_params["filtering_threshold"] = reranking_threshold
                     logger.info(f"Using custom filtering threshold: {reranking_threshold}")
 
                 reranker = LLMReranker(**reranker_params)
@@ -169,8 +169,8 @@ class KnowledgeBaseTable:
 
                 # Filter by threshold
                 scores_array = np.array(scores)
-                df = df[scores_array > reranker.reranking_threshold]
-                logger.debug(f"Applied reranking with model {rerank_model}, threshold: {reranker.reranking_threshold}")
+                df = df[scores_array > reranker.filtering_threshold]
+                logger.debug(f"Applied reranking with model {rerank_model}, threshold: {reranker.filtering_threshold}")
             except Exception as e:
                 logger.error(f"Error during reranking: {str(e)}")
                 # Fallback to distance-based relevance


### PR DESCRIPTION
Added filtering_threshold to the query conditions, and it can be tested using this query:

```

SELECT *
FROM kb_custom_model_ada
WHERE content = "Kindle Voyage" AND reranking_threshold =0.6 LIMIT 5;

```

## Description

Please include a summary of the change and the issue it solves. 

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [x]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



