### PR TITLE
Fixed the Action for Enhancing Release Notes

### DIFF
--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -29,22 +29,23 @@ jobs:
           echo $RELEASE_BODY
 
           # Prepare the LLM API payload
-          payload=$(cat <<EOF
-          {
-            "model": "gpt-4",
-            "messages": [
-              {
-                "role": "system",
-                "content": "Follow the instructions to update the GitHub release notes provided below. 1. Write a section titled \"TL;DR\" that describes everything contained in the \"What's Changed\" section. Provide a description of each change listed under the \"What's Changed\" section including a short description of why is this change beneficial to users and what good it brings. Make this \"TL;DR\" section informative and divide information into sections of related items. Do not mention any change authors in the \"TL;DR\" section. 2. The input comes in the Markdown format as below. Generate the output in the Markdown format as well. 3. Final format should adhere to the following: - start with the \"TL;DR\" section, which is a summary of the \"What's Changed\" section, - follow it with a new line containing \"---\" that separates the sections, - follow it with the \"What's Changed\" section, and DO NOT change the provided \"What's Changed\" section, - generate a Markdown format output that concatenates these two sections."
-              },
-              {
-                "role": "user",
-                "content": $RELEASE_BODY
-              }
-            ]
-          }
-          EOF
-          )
+          payload=$(jq -n \
+            --arg model "gpt-4" \
+            --arg system_content "Follow the instructions to update the GitHub release notes provided below. 1. Write a section titled \"TL;DR\" that describes everything contained in the \"What's Changed\" section. Provide a description of each change listed under the \"What's Changed\" section including a short description of why is this change beneficial to users and what good it brings. Make this \"TL;DR\" section informative and divide information into sections of related items. Do not mention any change authors in the \"TL;DR\" section. 2. The input comes in the Markdown format as below. Generate the output in the Markdown format as well. 3. Final format should adhere to the following: - start with the \"TL;DR\" section, which is a summary of the \"What's Changed\" section, - follow it with a new line containing \"---\" that separates the sections, - follow it with the \"What's Changed\" section, and DO NOT change the provided \"What's Changed\" section, - generate a Markdown format output that concatenates these two sections."
+            --arg user_content "$RELEASE_BODY" \
+            '{
+              model: $model,
+              messages: [
+                {
+                  role: "system",
+                  content: $system_content
+                },
+                {
+                  role: "user",
+                  content: $user_content
+                }
+              ]
+            }')
 
           # Call the OpenAI API
           response=$(curl -s -X POST https://api.openai.com/v1/chat/completions \

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -26,7 +26,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_BODY: ${{ github.event.release.body }}
         run: |
-          echo $RELEASE_BODY
+          echo "Release body:\n$RELEASE_BODY"
 
           # Prepare the LLM API payload
           payload=$(jq -n \
@@ -47,11 +47,15 @@ jobs:
               ]
             }')
 
+          echo "Payload sent to OpenAI:\n$payload"
+
           # Call the OpenAI API
           response=$(curl -s -X POST https://api.openai.com/v1/chat/completions \
             -H "Authorization: Bearer $OPENAI_API_KEY" \
             -H "Content-Type: application/json" \
             -d "$payload")
+
+          echo "Raw response from OpenAI:\n$response"
 
           # Extract enhanced notes from the API response
           ENHANCED_NOTES=$(echo "$response" | jq -r '.choices[0].message.content')

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -58,7 +58,7 @@ jobs:
           echo "Raw response from OpenAI:\n$response"
 
           # Extract enhanced notes from the API response
-          ENHANCED_NOTES=$(echo "$response" | jq -r '.choices[0].message.content')
+          ENHANCED_NOTES=$(echo "$response" | jq -r '.choices[0].message.content // empty')
 
           if [ -z "$ENHANCED_NOTES" ]; then
             echo "LLM enhancement failed. Exiting."

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -208,11 +208,5 @@ jobs:
           do
             pytest --cov=mindsdb/integrations/handlers/${handler}_handler tests/unit/handlers/test_${handler}.py 
           done
-
-          # Dont run coveralls for PRs from forks
-          if [ ${{ github.event.pull_request.head.repo.full_name }} == ${{ github.repository }} ]; then
-            coveralls --service=github --basedir=mindsdb/integrations/handlers
-          fi
         env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           github_token: ${{ secrets.REPO_DISPATCH_PAT_TOKEN }}


### PR DESCRIPTION
## Description

This PR fixes the GitHub Action for enhancing release notes with the use of a LLM.

Fixes https://linear.app/mindsdb/issue/BE-870/fix-the-github-action-for-generating-release-notes

This issue was caused as a result of an incorrect payload that was being passed in the body of the API call:
<img width="1512" alt="Screenshot 2025-04-06 at 15 44 56" src="https://github.com/user-attachments/assets/8c8ccae2-47e4-43f4-be9a-655ea53fb659" />

The solution here is to use `jq` in order to format the payload better.

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.