### PR TITLE
Disabled the Default Project from Getting Dropped

### DIFF
--- a/mindsdb/interfaces/database/projects.py
+++ b/mindsdb/interfaces/database/projects.py
@@ -69,6 +69,12 @@ class Project:
         self.id = record.id
 
     def delete(self):
+        if self.record.metadata_ and self.record.metadata_.get('is_default', False):
+            raise Exception(
+                f"Project '{self.name}' can not be deleted, because it is default project."
+                "The default project can be changed in the config file or by setting the environment variable MINDSDB_DEFAULT_PROJECT."
+            )
+
         tables = self.get_tables()
         tables = [key for key, val in tables.items() if val['type'] != 'table']
         if len(tables) > 0:

--- a/mindsdb/interfaces/database/projects.py
+++ b/mindsdb/interfaces/database/projects.py
@@ -472,7 +472,7 @@ class ProjectController:
 
         if new_metadata is not None:
             project.metadata = new_metadata
-            project.record.metadata = new_metadata
+            project.record.metadata_ = new_metadata
             flag_modified(project.record, 'metadata_')
 
         db.session.commit()


### PR DESCRIPTION
## Description

This PR disables the default project of MindsDB from being dropped.

Furthermore, a provision has been put in place to allow users of older versions of the application to run the app without crashing if they have in fact dropped the default project.

Fixes https://linear.app/mindsdb/issue/BE-889/fix-default-project-issue

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.