### PR TITLE
Update AWS metadata method

### DIFF
--- a/mindsdb/utilities/auth.py
+++ b/mindsdb/utilities/auth.py
@@ -16,8 +16,6 @@ def get_aws_meta_data() -> dict:
         'instance-id': None
     }
     aws_token = requests.put("http://169.254.169.254/latest/api/token", headers={'X-aws-ec2-metadata-token-ttl-seconds': '30'}).text
-    print("----------------------------------------------------------------------------")
-    print(aws_token)
     for key in aws_meta_data.keys():
         resp = requests.get(
             f'http://169.254.169.254/latest/meta-data/{key}',

--- a/mindsdb/utilities/auth.py
+++ b/mindsdb/utilities/auth.py
@@ -15,9 +15,13 @@ def get_aws_meta_data() -> dict:
         'ami-id': None,
         'instance-id': None
     }
+    aws_token = requests.put("http://169.254.169.254/latest/api/token", headers={'X-aws-ec2-metadata-token-ttl-seconds': '30'}).text
+    print("----------------------------------------------------------------------------")
+    print(aws_token)
     for key in aws_meta_data.keys():
         resp = requests.get(
             f'http://169.254.169.254/latest/meta-data/{key}',
+            headers={'X-aws-ec2-metadata-token': aws_token},
             timeout=1
         )
         if resp.status_code != 200:
@@ -35,7 +39,9 @@ def register_oauth_client():
     aws_meta_data = get_aws_meta_data()
 
     current_aws_meta_data = config.get('aws_meta_data', {})
-    oauth_meta = config.get('auth', {}).get('oauth', {})
+    oauth_meta = config.get('auth', {}).get('oauth')
+    if oauth_meta is None:
+        return
 
     public_hostname = aws_meta_data['public-hostname']
     if (


### PR DESCRIPTION
AWS has sunset the v1 version of metadata api we were using. We now need a session token to get the info we need