### PR TITLE
ChromaDB: cosine is default distance

### DIFF
--- a/docs/integrations/vector-db-integrations/chromadb.mdx
+++ b/docs/integrations/vector-db-integrations/chromadb.mdx
@@ -27,7 +27,7 @@ WITH ENGINE = 'chromadb'
 PARAMETERS = {
     "host": "YOUR_HOST",
     "port": YOUR_PORT,
-    "distance": "l2/cosine/ip" -- optional
+    "distance": "l2/cosine/ip" -- optional, default is cosine
 }
 ```
 

--- a/docs/integrations/vector-db-integrations/chromadb.mdx
+++ b/docs/integrations/vector-db-integrations/chromadb.mdx
@@ -19,38 +19,39 @@ Before proceeding, ensure the following prerequisites are met:
 
 This handler is implemented using the `chromadb` Python library.
 
-The required arguments to establish a connection are:
-* `host`: the host name or IP address of the ChromaDB instance.
-* `port`: the TCP/IP port of the ChromaDB instance.
-
-OR
-
-* `persist_directory`: the directory to use for persisting data.
-
-<Tip>
-The `host` and `port` arguments should be provided if you want to connect to a remote ChromaDB instance. Otherwise, the `persist_directory` argument should be provided. This will create an in-memory ChromaDB instance.
-</Tip> 
-
-To connect to a remote ChromaDB instance, the following CREATE DATABASE can be used:
+To connect to a remote ChromaDB instance, use the following statement:
 
 ```sql
 CREATE DATABASE chromadb_datasource
 WITH ENGINE = 'chromadb'
 PARAMETERS = {
     "host": "YOUR_HOST",
-    "port": YOUR_PORT
+    "port": YOUR_PORT,
+    "distance": "l2/cosine/ip" -- optional
 }
 ```
 
-Alternateively, to connect to an in-memory ChromaDB instance, the following CREATE DATABASE can be used:
+The required parameters are:
+
+* `host`: The host name or IP address of the ChromaDB instance.
+* `port`: The TCP/IP port of the ChromaDB instance.
+* `distance`: It defines how the distance between vectors is calculated. Available method include l2, cosine, and ip, as [explained here](https://docs.trychroma.com/docs/collections/configure).
+
+To connect to an in-memory ChromaDB instance, use the following statement:
 
 ```sql
 CREATE DATABASE chromadb_datasource
 WITH ENGINE = "chromadb",
 PARAMETERS = {
-    "persist_directory": "YOUR_PERSIST_DIRECTORY"
+    "persist_directory": "YOUR_PERSIST_DIRECTORY",
+    "distance": "l2/cosine/ip" -- optional
 }
 ```
+
+The required parameters are:
+
+* `persist_directory`: The directory to use for persisting data.
+* `distance`: It defines how the distance between vectors is calculated. Available method include l2, cosine, and ip, as [explained here](https://docs.trychroma.com/docs/collections/configure).
 
 ## Usage
 

--- a/mindsdb/integrations/handlers/chromadb_handler/README.md
+++ b/mindsdb/integrations/handlers/chromadb_handler/README.md
@@ -1,69 +1,96 @@
-# ChromaDB Handler
+---
+title: ChromaDB
+sidebarTitle: ChromaDB
+---
 
-This is the implementation of the ChromaDB for MindsDB.
+In this section, we present how to connect ChromaDB to MindsDB.
 
-## ChromaDB
+[ChromaDB](https://www.trychroma.com/) is the open-source embedding database. Chroma makes it easy to build LLM apps by making knowledge, facts, and skills pluggable for LLMs.
 
-Chroma is the open-source embedding database. Chroma makes it easy to build LLM apps by making knowledge, facts, and skills pluggable for LLMs.
+## Prerequisites
 
-## Implementation
+Before proceeding, ensure the following prerequisites are met:
 
-This handler uses `chromadb` python library connect to a chromadb instance, it uses langchain to make use of their pre-existing semantic search functionality
+1. Install MindsDB locally via [Docker](/setup/self-hosted/docker) or [Docker Desktop](/setup/self-hosted/docker-desktop).
+2. To connect ChromaDB to MindsDB, install the required dependencies following [this instruction](/setup/self-hosted/docker#install-dependencies).
+3. Install or ensure access to ChromaDB.
 
-The required arguments to establish a connection are:
+## Connection
 
-* `host`: the host name or IP address of the ChromaDB instance
-* `port`: the port to use when connecting
-* `persist_directory`: the directory to use for persisting data
+This handler is implemented using the `chromadb` Python library.
 
+To connect to a remote ChromaDB instance, use the following statement:
+
+```sql
+CREATE DATABASE chromadb_datasource
+WITH ENGINE = 'chromadb'
+PARAMETERS = {
+    "host": "YOUR_HOST",
+    "port": YOUR_PORT,
+    "distance": "l2/cosine/ip" -- optional
+}
+```
+
+The required parameters are:
+
+* `host`: The host name or IP address of the ChromaDB instance.
+* `port`: The TCP/IP port of the ChromaDB instance.
+* `distance`: It defines how the distance between vectors is calculated. Available method include l2, cosine, and ip, as [explained here](https://docs.trychroma.com/docs/collections/configure).
+
+To connect to an in-memory ChromaDB instance, use the following statement:
+
+```sql
+CREATE DATABASE chromadb_datasource
+WITH ENGINE = "chromadb",
+PARAMETERS = {
+    "persist_directory": "YOUR_PERSIST_DIRECTORY",
+    "distance": "l2/cosine/ip" -- optional
+}
+```
+
+The required parameters are:
+
+* `persist_directory`: The directory to use for persisting data.
+* `distance`: It defines how the distance between vectors is calculated. Available method include l2, cosine, and ip, as [explained here](https://docs.trychroma.com/docs/collections/configure).
 
 ## Usage
 
-In order to make use of this handler and connect to a hosted ChromaDB instance in MindsDB, the following syntax can be used:
+Now, you can use the established connection to create a collection (or table in the context of MindsDB) in ChromaDB and insert data into it:
 
 ```sql
-CREATE DATABASE chroma_dev
-WITH ENGINE = "chromadb",
-PARAMETERS = {
-   "host": "localhost",
-   "port": "8000"
-    }
-```
-
-Another option is to use in memory ChromaDB instance, you can do so by using the following syntax:
-
-```sql
-CREATE DATABASE chroma_dev
-WITH ENGINE = "chromadb",
-PARAMETERS = {
-   "persist_directory": "<persist_directory>"
-    }
-```
-
-You can insert data into a new collection like so
-
-```sql
-create table chroma_dev.test_embeddings (
-SELECT embeddings,'{"source": "fda"}' as metadata FROM mysql_demo_db.test_embeddings
+CREATE TABLE chromadb_datasource.test_embeddings (
+    SELECT embeddings,'{"source": "fda"}' as metadata
+    FROM mysql_datasource.test_embeddings
 );
 ```
 
-You can query a collection within your ChromaDB as follows:
+<Note>
+`mysql_datasource` is another MindsDB data source that has been created by connecting to a MySQL database. The `test_embeddings` table in the `mysql_datasource` data source contains the embeddings that we want to store in ChromaDB.
+</Note>
+
+You can query your collection (table) as shown below:
 
 ```sql
-SELECT * FROM chroma_dev.test_embeddings;
+SELECT * 
+FROM chromadb_datasource.test_embeddings;
 ```
 
-filter by metadata
+To filter the data in your collection (table) by metadata, you can use the following query:
 
 ```sql
-SELECT * FROM chroma_dev.test_embeddings
-where `metadata.source` = "fda";
+SELECT * 
+FROM chromadb_datasource.test_embeddings
+WHERE `metadata.source` = "fda";
+
 ```
 
-search for similar embeddings
+To conduct a similarity search, the following query can be used:
 
 ```sql
-SELECT * FROM chroma_dev.test_embeddings
-WHERE search_vector = (select embeddings from mysql_demo_db.test_embeddings limit 1);
-```
+SELECT *
+FROM chromadb_datasource.test_embeddings
+WHERE search_vector = (
+    SELECT embeddings
+    FROM mysql_datasource.test_embeddings
+    LIMIT 1
+);

--- a/mindsdb/integrations/handlers/chromadb_handler/README.md
+++ b/mindsdb/integrations/handlers/chromadb_handler/README.md
@@ -27,7 +27,7 @@ WITH ENGINE = 'chromadb'
 PARAMETERS = {
     "host": "YOUR_HOST",
     "port": YOUR_PORT,
-    "distance": "l2/cosine/ip" -- optional
+    "distance": "l2/cosine/ip" -- optional, default is cosine
 }
 ```
 

--- a/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
@@ -68,6 +68,10 @@ class ChromaDBHandler(VectorStoreHandler):
             "persist_directory": self.persist_directory,
         }
 
+        self.create_collection_metadata = {
+            "hnsw:space": config.distance,
+        }
+
         self._use_handler_storage = False
 
         self.connect()
@@ -397,7 +401,7 @@ class ChromaDBHandler(VectorStoreHandler):
         Insert/Upsert data into ChromaDB collection.
         If records with same IDs exist, they will be updated.
         """
-        collection = self._client.get_or_create_collection(collection_name)
+        collection = self._client.get_or_create_collection(collection_name, metadata=self.create_collection_metadata)
 
         # Convert metadata from string to dict if needed
         if TableField.METADATA.value in df.columns:
@@ -483,7 +487,8 @@ class ChromaDBHandler(VectorStoreHandler):
         """
         Create a collection with the given name in the ChromaDB database.
         """
-        self._client.create_collection(table_name, get_or_create=if_not_exists)
+        self._client.create_collection(table_name, get_or_create=if_not_exists,
+                                       metadata=self.create_collection_metadata)
         self._sync()
 
     def drop_table(self, table_name: str, if_exists=True):

--- a/mindsdb/integrations/handlers/chromadb_handler/settings.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/settings.py
@@ -14,6 +14,7 @@ class ChromaHandlerConfig(BaseModel):
     host: str = None
     port: str = None
     password: str = None
+    distance: str = 'cosine'
 
     class Config:
         extra = "forbid"

--- a/tests/integration_tests/knowledge_bases/test_kb_sql.py
+++ b/tests/integration_tests/knowledge_bases/test_kb_sql.py
@@ -176,7 +176,7 @@ class KBTest(KBTestBase):
         assert len(ret) == 4
 
         print('Limit with content')
-        ret = self.run_sql("select id, chunk_content from kb_crm where content = 'help' limit 4")
+        ret = self.run_sql("select id, chunk_content, distance from kb_crm where content = 'help' limit 4")
         assert len(ret) == 4
         assert ret['id'][0] == '1000'  # id is string
 


### PR DESCRIPTION
## Description

Default distance for chromadb is cosine, it is the same distance as in pgvector
To switch to previous behaviour:
```sql
CREATE DATABASE l2_chroma
    WITH
    ENGINE = "chromadb"
    PARAMETERS = {
        "persist_directory": '/srv/chromadb',  -- optional
        "distance": "l2"  -- optional
    };
```
Possible options for distance: l2, cosine, ip ([more info](https://docs.trychroma.com/docs/collections/configure))

Fixes #issue_number

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)
- [x] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)


## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



