### PR TITLE
Default limit in KB controller

### DIFF
--- a/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
@@ -244,12 +244,6 @@ class ChromaDBHandler(VectorStoreHandler):
         offset: int = None,
         limit: int = None,
     ) -> pd.DataFrame:
-        # Set default limit if conditions are present
-        if conditions:
-            if limit is None:
-                limit = 10
-            elif limit > 100:
-                limit = 100
 
         collection = self._client.get_collection(table_name)
         filters = self._translate_metadata_condition(conditions)

--- a/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
+++ b/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
@@ -270,13 +270,6 @@ class PgVectorHandler(PostgresHandler, VectorStoreHandler):
         if columns is None:
             columns = ["id", "content", "embeddings", "metadata"]
 
-        # Set default limit if conditions are present
-        if conditions:
-            if limit is None:
-                limit = 10
-            elif limit > 100:
-                limit = 100
-
         query = self._build_select_query(table_name, columns, conditions, limit, offset)
         result = self.raw_query(query)
 

--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -184,6 +184,16 @@ class KnowledgeBaseTable:
         logger.debug(f"Extracted query text: {query_text}")
 
         self.addapt_conditions_columns(conditions)
+
+        # Set default limit if query are present
+        if query_text is not None:
+            limit = query.limit.value if query.limit is not None else None
+            if limit is None:
+                limit = 10
+            elif limit > 100:
+                limit = 100
+            query.limit = Constant(limit)
+
         df = db_handler.dispatch_select(query, conditions)
         df = self.addapt_result_columns(df)
 

--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -185,7 +185,7 @@ class KnowledgeBaseTable:
 
         self.addapt_conditions_columns(conditions)
 
-        # Set default limit if query are present
+        # Set default limit if query is present
         if query_text is not None:
             limit = query.limit.value if query.limit is not None else None
             if limit is None:

--- a/tests/integration_tests/knowledge_bases/test_kb_sql.py
+++ b/tests/integration_tests/knowledge_bases/test_kb_sql.py
@@ -383,7 +383,7 @@ class KBTest(KBTestBase):
         ret = self.run_sql("""
             SELECT *
             FROM kb_crm
-            WHERE status = "solving" AND content = "noise" AND reranking_threshold=0.65
+            WHERE status = "solving" AND content = "noise" AND relevance_threshold=0.65
         """)
         assert set(ret.metadata.apply(lambda x: x.get('status'))) == {'solving'}
         assert 'noise' in ret.chunk_content[0]  # first line contents word
@@ -419,7 +419,7 @@ class KBTest(KBTestBase):
         ret = self.run_sql("""
             SELECT *
             FROM kb_crm
-            WHERE status = "solving" AND content = "noise" AND reranking_threshold=0.8
+            WHERE status = "solving" AND content = "noise" AND relevance_threshold=0.8
         """)
         assert set(ret.metadata.apply(lambda x: x.get('status'))) == {'solving'}
         for item in ret.chunk_content:


### PR DESCRIPTION
## Description

Moved default limit in KB controller. It works only if KB is queried with content columns
If vectordb is selected there is no limit.

Fixes #issue_number

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



