### PR TITLE
Run 3.11 for Windows and Mac

### DIFF
--- a/.github/workflows/matrix_includes.json
+++ b/.github/workflows/matrix_includes.json
@@ -12,11 +12,11 @@
   {
      "runs_on": "windows-latest",
      "python-version": 3.11,
-     "runOnBranch": "main"
+     "runOnBranch": "always"
   },
   {
      "runs_on": "macos-latest",
      "python-version": 3.11,
-     "runOnBranch": "main"
+     "runOnBranch": "always"
   }
 ]

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -175,8 +175,10 @@ jobs:
           uv pip freeze
           git clone https://github.com/mindsdb/mindsdb_sql_parser.git parser_tests
       - name: Install FreeTDS (macOS)
-        if: ${{ "$RUNNER_OS" == "macOS" && needs.changes.outputs.not-docs == 'true' }}
-        run: brew install freetds
+        if: ${{ needs.changes.outputs.not-docs == 'true' }}
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            brew install freetds
       - name: Install mssql dependencies
         if: ${{ needs.changes.outputs.not-docs == 'true' }}
         env:

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -177,7 +177,7 @@ jobs:
       - name: Install FreeTDS (macOS)
         if: ${{ needs.changes.outputs.not-docs == 'true' }}
         run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then
+          if [ "$RUNNER_OS" == "macOS" ]; then
             brew install freetds
       - name: Install mssql dependencies
         if: ${{ needs.changes.outputs.not-docs == 'true' }}

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -185,7 +185,7 @@ jobs:
             export CFLAGS="-I$(brew --prefix freetds)/include"
             uv pip install pymssql==2.3.1 --no-binary :all:
           else
-            uv pip install .[pymssql]
+            uv pip install .[mssql]
           fi
           
       - name: Run unit tests

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -186,7 +186,7 @@ jobs:
           LDFLAGS: "-L$(brew --prefix freetds)/lib"
           CFLAGS: "-I$(brew --prefix freetds)/include"
         run: |
-          uv pip install --no-cache-dir .[mssql]
+          uv pip install --pre --no-binary :all: pymssql --no-cache
       - name: Run unit tests
         if: ${{ needs.changes.outputs.not-docs == 'true' }}
         run: |

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -175,7 +175,7 @@ jobs:
           uv pip freeze
           git clone https://github.com/mindsdb/mindsdb_sql_parser.git parser_tests
       - name: Install FreeTDS (macOS)
-        if: ${{ runner.os == 'macOS' && needs.changes.outputs.not-docs == 'true' }}
+        if: ${{ "$RUNNER_OS" == "Linux" && needs.changes.outputs.not-docs == 'true' }}
         run: brew install freetds
       - name: Install mssql dependencies
         if: ${{ needs.changes.outputs.not-docs == 'true' }}

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -175,7 +175,7 @@ jobs:
           uv pip freeze
           git clone https://github.com/mindsdb/mindsdb_sql_parser.git parser_tests
       - name: Install FreeTDS (macOS)
-        if: ${{ "$RUNNER_OS" == "Linux" && needs.changes.outputs.not-docs == 'true' }}
+        if: ${{ "$RUNNER_OS" == "macOS" && needs.changes.outputs.not-docs == 'true' }}
         run: brew install freetds
       - name: Install mssql dependencies
         if: ${{ needs.changes.outputs.not-docs == 'true' }}

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -181,7 +181,7 @@ jobs:
             brew install freetds
           elif [[ "$RUNNER_OS" == "Linux" ]]; then
             sudo apt-get update -y
-            sudo apt-get install -y freetds-dev
+            sudo apt-get install -y freetds-dev libkrb5-dev
           fi
       - name: Install mssql dependencies
         if: ${{ needs.changes.outputs.not-docs == 'true' }}

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -189,7 +189,7 @@ jobs:
             export LDFLAGS="-L$(brew --prefix freetds)/lib"
             export CFLAGS="-I$(brew --prefix freetds)/include"
           fi
-          uv pip install --pre --no-binary :all: pymssql --no-cache --force
+          uv pip install pymssql==2.3.1 --no-binary :all:
       - name: Run unit tests
         if: ${{ needs.changes.outputs.not-docs == 'true' }}
         run: |

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -182,10 +182,13 @@ jobs:
           fi
       - name: Install mssql dependencies
         if: ${{ needs.changes.outputs.not-docs == 'true' }}
-        env:
-          LDFLAGS: "-L$(brew --prefix freetds)/lib"
-          CFLAGS: "-I$(brew --prefix freetds)/include"
         run: |
+          # Set FreeTDS build flags only on macOS
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            echo "Setting FreeTDS flags for macOS pymssql build"
+            export LDFLAGS="-L$(brew --prefix freetds)/lib"
+            export CFLAGS="-I$(brew --prefix freetds)/include"
+          fi
           uv pip install --pre --no-binary :all: pymssql --no-cache
       - name: Run unit tests
         if: ${{ needs.changes.outputs.not-docs == 'true' }}

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -179,6 +179,9 @@ jobs:
         run: |
           if [ "$RUNNER_OS" == "macOS" ]; then
             brew install freetds
+          elif [[ "$RUNNER_OS" == "Linux" ]]; then
+            sudo apt-get update -y
+            sudo apt-get install -y freetds-dev
           fi
       - name: Install mssql dependencies
         if: ${{ needs.changes.outputs.not-docs == 'true' }}

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -154,16 +154,12 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "**/requirements*.txt"
-      - name: Install FreeTDS (macOS)
-        if: ${{ runner.os == 'macOS' && needs.changes.outputs.not-docs == 'true' }}
-        run: brew install freetds
       - name: Install dependencies
         if: ${{ needs.changes.outputs.not-docs == 'true' }}
         run: |
           uv pip install .
           uv pip install -r requirements/requirements-test.txt
           uv pip install .[lightwood]  # TODO: for now some tests rely on lightwood
-          uv pip install .[mssql]
           uv pip install .[clickhouse]
           uv pip install .[snowflake]
           uv pip install .[web]
@@ -178,6 +174,16 @@ jobs:
           uv pip install .[mysql]
           uv pip freeze
           git clone https://github.com/mindsdb/mindsdb_sql_parser.git parser_tests
+      - name: Install FreeTDS (macOS)
+        if: ${{ runner.os == 'macOS' && needs.changes.outputs.not-docs == 'true' }}
+        run: brew install freetds
+      - name: Install mssql dependencies
+        if: ${{ needs.changes.outputs.not-docs == 'true' }}
+        env:
+          LDFLAGS: "-L$(brew --prefix freetds)/lib"
+          CFLAGS: "-I$(brew --prefix freetds)/include"
+        run: |
+          uv pip install --no-cache-dir .[mssql]
       - name: Run unit tests
         if: ${{ needs.changes.outputs.not-docs == 'true' }}
         run: |

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -189,7 +189,7 @@ jobs:
             export LDFLAGS="-L$(brew --prefix freetds)/lib"
             export CFLAGS="-I$(brew --prefix freetds)/include"
           fi
-          uv pip install --pre --no-binary :all: pymssql --no-cache
+          uv pip install --pre --no-binary :all: pymssql --no-cache --force
       - name: Run unit tests
         if: ${{ needs.changes.outputs.not-docs == 'true' }}
         run: |

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -174,25 +174,20 @@ jobs:
           uv pip install .[mysql]
           uv pip freeze
           git clone https://github.com/mindsdb/mindsdb_sql_parser.git parser_tests
-      - name: Install FreeTDS (macOS)
-        if: ${{ needs.changes.outputs.not-docs == 'true' }}
-        run: |
-          if [ "$RUNNER_OS" == "macOS" ]; then
-            brew install freetds
-          elif [[ "$RUNNER_OS" == "Linux" ]]; then
-            sudo apt-get update -y
-            sudo apt-get install -y freetds-dev libkrb5-dev
-          fi
       - name: Install mssql dependencies
         if: ${{ needs.changes.outputs.not-docs == 'true' }}
         run: |
           # Set FreeTDS build flags only on macOS
           if [[ "$RUNNER_OS" == "macOS" ]]; then
+            brew install freetds
             echo "Setting FreeTDS flags for macOS pymssql build"
             export LDFLAGS="-L$(brew --prefix freetds)/lib"
             export CFLAGS="-I$(brew --prefix freetds)/include"
+            uv pip install pymssql==2.3.1 --no-binary :all:
+          else
+            uv pip install .[pymssql]
           fi
-          uv pip install pymssql==2.3.1 --no-binary :all:
+          
       - name: Run unit tests
         if: ${{ needs.changes.outputs.not-docs == 'true' }}
         run: |

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -179,6 +179,7 @@ jobs:
         run: |
           if [ "$RUNNER_OS" == "macOS" ]; then
             brew install freetds
+          fi
       - name: Install mssql dependencies
         if: ${{ needs.changes.outputs.not-docs == 'true' }}
         env:


### PR DESCRIPTION
## Description

This PR updates the matrix for tests to always run on Windows and Mac using Python 3.11. On ubuntu we keep 3.10 until we migrate our Docker image to 3.11


## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [X] Relevant unit and integration tests are updated or added.



