### PR TITLE
Fixed DESCRIBE Commands for Objects in Projects

### DIFF
--- a/mindsdb/api/executor/command_executor.py
+++ b/mindsdb/api/executor/command_executor.py
@@ -869,6 +869,12 @@ class ExecuteCommands:
                 raise WrongArgumentError(f'Unknown describe type: {obj_type}')
 
         parts = obj_name.parts
+        if len(parts) > 2:
+            raise WrongArgumentError(
+                f"Invalid object name: {obj_name.to_string()}.\n"
+                "Only models support three-part namespaces."
+            )
+
         name = parts[-1]
         where = BinaryOperation(op='=', args=[
             Identifier('name'),

--- a/mindsdb/api/executor/command_executor.py
+++ b/mindsdb/api/executor/command_executor.py
@@ -868,13 +868,15 @@ class ExecuteCommands:
             else:
                 raise WrongArgumentError(f'Unknown describe type: {obj_type}')
 
-        name = obj_name.parts[-1]
+        parts = obj_name.parts
+        name = parts[-1]
         where = BinaryOperation(op='=', args=[
             Identifier('name'),
             Constant(name)
         ])
 
         if obj_type in project_objects:
+            database_name = parts[0] if len(parts) > 1 else database_name
             where = BinaryOperation(op='and', args=[
                 where,
                 BinaryOperation(op='=', args=[Identifier('project'), Constant(database_name)])


### PR DESCRIPTION
## Description

This PR fixes running `DESCRIBE` queries on objects like Knowledge Bases when the name has been prefixed by the project. For example:
`DESCRIBE KNOWLEDGE_BASE kb_proj.test_proj_kb;`

Fixes https://linear.app/mindsdb/issue/BE-903/fixed-describe-commands-for-knowledge-bases-and-other-objects-in

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

<img width="858" alt="image" src="https://github.com/user-attachments/assets/edd09fdf-1289-4f1e-bd63-be2f757b423e" />

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added.