### PR TITLE
Fixed the Name of the Knowledge Base Used in the Documentation

### DIFF
--- a/docs/mindsdb_sql/knowledge-bases.mdx
+++ b/docs/mindsdb_sql/knowledge-bases.mdx
@@ -20,7 +20,7 @@ MindsDB stores objects, such as models or knowledge bases, inside projects. Lear
 </Note>
 
 ```sql
-CREATE KNOWLEDGE_BASE test_kb_ms_teams
+CREATE KNOWLEDGE_BASE my_kb
 USING
     embedding_model = {
        "provider": "openai", -- choose one of openai or azure_openai


### PR DESCRIPTION
## Description

This PR updates the name of the created knowledge base to be consistent across the page.

Fixes #issue_number

## Type of change

- [X] 📄 This is a documentation update