### PR TITLE
Resolve bs4 deprecation warnings

### DIFF
--- a/mindsdb/integrations/handlers/web_handler/urlcrawl_helpers.py
+++ b/mindsdb/integrations/handlers/web_handler/urlcrawl_helpers.py
@@ -151,7 +151,7 @@ def get_all_website_links(url) -> dict:
             # Parse HTML content with BeautifulSoup
             soup = BeautifulSoup(content_html, "html.parser")
             content_text = get_readable_text_from_soup(soup)
-            for a_tag in soup.findAll("a"):
+            for a_tag in soup.find_all("a"):
                 href = a_tag.attrs.get("href")
                 if href == "" or href is None:
                     continue


### PR DESCRIPTION
## Description
The small PR fixes the `bs4` deprecation warnings by replacing `findAll()` with `find_all()` The resolves the warnings found in the[ CI logs](https://github.com/mindsdb/mindsdb/actions/runs/14538889061/job/40792916457#step:9:127):
```python
/Users/runner/work/mindsdb/mindsdb/mindsdb/integrations/handlers/web_handler/urlcrawl_helpers.py:154: DeprecationWarning: Call to deprecated method findAll. (Replaced by find_all) -- Deprecated since version 4.0.0.
  for a_tag in soup.findAll("a"):
```

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [x]   Test Location: Specify the URL or path for testing.
 - [x]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



