### PR TITLE
Distance setting for pgvector

### DIFF
--- a/docs/integrations/vector-db-integrations/pgvector.mdx
+++ b/docs/integrations/vector-db-integrations/pgvector.mdx
@@ -3,34 +3,43 @@ title: PGVector
 sidebarTitle: PGVector
 ---
 
-
-
 This is the implementation of the PGVector for MindsDB.
 
-## PGVector
+PGVector is an open-source vector similarity search for Postgres. It supports the following:
 
-Open-source vector similarity search for Postgres
+- exact and approximate nearest neighbor search,
+- L2 distance, inner product, and cosine distance,
+- any language with a Postgres client,
+- ACID compliance, point-in-time recovery, JOINs, and all of the other great features of Postgres.
 
-Store your vectors with the rest of your data. 
+## Connection
 
-Supports:
+This handler uses `pgvector` Python library.
 
-exact and approximate nearest neighbor search
-L2 distance, inner product, and cosine distance
-any language with a Postgres client
-Plus ACID compliance, point-in-time recovery, JOINs, and all of the other great features of Postgres
+To connect to a PGVector instance, use the following statement:
 
-## Implementation
+```sql
+CREATE DATABASE pvec
+WITH
+    ENGINE = 'pgvector',
+    PARAMETERS = {
+    "host": "127.0.0.1",
+    "port": 5432,
+    "database": "postgres",
+    "user": "user",
+    "password": "password",
+    "distance": "cosine"
+    };
+```
 
-This handler uses `pgvector` python library to make use of the vector data type in postgres created from the pgvector extension
+The required arguments to establish a connection are the following:
 
-The required arguments to establish a connection are the same as a regular postgres connection:
-
-* `host`: the host name or IP address of the postgres instance
-* `port`: the port to use when connecting
-* `database`: the database to connect to
-* `user`: the user to connect as
-* `password`: the password to use when connecting
+* `host`: The host name or IP address of the postgres instance.
+* `port`: The port to use when connecting.
+* `database`: The database to connect to.
+* `user`: The user to connect as.
+* `password`: The password to use when connecting.
+* `distance`: It defines how the distance between vectors is calculated. Available methods include cosine (default), l1, l2, ip, hamming, jaccard. [Learn more here](https://github.com/pgvector/pgvector/blob/master/README.md).
 
 ## Usage
 

--- a/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
+++ b/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
@@ -40,8 +40,31 @@ class PgVectorHandler(PostgresHandler, VectorStoreHandler):
         # we get these from the connection args on PostgresHandler parent
         self._is_sparse = self.connection_args.get('is_sparse', False)
         self._vector_size = self.connection_args.get('vector_size', None) 
-        if self._is_sparse and not self._vector_size:
-            raise ValueError("vector_size is required when is_sparse=True")
+
+        if self._is_sparse:
+            if not self._vector_size:
+                raise ValueError("vector_size is required when is_sparse=True")
+
+                # Use inner product for sparse vectors
+                distance_op = "<#>"
+
+        else:
+            distance_op = '<=>'
+            if 'distance' in self.connection_args:
+                distance_ops = {
+                    'l1': '<+>',
+                    'l2': '<->',
+                    'ip': '<#>',  # inner product
+                    'cosine': '<=>',
+                    'hamming': '<~>',
+                    'jaccard': '<%>'
+                }
+
+                distance_op = distance_ops.get(self.connection_args['distance'])
+                if distance_op is None:
+                    raise ValueError(f'Wrong distance type. Allowed options are {list(distance_ops.keys())}')
+
+        self.distance_op = distance_op
         self.connect()
 
     def _make_connection_args(self):
@@ -224,20 +247,16 @@ class PgVectorHandler(PostgresHandler, VectorStoreHandler):
                         from pgvector.utils import SparseVector
                         embedding = SparseVector(search_vector, self._vector_size)
                         search_vector = embedding.to_text()
-                    # Use inner product for sparse vectors
-                    distance_op = "<#>"
                 else:
                     # Convert list to vector string if needed
                     if isinstance(search_vector, list):
                         search_vector = f"[{','.join(str(x) for x in search_vector)}]"
-                    # Use cosine similarity for dense vectors
-                    distance_op = "<=>"
 
                 # Calculate distance as part of the query if needed
                 if has_distance:
-                    targets = f"{targets}, (embeddings {distance_op} '{search_vector}') as distance"
+                    targets = f"{targets}, (embeddings {self.distance_op} '{search_vector}') as distance"
                 
-                return f"SELECT {targets} FROM {table_name} {where_clause} ORDER BY embeddings {distance_op} '{search_vector}' ASC {limit_clause} {offset_clause} "
+                return f"SELECT {targets} FROM {table_name} {where_clause} ORDER BY embeddings {self.distance_op} '{search_vector}' ASC {limit_clause} {offset_clause} "
 
             else:
                 # if filter conditions, return rows that satisfy the conditions

--- a/tests/integration_tests/knowledge_bases/test_kb_sql.py
+++ b/tests/integration_tests/knowledge_bases/test_kb_sql.py
@@ -419,13 +419,14 @@ class KBTest(KBTestBase):
             );
         """)
 
-        ret = self.run_sql("""
+        threshold = 0.5
+        ret = self.run_sql(f"""
             SELECT *
             FROM kb_crm
-            WHERE status = "solving" AND content = "noise" AND relevance_threshold=0.8
+            WHERE status = "solving" AND content = "noise" AND relevance_threshold={threshold}
         """)
         assert set(ret.metadata.apply(lambda x: x.get('status'))) == {'solving'}
         for item in ret.chunk_content:
             assert 'noise' in item  # all lines line contents word
 
-        assert len(ret[ret.relevance < 0.8]) == 0
+        assert len(ret[ret.relevance < threshold]) == 0


### PR DESCRIPTION
## Description

Added optional `distance` setting for pgvector handler
Posible options for it:  cosine (default),  l1, l2, ip, hamming, jaccard ([more info](https://github.com/pgvector/pgvector?tab=readme-ov-file#querying))

Example:
```sql
CREATE DATABASE pvec
WITH
    ENGINE = 'pgvector',
    PARAMETERS = {
      "host": "127.0.0.1",
      "port": 5432,
      "database": "postgres",
      "user": "user",
      "password": "password",
      "distance": "l2" -- optional, default is cosine
    };
```

Fixes #issue_number

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



