### PR TITLE
Added Support for Pre-defined MindsDB Models for Re-ranking in Knowledge Bases

### DIFF
--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -885,7 +885,7 @@ class KnowledgeBaseController:
             raise EntityExistsError("Knowledge base already exists", name)
 
         embedding_model_params = get_model_params(params.get('embedding_model', {}), 'default_embedding_model')
-        reranking_model_params = get_model_params(params.get('reranking_model', {}), 'default_reranking_model')
+        reranking_model_params = get_model_params(params.get('reranking_model', {}), 'default_llm')
 
         if embedding_model:
             model_name = embedding_model.parts[-1]

--- a/mindsdb/interfaces/storage/db.py
+++ b/mindsdb/interfaces/storage/db.py
@@ -519,10 +519,18 @@ class KnowledgeBase(Base):
         ForeignKey("predictor.id", name="fk_knowledge_base_embedding_model_id"),
         doc="fk to the embedding model",
     )
-
     embedding_model = relationship(
         "Predictor", foreign_keys=[embedding_model_id], doc="embedding model"
     )
+
+    reranking_model_id = Column(
+        ForeignKey("predictor.id", name="fk_knowledge_base_reranking_model_id"),
+        doc="fk to the reranking model",
+    )
+    reranking_model = relationship(
+        "Predictor", foreign_keys=[reranking_model_id], doc="reranking model"
+    )
+
     query_id = Column(Integer, nullable=True)
 
     created_at = Column(DateTime, default=datetime.datetime.now)
@@ -542,6 +550,7 @@ class KnowledgeBase(Base):
             "name": self.name,
             "project_id": self.project_id,
             "embedding_model": None if self.embedding_model is None else self.embedding_model.name,
+            "reranking_model": None if self.reranking_model is None else self.reranking_model.name,
             "vector_database": None if self.vector_database is None else self.vector_database.name,
             "vector_database_table": self.vector_database_table,
             "updated_at": self.updated_at,

--- a/mindsdb/migrations/versions/2025-04-23_c059a40d41f1_added_reranking_model_id_to_knowledge_.py
+++ b/mindsdb/migrations/versions/2025-04-23_c059a40d41f1_added_reranking_model_id_to_knowledge_.py
@@ -23,7 +23,7 @@ def upgrade():
         batch_op.add_column(sa.Column("reranking_model_id", sa.Integer(), nullable=True))
         batch_op.create_foreign_key(
             "fk_knowledge_base_reranking_model_id",
-            "predictor"
+            "predictor",
             ["reranking_model_id"],
             ["id"]
         )

--- a/mindsdb/migrations/versions/2025-04-23_c059a40d41f1_added_reranking_model_id_to_knowledge_.py
+++ b/mindsdb/migrations/versions/2025-04-23_c059a40d41f1_added_reranking_model_id_to_knowledge_.py
@@ -1,0 +1,35 @@
+"""added_reranking_model_id_to_knowledge_bases
+
+Revision ID: c059a40d41f1
+Revises: fda503400e43
+Create Date: 2025-04-23 19:20:25.966894
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import mindsdb.interfaces.storage.db  # noqa
+
+
+
+# revision identifiers, used by Alembic.
+revision = 'c059a40d41f1'
+down_revision = 'fda503400e43'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('knowledge_base', schema=None) as batch_op:
+        batch_op.add_column(sa.Column("reranking_model_id", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_knowledge_base_reranking_model_id",
+            "predictor"
+            ["reranking_model_id"],
+            ["id"]
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('knowledge_base', schema=None) as batch_op:
+        batch_op.drop_constraint("fk_knowledge_base_reranking_model_id", type_="foreignkey")
+        batch_op.drop_column("reranking_model_id")


### PR DESCRIPTION
## Description

Please include a summary of the change and the issue it solves. 

Fixes https://linear.app/mindsdb/issue/BE-905/enable-the-specification-of-default-models-for-kbs-and-other

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



