### PR TITLE
Potential fix for code scanning alert no. 41: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/build_deploy_dev.yml
+++ b/.github/workflows/build_deploy_dev.yml
@@ -1,7 +1,7 @@
 name: Build and deploy to dev
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize, labeled]
     branches:
       - 'main'


### PR DESCRIPTION
Potential fix for [https://github.com/mindsdb/mindsdb/security/code-scanning/41](https://github.com/mindsdb/mindsdb/security/code-scanning/41)

To fix the issue, we need to ensure that untrusted code from pull requests does not execute in the context of the default branch. This can be achieved by replacing the `pull_request_target` event with the `pull_request` event. The `pull_request` event runs in the context of the pull request branch, which isolates it from the default branch and prevents privilege escalation. Additionally, we should validate cache contents before use and ensure that cache keys are scoped to the pull request branch.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
