### PR TITLE
Fix getting columns for information schema

### DIFF
--- a/mindsdb/api/executor/datahub/datanodes/information_schema_datanode.py
+++ b/mindsdb/api/executor/datahub/datanodes/information_schema_datanode.py
@@ -22,6 +22,8 @@ from .mindsdb_tables import (
     ModelsTable, DatabasesTable, MLEnginesTable, HandlersTable, JobsTable, QueriesTable,
     ChatbotsTable, KBTable, SkillsTable, AgentsTable, ViewsTable, TriggersTable)
 
+from mindsdb.api.executor.datahub.classes.tables_row import TablesRow
+
 
 logger = log.getLogger(__name__)
 
@@ -166,11 +168,10 @@ class InformationSchemaDataNode(DataNode):
         return [x.lower() for x in projects]
 
     def get_tables(self):
-        return {
-            name: table
-            for name, table in self.tables.items()
-            if table.visible
-        }
+        return [
+            TablesRow(TABLE_NAME=name)
+            for name in self.tables.keys()
+        ]
 
     def query(self, query: ASTNode, session=None) -> DataHubResponse:
         query_tables = [x[1] for x in get_query_tables(query)]

--- a/mindsdb/api/executor/datahub/datanodes/system_tables.py
+++ b/mindsdb/api/executor/datahub/datanodes/system_tables.py
@@ -311,20 +311,17 @@ class ColumnsTable(Table):
         result = []
         for db_name in databases:
             tables = {}
-            if db_name == 'information_schema':
-                for table_name, table in inf_schema.tables.items():
-                    tables[table_name] = [
-                        {'name': name} for name in table.columns
-                    ]
-            else:
-                dn = inf_schema.get(db_name)
-                if dn is None:
-                    continue
 
-                if tables_names is None:
-                    tables_names = [t.TABLE_NAME for t in dn.get_tables()]
-                for table_name in tables_names:
-                    tables[table_name] = dn.get_table_columns_df(table_name)
+            dn = inf_schema.get(db_name)
+            if dn is None:
+                continue
+
+            if tables_names is None:
+                list_tables = [t.TABLE_NAME for t in dn.get_tables()]
+            else:
+                list_tables = tables_names
+            for table_name in list_tables:
+                tables[table_name] = dn.get_table_columns_df(table_name)
 
             for table_name, table_columns_df in tables.items():
                 for _, row in table_columns_df.iterrows():

--- a/tests/unit/executor/test_schema.py
+++ b/tests/unit/executor/test_schema.py
@@ -180,6 +180,14 @@ class TestSchema(BaseExecutorDummyML):
 
         # --- information_schema ---
 
+        df = self.run_sql('select * from information_schema.TABLES')
+        df = df[df.TABLE_SCHEMA == 'information_schema']
+        for table in ('TABLES', 'COLUMNS', 'MODELS', 'DATABASES', 'ML_ENGINES', 'HANDLERS', 'JOBS', 'CHATBOTS', 'KNOWLEDGE_BASES', 'AGENTS', 'VIEWS', 'TRIGGERS', 'QUERIES'):
+            assert table in list(df.TABLE_NAME)
+
+            # selectable
+            self.run_sql(f'select * from information_schema.{table}')
+
         # handlers
         df = self.run_sql('select * from information_schema.HANDLERS')
         assert 'dummy_ml' in list(df.NAME)


### PR DESCRIPTION
## Description

Fixed error `AttributeError: 'list' object has no attribute 'iterrows'` when 'columns' table is selected:
`SELECT * FROM information_schema.columns`
The information_schema_datanode didn't use 'get_table_columns_df' introduced in: 
https://github.com/mindsdb/mindsdb/pull/10663 


Fixes #issue_number

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



