### PR TITLE
Dummy embeddings for unit tests

### DIFF
--- a/tests/unit/executor/test_agent.py
+++ b/tests/unit/executor/test_agent.py
@@ -345,9 +345,9 @@ class TestKB(BaseExecutorDummyML):
                 CREATE model {name}
                 PREDICT predicted
                 using
-                  column='content',
+                  input_column='english',
                   engine='dummy_ml',
-                  output=[1,2],
+                  mode='embeddings',
                   join_learn_process=true
             '''
         )


### PR DESCRIPTION
## Description

Created function to generate embeddings for unit tests. It returns similar responses for similar string. It is required for similarity search testing in unit tests. 
Logic:
- it creates vector with dimition 25^2
- input is split by words:
  - first two symbols of the work define position in the vector
  - next 4 symbols of wht word define value of the vector (letters from left are more important)
- only latin letters are used from input

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



