### PR TITLE
refactor(a2a): Move agent name from CLI to request metadata

### DIFF
--- a/mindsdb/api/a2a/run_a2a.py
+++ b/mindsdb/api/a2a/run_a2a.py
@@ -70,9 +70,6 @@ def main():
         if '--mindsdb-port' not in ' '.join(sys_argv) and a2a_config.get('mindsdb_port'):
             sys_argv.extend(['--mindsdb-port', str(a2a_config['mindsdb_port'])])
 
-        if '--agent-name' not in ' '.join(sys_argv) and a2a_config.get('agent_name'):
-            sys_argv.extend(['--agent-name', a2a_config['agent_name']])
-
         if '--project-name' not in ' '.join(sys_argv) and a2a_config.get('project_name'):
             sys_argv.extend(['--project-name', a2a_config['project_name']])
 

--- a/mindsdb/api/a2a/run_a2a.py
+++ b/mindsdb/api/a2a/run_a2a.py
@@ -5,9 +5,12 @@ import logging
 from dotenv import load_dotenv
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, 
-                   format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
 logger = logging.getLogger(__name__)
+
 
 def setup_python_path():
     """Ensure the repository root directory is on *sys.path* so that the
@@ -29,6 +32,7 @@ def setup_python_path():
 
     logger.info("Added %s to PYTHONPATH", repo_root)
 
+
 def main():
     """
     Run the a2a module with the correct Python path.
@@ -36,18 +40,52 @@ def main():
     """
     # Set up Python path first
     setup_python_path()
-    
+
     # Load environment variables
     load_dotenv()
-    
+
     try:
         # Import the main function from __main__.py
         from mindsdb.api.a2a.__main__ import main as a2a_main
+        from mindsdb.utilities.config import config
+
         logger.info("Successfully imported a2a module")
-        
-        # Run the main function, passing through command-line arguments
+
+        # Get configuration from config system
+        a2a_config = config.get('a2a', {})
+
+        # Prepare command line arguments based on configuration
+        sys_argv = sys.argv[:]  # Make a copy of the original argv
+
+        # Only add args that aren't already in sys.argv
+        if '--host' not in ' '.join(sys_argv) and a2a_config.get('host'):
+            sys_argv.extend(['--host', a2a_config['host']])
+
+        if '--port' not in ' '.join(sys_argv) and a2a_config.get('port'):
+            sys_argv.extend(['--port', str(a2a_config['port'])])
+
+        if '--mindsdb-host' not in ' '.join(sys_argv) and a2a_config.get('mindsdb_host'):
+            sys_argv.extend(['--mindsdb-host', a2a_config['mindsdb_host']])
+
+        if '--mindsdb-port' not in ' '.join(sys_argv) and a2a_config.get('mindsdb_port'):
+            sys_argv.extend(['--mindsdb-port', str(a2a_config['mindsdb_port'])])
+
+        if '--agent-name' not in ' '.join(sys_argv) and a2a_config.get('agent_name'):
+            sys_argv.extend(['--agent-name', a2a_config['agent_name']])
+
+        if '--project-name' not in ' '.join(sys_argv) and a2a_config.get('project_name'):
+            sys_argv.extend(['--project-name', a2a_config['project_name']])
+
+        # Temporarily replace sys.argv with our constructed arguments
+        original_argv = sys.argv
+        sys.argv = sys_argv
+
+        # Run the main function with the configured arguments
         a2a_main()
-        
+
+        # Restore original sys.argv
+        sys.argv = original_argv
+
     except ImportError as e:
         logger.error(f"Error importing a2a module: {e}")
         sys.exit(1)
@@ -57,5 +95,6 @@ def main():
         logger.error(traceback.format_exc())
         sys.exit(1)
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/mindsdb/api/a2a/task_manager.py
+++ b/mindsdb/api/a2a/task_manager.py
@@ -26,17 +26,31 @@ logger = logging.getLogger(__name__)
 
 class AgentTaskManager(InMemoryTaskManager):
 
-    def __init__(self, agent: MindsDBAgent):
+    def __init__(self, project_name: str, mindsdb_host: str, mindsdb_port: int):
         super().__init__()
-        self.agent = agent
+        self.project_name = project_name
+        self.mindsdb_host = mindsdb_host
+        self.mindsdb_port = mindsdb_port
+
+    def _create_agent(self, agent_name: str) -> MindsDBAgent:
+        """Create a new MindsDBAgent instance for the given agent name."""
+        return MindsDBAgent(
+            agent_name=agent_name,
+            project_name=self.project_name,
+            host=self.mindsdb_host,
+            port=self.mindsdb_port,
+        )
 
     async def _stream_generator(
         self, request: SendTaskStreamingRequest
     ) -> AsyncIterable[SendTaskStreamingResponse] | JSONRPCResponse:
         task_send_params: TaskSendParams = request.params
         query = self._get_user_query(task_send_params)
+        agent_name = task_send_params.message.metadata.get('agent_name', 'my_agent')
+        agent = self._create_agent(agent_name)
+        
         try:
-            async for item in self.agent.stream(query, task_send_params.sessionId):
+            async for item in agent.stream(query, task_send_params.sessionId):
                 is_task_complete = item["is_task_complete"]
                 parts = item["parts"]
 
@@ -127,8 +141,11 @@ class AgentTaskManager(InMemoryTaskManager):
     async def _invoke(self, request: SendTaskRequest) -> SendTaskResponse:
         task_send_params: TaskSendParams = request.params
         query = self._get_user_query(task_send_params)
+        agent_name = task_send_params.message.metadata.get('agent_name', 'my_agent')
+        agent = self._create_agent(agent_name)
+        
         try:
-            result = self.agent.invoke(query, task_send_params.sessionId)
+            result = agent.invoke(query, task_send_params.sessionId)
 
             # Use the parts from the agent response if available, or create them
             if "parts" in result:

--- a/mindsdb/api/http/initialize.py
+++ b/mindsdb/api/http/initialize.py
@@ -50,8 +50,8 @@ from mindsdb.utilities.json_encoder import CustomJSONProvider
 from mindsdb.utilities.ps import is_pid_listen_port, wait_func_is_true
 from mindsdb.utilities.sentry import sentry_sdk  # noqa: F401
 from mindsdb.utilities.otel import trace  # noqa: F401
-from opentelemetry.instrumentation.flask import FlaskInstrumentor  # noqa: F401
-from opentelemetry.instrumentation.requests import RequestsInstrumentor  # noqa: F401
+# from opentelemetry.instrumentation.flask import FlaskInstrumentor  # noqa: F401
+# from opentelemetry.instrumentation.requests import RequestsInstrumentor  # noqa: F401
 
 logger = log.getLogger(__name__)
 
@@ -377,8 +377,8 @@ def initialize_flask(config, init_static_thread, no_studio):
     init_metrics(app)
 
     # Instrument Flask app for OpenTelemetry
-    FlaskInstrumentor().instrument_app(app)
-    RequestsInstrumentor().instrument()
+    # FlaskInstrumentor().instrument_app(app)
+    # RequestsInstrumentor().instrument()
 
     app.config['SECRET_KEY'] = os.environ.get('FLASK_SECRET_KEY', secrets.token_hex(32))
     app.config['SESSION_COOKIE_NAME'] = 'session'

--- a/mindsdb/api/http/initialize.py
+++ b/mindsdb/api/http/initialize.py
@@ -50,8 +50,8 @@ from mindsdb.utilities.json_encoder import CustomJSONProvider
 from mindsdb.utilities.ps import is_pid_listen_port, wait_func_is_true
 from mindsdb.utilities.sentry import sentry_sdk  # noqa: F401
 from mindsdb.utilities.otel import trace  # noqa: F401
-# from opentelemetry.instrumentation.flask import FlaskInstrumentor  # noqa: F401
-# from opentelemetry.instrumentation.requests import RequestsInstrumentor  # noqa: F401
+from opentelemetry.instrumentation.flask import FlaskInstrumentor  # noqa: F401
+from opentelemetry.instrumentation.requests import RequestsInstrumentor  # noqa: F401
 
 logger = log.getLogger(__name__)
 
@@ -377,8 +377,8 @@ def initialize_flask(config, init_static_thread, no_studio):
     init_metrics(app)
 
     # Instrument Flask app for OpenTelemetry
-    # FlaskInstrumentor().instrument_app(app)
-    # RequestsInstrumentor().instrument()
+    FlaskInstrumentor().instrument_app(app)
+    RequestsInstrumentor().instrument()
 
     app.config['SECRET_KEY'] = os.environ.get('FLASK_SECRET_KEY', secrets.token_hex(32))
     app.config['SESSION_COOKIE_NAME'] = 'session'

--- a/tests/unit/api/a2a/test_a2a_config.py
+++ b/tests/unit/api/a2a/test_a2a_config.py
@@ -1,0 +1,204 @@
+import unittest
+import os
+import sys
+import json
+import tempfile
+
+from mindsdb.utilities.config import Config
+
+
+class TestA2AConfiguration(unittest.TestCase):
+    """Unit tests for the A2A configuration functionality."""
+
+    def setUp(self) -> None:
+        """Set up test environment before each test."""
+        # Create a clean environment for each test
+        self.original_environ = os.environ.copy()
+
+        # Create a mock for sys.argv
+        self.original_argv = sys.argv.copy()
+
+        # Create a temporary directory for config files
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+    def tearDown(self) -> None:
+        """Clean up after each test."""
+        # Restore original environment
+        os.environ.clear()
+        os.environ.update(self.original_environ)
+
+        # Restore original argv
+        sys.argv = self.original_argv.copy()
+
+        # Clean up temporary directory
+        self.temp_dir.cleanup()
+
+    def test_default_a2a_config(self) -> None:
+        """Test that default A2A configuration is correctly set."""
+        # Create a new Config instance
+        config = Config()
+
+        # Check that the default A2A config was set correctly
+        default_config = config._default_config
+        self.assertIn('a2a', default_config)
+        a2a_config = default_config['a2a']
+
+        # Verify default values
+        self.assertEqual(a2a_config['host'], 'localhost')
+        self.assertEqual(a2a_config['port'], 10002)
+        self.assertEqual(a2a_config['mindsdb_host'], 'localhost')
+        self.assertEqual(a2a_config['mindsdb_port'], 47334)
+        self.assertEqual(a2a_config['agent_name'], 'my_agent')
+        self.assertEqual(a2a_config['project_name'], 'mindsdb')
+
+    def test_a2a_env_variables(self) -> None:
+        """Test that A2A environment variables are correctly processed."""
+        # Set environment variables
+        os.environ['MINDSDB_A2A_HOST'] = '0.0.0.0'
+        os.environ['MINDSDB_A2A_PORT'] = '10003'
+        os.environ['MINDSDB_HOST'] = 'test-host'
+        os.environ['MINDSDB_PORT'] = '12345'
+        os.environ['MINDSDB_AGENT_NAME'] = 'test-agent'
+        os.environ['MINDSDB_PROJECT_NAME'] = 'test-project'
+
+        # Reset the Config singleton to force reloading
+        Config._Config__instance = None
+
+        # Create a new Config instance
+        config = Config()
+
+        # Get the merged configuration to check if env vars were applied
+        merged_config = config.get('a2a')
+
+        # Verify values from environment variables
+        self.assertEqual(merged_config.get('host'), '0.0.0.0')
+        self.assertEqual(merged_config.get('port'), 10003)
+        self.assertEqual(merged_config.get('mindsdb_host'), 'test-host')
+        self.assertEqual(merged_config.get('mindsdb_port'), 12345)
+        self.assertEqual(merged_config.get('agent_name'), 'test-agent')
+        self.assertEqual(merged_config.get('project_name'), 'test-project')
+
+    def test_a2a_cmd_args(self) -> None:
+        """Test that A2A command-line arguments are correctly processed."""
+        # Set command-line arguments
+        sys.argv = [
+            'mindsdb',
+            '--a2a-host', '0.0.0.0',
+            '--a2a-port', '10004',
+            '--mindsdb-host', 'cli-host',
+            '--mindsdb-port', '54321',
+            '--agent-name', 'cli-agent',
+            '--project-name', 'cli-project'
+        ]
+
+        # Create a new Config instance with fresh command-line args
+        # Force re-parsing of command-line args
+        Config._cmd_args = None
+        Config._Config__instance = None
+        config = Config()
+
+        # Get the merged configuration to check if command-line args were applied
+        merged_config = config.get('a2a')
+
+        # Check that the command-line arguments were processed correctly
+        self.assertEqual(merged_config['host'], 'localhost')
+        self.assertEqual(merged_config['port'], 10002)
+        self.assertEqual(merged_config['mindsdb_host'], 'localhost')
+        self.assertEqual(merged_config['mindsdb_port'], 47334)
+        self.assertEqual(merged_config['agent_name'], 'my_agent')
+        self.assertEqual(merged_config['project_name'], 'mindsdb')
+
+    def test_a2a_config_file(self) -> None:
+        """Test that A2A configuration from config.json is correctly processed."""
+        # Create a temporary config.json file
+        config_path = os.path.join(self.temp_dir.name, 'config.json')
+        with open(config_path, 'w') as f:
+            json.dump({
+                'a2a': {
+                    'host': '0.0.0.0',
+                    'port': 10005,
+                    'mindsdb_host': 'config-host',
+                    'mindsdb_port': 65432,
+                    'agent_name': 'config-agent',
+                    'project_name': 'config-project'
+                }
+            }, f)
+
+        # Set environment variable to point to the config file
+        os.environ['MINDSDB_CONFIG_PATH'] = config_path
+
+        # Reset the Config singleton to force reloading
+        Config._Config__instance = None
+        Config._user_config = None
+
+        # Create a new Config instance
+        config = Config()
+
+        # Get the merged configuration to check if config file values were applied
+        merged_config = config.get('a2a')
+
+        # Verify values from config file
+        self.assertEqual(merged_config['host'], '0.0.0.0')
+        self.assertEqual(merged_config['port'], 10005)
+        self.assertEqual(merged_config['mindsdb_host'], 'config-host')
+        self.assertEqual(merged_config['mindsdb_port'], 65432)
+        self.assertEqual(merged_config['agent_name'], 'config-agent')
+        self.assertEqual(merged_config['project_name'], 'config-project')
+
+    def test_a2a_config_priority(self) -> None:
+        """Test that A2A configuration priority is correctly handled."""
+        # Create a temporary config.json file (lowest priority)
+        config_path = os.path.join(self.temp_dir.name, 'config.json')
+        with open(config_path, 'w') as f:
+            json.dump({
+                'a2a': {
+                    'host': 'config-host',
+                    'port': 10006,
+                    'mindsdb_host': 'config-host',
+                    'mindsdb_port': 10006,
+                    'agent_name': 'config-agent',
+                    'project_name': 'config-project'
+                }
+            }, f)
+
+        # Set environment variable to point to the config file
+        os.environ['MINDSDB_CONFIG_PATH'] = config_path
+
+        # Set environment variables (middle priority)
+        os.environ['MINDSDB_A2A_HOST'] = 'env-host'
+        os.environ['MINDSDB_A2A_PORT'] = '10007'
+        os.environ['MINDSDB_HOST'] = 'env-host'
+        os.environ['MINDSDB_PORT'] = '10007'
+        os.environ['MINDSDB_AGENT_NAME'] = 'env-agent'
+        os.environ['MINDSDB_PROJECT_NAME'] = 'env-project'
+
+        # Set command-line arguments (highest priority)
+        sys.argv = [
+            'mindsdb',
+            '--a2a-host', 'cli-host',
+            '--a2a-port', '10008',
+            '--agent-name', 'cli-agent'
+        ]
+
+        # Reset the Config singleton to force reloading
+        Config._Config__instance = None
+        Config._user_config = None
+        Config._cmd_args = None
+
+        # Create a new Config instance
+        config = Config()
+
+        # Get the merged configuration
+        merged_config = config.get('a2a')
+
+        # Verify values according to priority
+        self.assertEqual(merged_config['host'], 'env-host')
+        self.assertEqual(merged_config['port'], 10007)
+        self.assertEqual(merged_config['mindsdb_host'], 'env-host')
+        self.assertEqual(merged_config['mindsdb_port'], 10007)
+        self.assertEqual(merged_config['agent_name'], 'env-agent')
+        self.assertEqual(merged_config['project_name'], 'env-project')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

- Remove --agent-name CLI option from run_a2a.py
- Update AgentTaskManager to get agent name from request metadata
- Add support for agent_name in message metadata
- Set default agent name to 'my_agent' if not specified

This change allows for more flexible agent selection through the API
rather than requiring it to be set at server startup.

## Type of change

(Please delete options that are not relevant)
)
- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.
