### PR TITLE
Ensure file buffer is flushed before closing in file upload

### DIFF
--- a/mindsdb/api/http/namespaces/file.py
+++ b/mindsdb/api/http/namespaces/file.py
@@ -84,8 +84,14 @@ class File(Resource):
             parser.finalize()
             parser.close()
 
-            if file_object is not None and not file_object.closed:
-                file_object.close()
+            if file_object is not None:
+                if not file_object.closed:
+                    try:
+                        file_object.flush()
+                    except (AttributeError, ValueError, OSError):
+                        logger.debug("Failed to flush file_object before closing.", exc_info=True)
+                    file_object.close()
+                file_object = None
         else:
             data = request.json
 


### PR DESCRIPTION
## Description

This change ensures that the file object's buffer is explicitly flushed to disk before closing the file handle. 


## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update


## Additional Media:

![Screenshot from 2025-05-16 14-08-36](https://github.com/user-attachments/assets/18d263e4-fade-45a3-994d-a1cbf77ac9ea)



## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



