### PR TITLE
Enabled Default Re-ranking Model for Knowledge Bases

### DIFF
--- a/mindsdb/api/http/namespaces/config.py
+++ b/mindsdb/api/http/namespaces/config.py
@@ -32,7 +32,7 @@ class GetConfig(Resource):
                 'http_auth_enabled': config['auth']['http_auth_enabled']
             }
         }
-        for key in ['default_llm', 'default_embedding_model']:
+        for key in ['default_llm', 'default_embedding_model', 'default_reranking_model']:
             value = config.get(key)
             if value is not None:
                 resp[key] = value
@@ -43,7 +43,7 @@ class GetConfig(Resource):
     def put(self):
         data = request.json
 
-        allowed_arguments = {'auth', 'default_llm', 'default_embedding_model'}
+        allowed_arguments = {'auth', 'default_llm', 'default_embedding_model', 'default_reranking_model'}
         unknown_arguments = list(set(data.keys()) - allowed_arguments)
         if len(unknown_arguments) > 0:
             return http_error(

--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -233,7 +233,8 @@ class KnowledgeBaseTable:
     def add_relevance(self, df, query_text, relevance_threshold=None):
         relevance_column = TableField.RELEVANCE.value
 
-        reranking_model_params = get_model_params(self._kb.params.get("reranking_model"), "default_llm")
+        default_config_key = 'default_reranking_model' if config.get('default_reranking_model') else 'default_llm'
+        reranking_model_params = get_model_params(self._kb.params.get("reranking_model"), default_config_key)
         if reranking_model_params and query_text and len(df) > 0:
             # Use reranker for relevance score
             try:
@@ -909,7 +910,8 @@ class KnowledgeBaseController:
             model_record = db.Predictor.query.get(model['id'])
             embedding_model_id = model_record.id
 
-        reranking_model_params = get_model_params(params.get('reranking_model', {}), 'default_llm')
+        default_config_key = 'default_reranking_model' if config.get('default_reranking_model') else 'default_llm'
+        reranking_model_params = get_model_params(params.get('reranking_model', {}), default_config_key)
         if reranking_model_params:
             # Get reranking model from params.
             # This is called here to check validaity of the parameters.

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -233,7 +233,8 @@ class Config:
             },
             "default_project": "mindsdb",
             "default_llm": {},
-            "default_embedding_model": {}
+            "default_embedding_model": {},
+            "default_reranking_model": {}
         }
         # endregion
 
@@ -379,6 +380,10 @@ class Config:
         if os.environ.get('MINDSDB_DEFAULT_EMBEDDING_MODEL_API_KEY', '') != '':
             self._env_config['default_embedding_model'] = {
                 'api_key': os.environ['MINDSDB_DEFAULT_EMBEDDING_MODEL_API_KEY']
+            }
+        if os.environ.get('MINDSDB_DEFAULT_RERANKING_MODEL_API_KEY', '') != '':
+            self._env_config['default_reranking_model'] = {
+                'api_key': os.environ['MINDSDB_DEFAULT_RERANKING_MODEL_API_KEY']
             }
 
     def parse_cmd_args(self) -> None:


### PR DESCRIPTION
## Description

This PR enables users to define a default re-ranking model (`default_reranking_model`) in the configuration for use when creating knowledge bases.

Fixes https://linear.app/mindsdb/issue/UNI-76/add-default-model-configuration-for-re-ranking

## Type of change

- [X] ⚡ New feature (non-breaking change which adds functionality)
- [X] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [X] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.