### PR TITLE
Fixed Imports of Handler Utilities

### DIFF
--- a/mindsdb/integrations/handlers/bigquery_handler/bigquery_handler.py
+++ b/mindsdb/integrations/handlers/bigquery_handler/bigquery_handler.py
@@ -7,7 +7,7 @@ from mindsdb.utilities import log
 from mindsdb_sql_parser.ast.base import ASTNode
 from mindsdb.integrations.libs.base import DatabaseHandler
 from mindsdb.utilities.render.sqlalchemy_render import SqlalchemyRender
-from mindsdb.integrations.utilities.handlers.auth_utilities import GoogleServiceAccountOAuth2Manager
+from mindsdb.integrations.utilities.handlers.auth_utilities.google import GoogleServiceAccountOAuth2Manager
 from mindsdb.integrations.libs.response import (
     HandlerStatusResponse as StatusResponse,
     HandlerResponse as Response,

--- a/mindsdb/integrations/handlers/bigquery_handler/tests/test_bigquery_handler.py
+++ b/mindsdb/integrations/handlers/bigquery_handler/tests/test_bigquery_handler.py
@@ -4,7 +4,7 @@ import pandas as pd
 from google.cloud import bigquery
 
 from mindsdb.integrations.handlers.bigquery_handler.bigquery_handler import BigQueryHandler
-from mindsdb.integrations.utilities.handlers.auth_utilities import GoogleServiceAccountOAuth2Manager
+from mindsdb.integrations.utilities.handlers.auth_utilities.google import GoogleServiceAccountOAuth2Manager
 from mindsdb.integrations.libs.response import (
     HandlerResponse as Response,
     RESPONSE_TYPE,

--- a/mindsdb/integrations/handlers/gmail_handler/gmail_handler.py
+++ b/mindsdb/integrations/handlers/gmail_handler/gmail_handler.py
@@ -22,7 +22,7 @@ from email.message import EmailMessage
 
 from base64 import urlsafe_b64encode, urlsafe_b64decode
 
-from mindsdb.integrations.utilities.handlers.auth_utilities import GoogleUserOAuth2Manager
+from mindsdb.integrations.utilities.handlers.auth_utilities.google import GoogleUserOAuth2Manager
 from mindsdb.integrations.utilities.handlers.auth_utilities.exceptions import AuthException
 
 DEFAULT_SCOPES = [

--- a/mindsdb/integrations/handlers/google_calendar_handler/google_calendar_handler.py
+++ b/mindsdb/integrations/handlers/google_calendar_handler/google_calendar_handler.py
@@ -9,7 +9,7 @@ from mindsdb.integrations.libs.response import (
 )
 from mindsdb.utilities.config import Config
 from mindsdb.utilities import log
-from mindsdb.integrations.utilities.handlers.auth_utilities import GoogleUserOAuth2Manager
+from mindsdb.integrations.utilities.handlers.auth_utilities.google import GoogleUserOAuth2Manager
 from mindsdb.integrations.utilities.handlers.auth_utilities.exceptions import AuthException
 
 from .google_calendar_tables import GoogleCalendarEventsTable

--- a/mindsdb/integrations/handlers/ms_one_drive_handler/ms_one_drive_handler.py
+++ b/mindsdb/integrations/handlers/ms_one_drive_handler/ms_one_drive_handler.py
@@ -9,7 +9,7 @@ from requests.exceptions import RequestException
 
 from mindsdb.integrations.handlers.ms_one_drive_handler.ms_graph_api_one_drive_client import MSGraphAPIOneDriveClient
 from mindsdb.integrations.handlers.ms_one_drive_handler.ms_one_drive_tables import FileTable, ListFilesTable
-from mindsdb.integrations.utilities.handlers.auth_utilities import MSGraphAPIDelegatedPermissionsManager
+from mindsdb.integrations.utilities.handlers.auth_utilities.microsoft import MSGraphAPIDelegatedPermissionsManager
 from mindsdb.integrations.utilities.handlers.auth_utilities.exceptions import AuthException
 from mindsdb.integrations.libs.response import (
     HandlerResponse as Response,

--- a/mindsdb/integrations/handlers/ms_teams_handler/ms_teams_handler.py
+++ b/mindsdb/integrations/handlers/ms_teams_handler/ms_teams_handler.py
@@ -19,7 +19,7 @@ from mindsdb.integrations.libs.response import (
     HandlerStatusResponse as StatusResponse,
 )
 from mindsdb.integrations.libs.api_handler import APIChatHandler
-from mindsdb.integrations.utilities.handlers.auth_utilities import (
+from mindsdb.integrations.utilities.handlers.auth_utilities.microsoft import (
     MSGraphAPIApplicationPermissionsManager,
     MSGraphAPIDelegatedPermissionsManager
 )

--- a/mindsdb/integrations/handlers/vertex_handler/vertex_client.py
+++ b/mindsdb/integrations/handlers/vertex_handler/vertex_client.py
@@ -2,7 +2,7 @@ from mindsdb.utilities import log
 from google.cloud.aiplatform import init, TabularDataset, Model, Endpoint
 import pandas as pd
 
-from mindsdb.integrations.utilities.handlers.auth_utilities import GoogleServiceAccountOAuth2Manager
+from mindsdb.integrations.utilities.handlers.auth_utilities.google import GoogleServiceAccountOAuth2Manager
 
 logger = log.getLogger(__name__)
 

--- a/mindsdb/integrations/handlers/youtube_handler/youtube_handler.py
+++ b/mindsdb/integrations/handlers/youtube_handler/youtube_handler.py
@@ -14,7 +14,7 @@ from mindsdb.utilities.config import Config
 
 from googleapiclient.discovery import build
 
-from mindsdb.integrations.utilities.handlers.auth_utilities import GoogleUserOAuth2Manager
+from mindsdb.integrations.utilities.handlers.auth_utilities.google import GoogleUserOAuth2Manager
 
 DEFAULT_SCOPES = [
 	'https://www.googleapis.com/auth/youtube',

--- a/mindsdb/integrations/utilities/handlers/api_utilities/__init__.py
+++ b/mindsdb/integrations/utilities/handlers/api_utilities/__init__.py
@@ -1,1 +1,0 @@
-from .microsoft import MSGraphAPIBaseClient

--- a/mindsdb/integrations/utilities/handlers/auth_utilities/__init__.py
+++ b/mindsdb/integrations/utilities/handlers/auth_utilities/__init__.py
@@ -1,2 +1,0 @@
-from .google import GoogleUserOAuth2Manager, GoogleServiceAccountOAuth2Manager
-from .microsoft import MSGraphAPIApplicationPermissionsManager, MSGraphAPIDelegatedPermissionsManager

--- a/tests/unit/handlers/test_bigquery.py
+++ b/tests/unit/handlers/test_bigquery.py
@@ -19,7 +19,7 @@ class TestBigQueryHandler(unittest.TestCase):
     )
 
     def setUp(self):
-        self.patcher_get_oauth2_credentials = patch('mindsdb.integrations.utilities.handlers.auth_utilities.GoogleServiceAccountOAuth2Manager.get_oauth2_credentials')
+        self.patcher_get_oauth2_credentials = patch('mindsdb.integrations.utilities.handlers.auth_utilities.google.GoogleServiceAccountOAuth2Manager.get_oauth2_credentials')
         self.patcher_client = patch('mindsdb.integrations.handlers.bigquery_handler.bigquery_handler.Client')
         self.mock_get_oauth2_credentials = self.patcher_get_oauth2_credentials.start()
         self.mock_connect = self.patcher_client.start()


### PR DESCRIPTION
## Description

This PR fixes the imports of API and auth utilities within the handlers that they are used in.

Fixes https://linear.app/mindsdb/issue/BE-990/bigquery-integration-cannot-be-used-with-minds

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added - N/A