### PR TITLE
Fix: Broken image paths in documentation

### DIFF
--- a/docs/minds.mdx
+++ b/docs/minds.mdx
@@ -7,7 +7,7 @@ icon: "house"
 Minds are advanced AI systems designed to answer questions across connected data sources, providing comprehensive insights while reducing the time and effort needed for manual data analysis.
 
 <p align="center">
-  <img src="../assets/minds/MindsWorkflow.png"/>
+  <img src="assets/minds/MindsWorkflow.png"/>
 </p>
 
 Minds function similarly to **large language models (LLMs) but go beyond** by answering queries using any connected data. This is achieved through:

--- a/docs/minds.mdx
+++ b/docs/minds.mdx
@@ -7,7 +7,7 @@ icon: "house"
 Minds are advanced AI systems designed to answer questions across connected data sources, providing comprehensive insights while reducing the time and effort needed for manual data analysis.
 
 <p align="center">
-  <img src="/assets/minds/MindsWorkflow.png"/>
+  <img src="../assets/minds/MindsWorkflow.png"/>
 </p>
 
 Minds function similarly to **large language models (LLMs) but go beyond** by answering queries using any connected data. This is achieved through:

--- a/docs/minds/minds_overview.mdx
+++ b/docs/minds/minds_overview.mdx
@@ -26,8 +26,9 @@ Minds are composed of several key components:
 * **reasoning and decision-making tools**, which identify the most relevant data and construct an accurate response.
 
 <p align="center">
-  <img src="/assets/minds/MindsWorkflow.png"/>
+  <img src="../assets/minds/MindsWorkflow.png"/>
 </p>
+
 
 ### How It Works
 

--- a/docs/minds/quickstart.mdx
+++ b/docs/minds/quickstart.mdx
@@ -17,7 +17,7 @@ Begin your journey by signing up for your [free Minds Cloud account](https://mdb
   View and manage your Minds in the **Minds** tab. Check out the connected data sources in the **Datasources** tab. Find the API key needed to interact with Minds via the Python SDK or API endpoints in the **API Keys** tab. Access our documentation to learn more about Minds.
 
   <p align="center">
-    <img src="/assets/minds/Dashboard_Minds.png"/>
+    <img src="../assets/minds/Dashboard_Minds.png"/>
   </p>
 
 * **Upgrade options**
@@ -33,7 +33,7 @@ Dive into the Sales Manager Demo Mind to see AI in action. Here, you'll preview 
   Go to the **Datasources** tab and click on `Sales_Data_Expert_Demo_Data` to preview the available data.
 
   <p align="center">
-    <img src="/assets/minds/PreviewData_Minds.png"/>
+    <img src="../assets/minds/PreviewData_Minds.png"/>
   </p>
 
 * **Chat with the Mind**
@@ -41,7 +41,7 @@ Dive into the Sales Manager Demo Mind to see AI in action. Here, you'll preview 
   Go to the **Minds** tab and click on `Sales_Data_Expert_Demo_Mind` to enter the demo Mind. You are now in the playground where you can ask questions about the demo data, which includes customer details and call summaries.
 
   <p align="center">
-    <img src="/assets/minds/Playground_Mind.png"/>
+    <img src="../assets/minds/Playground_Mind.png"/>
   </p>
 
   The free Minds Cloud account comes with 1M tokens that you can use to ask questions over your data. If you’d like to upgrade to the enterprise version, click the *Upgrade to enterprise* button and fill out the form - our sales team will reach out to you shortly.

--- a/docs/minds/quickstart_best_practices.mdx
+++ b/docs/minds/quickstart_best_practices.mdx
@@ -11,7 +11,7 @@ Customize and enhance Minds by providing descriptions for data sources and promp
 When connecting a data source, providing a **clear and detailed description** is crucial. A well-crafted description helps the Mind select the most relevant data source when answering questions.
 
 <p align="center">
-  <img src="/assets/minds/DatasourcesConn_Minds.png"/>
+  <img src="../assets/minds/DatasourcesConn_Minds.png"/>
 </p>
 
 Here is what can be included in the description of the data source:
@@ -28,7 +28,7 @@ Here is what can be included in the description of the data source:
 When creating a Mind, the **system prompt is optional**, but it can significantly enhance functionality by defining behavior, response format, and personality.
 
 <p align="center">
-  <img src="/assets/minds/NewMind_Minds.png"/>
+  <img src="../assets/minds/NewMind_Minds.png"/>
 </p>
 
 Here is what can be included in the system prompt:

--- a/docs/minds/quickstart_custom_mind.mdx
+++ b/docs/minds/quickstart_custom_mind.mdx
@@ -11,19 +11,19 @@ This guide walks you through connecting your data and creating a Mind that can a
 Navigate to the **Datasources** tab and click the **New datasource** button.
 
 <p align="center">
-  <img src="/assets/minds/DatasourcesTab_Minds.png"/>
+  <img src="../assets/minds/DatasourcesTab_Minds.png"/>
 </p>
 
 Select one of the [supported data sources](/minds/data_sources).
 
 <p align="center">
-  <img src="/assets/minds/DatasourcesType_Minds.png"/>
+  <img src="../assets/minds/DatasourcesType_Minds.png"/>
 </p>
 
 Enter the connection parameters for your selected data source and click the `Connect` button.
 
 <p align="center">
-  <img src="/assets/minds/DatasourcesConn_Minds.png"/>
+  <img src="../assets/minds/DatasourcesConn_Minds.png"/>
 </p>
 
 The `Name your datasource` and `Description` fields are required for all data source types. The `Name your datasource` field stores the name of your data connection, while the `Description` field stores the description of your data. Note that the `Description` field can contain verbose instructions on what data is stored and how to use it. [Learn more about best practices for data descriptions](/minds/quickstart_best_practices).
@@ -33,13 +33,13 @@ The `Name your datasource` and `Description` fields are required for all data so
 Navigate to the **Minds** tab and click the **New Mind** button.
 
 <p align="center">
-  <img src="/assets/minds/MindsTab_Minds.png"/>
+  <img src="../assets/minds/MindsTab_Minds.png"/>
 </p>
 
 Enter a name for your Mind in the `Mind name` field and select one of the connected data sources. Note that upon checking the data source, you can limit the connected tables by clicking the `Select tables` button.
 
 <p align="center">
-  <img src="/assets/minds/NewMind_Minds.png"/>
+  <img src="../assets/minds/NewMind_Minds.png"/>
 </p>
 
 Now click the `Create` button to complete the creation of the Mind.
@@ -51,7 +51,7 @@ Note that in the *Settings* tab, you can add a system prompt to provide further 
 When you enter a Mind, you'll see the chat interface where you can interact with the Mind and observe its thought process as it works through your queries.
 
 <p align="center">
-  <img src="/assets/minds/MindChat_Minds.png"/>
+  <img src="../assets/minds/MindChat_Minds.png"/>
 </p>
 
 The chat interface is divided into three sections:


### PR DESCRIPTION
## Description

This PR fixes broken image links in several documentation `.mdx` files. The issue was due to incorrect relative paths used in the `<img src="...">` tags. The original image links pointed to `/assets/...`, but the images are actually located in the `/docs/assets/` directory. Since the `.mdx` files are inside nested folders like `/docs/minds/`, we updated the paths to use the correct relative format (`../assets/...`) so that the images resolve properly.

Fixes #10883

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

- [x] Test Location: Various `.mdx` documentation files under the `/docs` folder.
- [x] Verification Steps:
  1. Verified the images exist at `/docs/assets/minds/`.
  2. Located all `.mdx` files using incorrect `<img src="/assets/...">` paths.
  3. Updated each image path to a correct relative path like `../assets/minds/...` depending on the `.mdx` file location.
  4. **Note**: Final documentation rendering cannot be verified locally without full project setup. Please confirm correct rendering as part of review.

## Additional Media

- N/A

## Checklist

- [x] My code follows the style guidelines of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
