### PR TITLE
Add SSL certificate verification support to Elasticsearch handler

### DIFF
--- a/mindsdb/integrations/handlers/elasticsearch_handler/elasticsearch_handler.py
+++ b/mindsdb/integrations/handlers/elasticsearch_handler/elasticsearch_handler.py
@@ -78,11 +78,20 @@ class ElasticsearchHandler(DatabaseHandler):
             )
 
         # Optional/Additional connection parameters.
-        optional_parameters = ["hosts", "cloud_id", "api_key"]
+        optional_parameters = ["hosts", "cloud_id", "api_key", "verify_certs", "ssl_show_warn", "ssl_assert_hostname"]
         for parameter in optional_parameters:
             if parameter in self.connection_data:
                 if parameter == "hosts":
                     config["hosts"] = self.connection_data[parameter].split(",")
+                else:
+                    config[parameter] = self.connection_data[parameter]
+
+        # SSL parameter handling
+        ssl_parameters = ["verify_certs", "ssl_show_warn", "ssl_assert_hostname", "ca_certs"]
+        for parameter in ssl_parameters:
+            if parameter in self.connection_data:
+                if parameter == "verify_certs":
+                    config[parameter] = self.connection_data[parameter].lower() == "true"
                 else:
                     config[parameter] = self.connection_data[parameter]
 


### PR DESCRIPTION
## Description

This pull request adds SSL certificate verification configuration support to the MindsDB Elasticsearch handler. Previously, users encountering SSL certificate verification issues (such as ConnectionError([SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed) had no way to configure SSL settings through MindsDB's connection parameters.

This change adds support for the following SSL-related connection parameters:
- verify_certs: Enable/disable SSL certificate verification
- ssl_show_warn: Control SSL warning display
- ssl_assert_hostname: Enable/disable hostname verification

These parameters are passed directly to the underlying Elasticsearch Python client, providing users with the same SSL configuration flexibility available in the native client.

## Type of change

(Please delete options that are not relevant)

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

Create an Elasticsearch database connection with SSL verification disabled:

```sql
Copy SQL
CREATE DATABASE elasticsearch_test
WITH ENGINE = "elasticsearch",
PARAMETERS = {
    "hosts": "https://your-elasticsearch-host:9200",
    "user": "username",
    "password": "password",
    "verify_certs": "false"
};
```

Verify successful connection without SSL certificate errors
Test querying data: 

```sql
SELECT * FROM elasticsearch_test.your_index LIMIT 5;
```

Confirm that existing connections without SSL parameters continue to work normally

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.



