### PR TITLE
Fix undetectable character encodings (NoneType Error)

### DIFF
--- a/mindsdb/integrations/handlers/email_handler/email_ingestor.py
+++ b/mindsdb/integrations/handlers/email_handler/email_ingestor.py
@@ -40,6 +40,9 @@ class EmailIngestor:
         encoding = None
         if isinstance(body_str, bytes):
             encoding = chardet.detect(body_str)['encoding']
+            if encoding is None:
+                # Added a fallback to utf-8 since chardet failed to detect the encoding.
+                encoding = 'utf-8'
             if 'windows' in encoding.lower():
                 # Easier to treat this at utf-8 since str constructor doesn't support all encodings here:
                 # https://chardet.readthedocs.io/en/latest/supported-encodings.html.


### PR DESCRIPTION
## Description

Fixes an issue where the email handler would fail when processing emails with undetectable character encodings. The error occurred when `chardet.detect()` returned `None` for the encoding, causing a `NoneType` error.

Fixes #10884 

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

- [x]  Test Location: [tests/handler_tests/test_email_handler.py](cci:7://file:///home/trickster026/Desktop/open-source/mindsdb/tests/handler_tests/test_email_handler.py:0:0-0:0)
- [x] Verification Steps:
  1. Run the test suite: `pytest tests/handler_tests/test_email_handler.py::TestEmailHandler::test_undetectable_encoding_handling -v`
  2. The test verifies that:
     - Emails with undetectable encodings are processed without raising exceptions
     - The result contains all expected fields
     - The handler gracefully handles binary content in email bodies


## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.