### PR TITLE
Disabled Use of MindsDB Models for Knowledge Bases

### DIFF
--- a/mindsdb/api/executor/command_executor.py
+++ b/mindsdb/api/executor/command_executor.py
@@ -1370,6 +1370,12 @@ class ExecuteCommands:
         return ExecuteAnswer()
 
     def answer_create_kb(self, statement: CreateKnowledgeBase, database_name: str):
+        if statement.model:
+            raise ExecutorException(
+                "Creating a knowledge base using pre-existing models is no longer supported.\n"
+                "Please pass the model parameters as a JSON object in the embedding_model field."
+            )
+        
         project_name = (
             statement.name.parts[0]
             if len(statement.name.parts) > 1
@@ -1395,7 +1401,7 @@ class ExecuteCommands:
         _ = self.session.kb_controller.add(
             name=kb_name,
             project_name=project_name,
-            embedding_model=statement.model,
+            # embedding_model=statement.model,
             storage=statement.storage,
             params=statement.params,
             if_not_exists=statement.if_not_exists,

--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -903,13 +903,11 @@ class KnowledgeBaseController:
         #     else:
         #         # it is params for model
         #         embedding_params.update(params["embedding_model"])
-        
-        if 'embedding_model' in params:
-            if not isinstance(params['embedding_model'], dict):
-                raise ValueError(
-                    "embedding_model should be JSON object with model parameters."
-                )
-            embedding_params.update(params['embedding_model'])
+
+        if "embedding_model" in params:
+            if not isinstance(params["embedding_model"], dict):
+                raise ValueError("embedding_model should be JSON object with model parameters.")
+            embedding_params.update(params["embedding_model"])
 
         # if model_name is None:  # Legacy
         model_name = self._create_embedding_model(
@@ -917,7 +915,7 @@ class KnowledgeBaseController:
             params=embedding_params,
             kb_name=name,
         )
-            # if model_name is not None:  # Legacy
+        # if model_name is not None:  # Legacy
         params["created_embedding_model"] = model_name
 
         embedding_model_id = None

--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -846,11 +846,11 @@ class KnowledgeBaseController:
         self,
         name: str,
         project_name: str,
-        embedding_model: Identifier,
         storage: Identifier,
         params: dict,
         preprocessing_config: Optional[dict] = None,
         if_not_exists: bool = False,
+        # embedding_model: Identifier = None, # Legacy: Allow MindsDB models to be passed as embedding_model.
     ) -> db.KnowledgeBase:
         """
         Add a new knowledge base to the database
@@ -888,35 +888,43 @@ class KnowledgeBaseController:
 
         embedding_params = copy.deepcopy(config.get("default_embedding_model", {}))
 
-        model_name = None
-        model_project = project
-        if embedding_model:
-            model_name = embedding_model.parts[-1]
-            if len(embedding_model.parts) > 1:
-                model_project = self.session.database_controller.get_project(embedding_model.parts[-2])
+        # Legacy
+        # model_name = None
+        # model_project = project
+        # if embedding_model:
+        #     model_name = embedding_model.parts[-1]
+        #     if len(embedding_model.parts) > 1:
+        #         model_project = self.session.database_controller.get_project(embedding_model.parts[-2])
 
-        elif "embedding_model" in params:
-            if isinstance(params["embedding_model"], str):
-                # it is model name
-                model_name = params["embedding_model"]
-            else:
-                # it is params for model
-                embedding_params.update(params["embedding_model"])
+        # elif "embedding_model" in params:
+        #     if isinstance(params["embedding_model"], str):
+        #         # it is model name
+        #         model_name = params["embedding_model"]
+        #     else:
+        #         # it is params for model
+        #         embedding_params.update(params["embedding_model"])
+        
+        if 'embedding_model' in params:
+            if not isinstance(params['embedding_model'], dict):
+                raise ValueError(
+                    "embedding_model should be JSON object with model parameters."
+                )
+            embedding_params.update(params['embedding_model'])
 
-        if model_name is None:
-            model_name = self._create_embedding_model(
-                project.name,
-                params=embedding_params,
-                kb_name=name,
-            )
-            if model_name is not None:
-                params["created_embedding_model"] = model_name
+        # if model_name is None:  # Legacy
+        model_name = self._create_embedding_model(
+            project.name,
+            params=embedding_params,
+            kb_name=name,
+        )
+            # if model_name is not None:  # Legacy
+        params["created_embedding_model"] = model_name
 
         embedding_model_id = None
-        if model_name is not None:
-            model = self.session.model_controller.get_model(name=model_name, project_name=model_project.name)
-            model_record = db.Predictor.query.get(model["id"])
-            embedding_model_id = model_record.id
+        # if model_name is not None:  # Legacy
+        model = self.session.model_controller.get_model(name=model_name, project_name=project.name)
+        model_record = db.Predictor.query.get(model["id"])
+        embedding_model_id = model_record.id
 
         reranking_model_params = get_model_params(params.get("reranking_model", {}), "default_reranking_model")
         if reranking_model_params:

--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -915,14 +915,14 @@ class KnowledgeBaseController:
             params=embedding_params,
             kb_name=name,
         )
-        # if model_name is not None:  # Legacy
-        params["created_embedding_model"] = model_name
+        if model_name is not None:
+            params["created_embedding_model"] = model_name
 
         embedding_model_id = None
-        # if model_name is not None:  # Legacy
-        model = self.session.model_controller.get_model(name=model_name, project_name=project.name)
-        model_record = db.Predictor.query.get(model["id"])
-        embedding_model_id = model_record.id
+        if model_name is not None:
+            model = self.session.model_controller.get_model(name=model_name, project_name=project.name)
+            model_record = db.Predictor.query.get(model["id"])
+            embedding_model_id = model_record.id
 
         reranking_model_params = get_model_params(params.get("reranking_model", {}), "default_reranking_model")
         if reranking_model_params:

--- a/tests/unit/executor/test_agent.py
+++ b/tests/unit/executor/test_agent.py
@@ -14,6 +14,7 @@ from mindsdb.interfaces.agents.langchain_agent import SkillData
 @contextmanager
 def task_monitor():
     from mindsdb.interfaces.tasks.task_monitor import TaskMonitor
+
     monitor = TaskMonitor()
 
     stop_event = threading.Event()
@@ -27,7 +28,6 @@ def task_monitor():
 
 
 def set_openai_completion(mock_openai, response):
-
     if not isinstance(response, list):
         response = [response]
 
@@ -39,26 +39,17 @@ def set_openai_completion(mock_openai, response):
         else:
             resp = response.pop(0)
 
-        return {
-            'choices': [{
-                'message': {
-                    'role': 'system',
-                    'content': resp
-                }
-            }]
-        }
+        return {"choices": [{"message": {"role": "system", "content": resp}}]}
 
     mock_openai().chat.completions.create.side_effect = resp_f
 
 
 class TestAgent(BaseExecutorDummyML):
-
     def test_mindsdb_provider(self):
-
-        agent_response = 'how can I help you'
+        agent_response = "how can I help you"
         # model
         self.run_sql(
-            f'''
+            f"""
                 CREATE model base_model
                 PREDICT output
                 using
@@ -66,139 +57,143 @@ class TestAgent(BaseExecutorDummyML):
                   output='{agent_response}',
                   engine='dummy_ml',
                   join_learn_process=true
-            '''
+            """
         )
 
-        self.run_sql('CREATE ML_ENGINE langchain FROM langchain')
+        self.run_sql("CREATE ML_ENGINE langchain FROM langchain")
 
-        self.run_sql('''
+        self.run_sql("""
             CREATE AGENT my_agent
             USING
              provider='mindsdb',
              model = "base_model", -- <
              prompt_template="Answer the user input in a helpful way"
-         ''')
+         """)
         ret = self.run_sql("select * from my_agent where question = 'hi'")
 
         assert agent_response in ret.answer[0]
 
-    @patch('openai.OpenAI')
+    @patch("openai.OpenAI")
     def test_openai_provider_with_model(self, mock_openai):
-        agent_response = 'how can I assist you today?'
+        agent_response = "how can I assist you today?"
         set_openai_completion(mock_openai, agent_response)
 
-        self.run_sql('CREATE ML_ENGINE langchain FROM langchain')
+        self.run_sql("CREATE ML_ENGINE langchain FROM langchain")
 
-        self.run_sql('''
+        self.run_sql("""
             CREATE MODEL lang_model
                 PREDICT answer USING
             engine = "langchain",
             model = "gpt-3.5-turbo",
             openai_api_key='--',
             prompt_template="Answer the user input in a helpful way";
-         ''')
+         """)
 
         time.sleep(5)
 
-        self.run_sql('''
+        self.run_sql("""
             CREATE AGENT my_agent
             USING
               model='lang_model'
-         ''')
+         """)
         ret = self.run_sql("select * from my_agent where question = 'hi'")
 
         assert agent_response in ret.answer[0]
 
-    @patch('openai.OpenAI')
+    @patch("openai.OpenAI")
     def test_openai_provider(self, mock_openai):
-        agent_response = 'how can I assist you today?'
+        agent_response = "how can I assist you today?"
         set_openai_completion(mock_openai, agent_response)
 
-        self.run_sql('''
+        self.run_sql("""
             CREATE AGENT my_agent
             USING
              provider='openai',
              model = "gpt-3.5-turbo",
              openai_api_key='--',
              prompt_template="Answer the user input in a helpful way"
-         ''')
+         """)
         ret = self.run_sql("select * from my_agent where question = 'hi'")
 
         assert agent_response in ret.answer[0]
 
         # test join
-        df = pd.DataFrame([
-            {'q': 'hi'},
-        ])
-        self.save_file('questions', df)
+        df = pd.DataFrame(
+            [
+                {"q": "hi"},
+            ]
+        )
+        self.save_file("questions", df)
 
-        ret = self.run_sql('''
+        ret = self.run_sql("""
             select * from files.questions t
             join my_agent a on a.question=t.q
-        ''')
+        """)
 
         assert agent_response in ret.answer[0]
 
         # empty query
-        ret = self.run_sql('''
+        ret = self.run_sql("""
             select * from files.questions t
             join my_agent a on a.question=t.q
             where t.q = ''
-        ''')
+        """)
         assert len(ret) == 0
 
-    @patch('openai.OpenAI')
+    @patch("openai.OpenAI")
     def test_agent_with_tables(self, mock_openai):
-        sd = SkillData(
-            name='test', type='', project_id=1,
-            params={'tables': []},
-            agent_tables_list=[]
-        )
+        sd = SkillData(name="test", type="", project_id=1, params={"tables": []}, agent_tables_list=[])
 
-        sd.params = {'tables': ['x', 'y']}
-        sd.agent_tables_list = ['x', 'y']
-        assert sd.restriction_on_tables == {None: {'x', 'y'}}
+        sd.params = {"tables": ["x", "y"]}
+        sd.agent_tables_list = ["x", "y"]
+        assert sd.restriction_on_tables == {None: {"x", "y"}}
 
-        sd.params = {'tables': ['x', 'y']}
-        sd.agent_tables_list = ['x', 'y', 'z']
-        assert sd.restriction_on_tables == {None: {'x', 'y'}}
+        sd.params = {"tables": ["x", "y"]}
+        sd.agent_tables_list = ["x", "y", "z"]
+        assert sd.restriction_on_tables == {None: {"x", "y"}}
 
-        sd.params = {'tables': ['x', 'y']}
-        sd.agent_tables_list = ['x']
-        assert sd.restriction_on_tables == {None: {'x'}}
+        sd.params = {"tables": ["x", "y"]}
+        sd.agent_tables_list = ["x"]
+        assert sd.restriction_on_tables == {None: {"x"}}
 
-        sd.params = {'tables': ['x', 'y']}
-        sd.agent_tables_list = ['z']
+        sd.params = {"tables": ["x", "y"]}
+        sd.agent_tables_list = ["z"]
         with pytest.raises(ValueError):
             print(sd.restriction_on_tables)
 
-        sd.params = {'tables': ['x', {'schema': 'S', 'table': 'y'}]}
-        sd.agent_tables_list = ['x']
-        assert sd.restriction_on_tables == {None: {'x'}}
+        sd.params = {"tables": ["x", {"schema": "S", "table": "y"}]}
+        sd.agent_tables_list = ["x"]
+        assert sd.restriction_on_tables == {None: {"x"}}
 
-        sd.params = {'tables': ['x', {'schema': 'S', 'table': 'y'}]}
-        sd.agent_tables_list = ['x', {'schema': 'S', 'table': 'y'}]
-        assert sd.restriction_on_tables == {None: {'x'}, 'S': {'y'}}
+        sd.params = {"tables": ["x", {"schema": "S", "table": "y"}]}
+        sd.agent_tables_list = ["x", {"schema": "S", "table": "y"}]
+        assert sd.restriction_on_tables == {None: {"x"}, "S": {"y"}}
 
-        sd.params = {'tables': [{'schema': 'S', 'table': 'x'}, {'schema': 'S', 'table': 'y'}, {'schema': 'S', 'table': 'z'}]}
-        sd.agent_tables_list = [{'schema': 'S', 'table': 'y'}, {'schema': 'S', 'table': 'z'}, {'schema': 'S', 'table': 'f'}]
-        assert sd.restriction_on_tables == {'S': {'y', 'z'}}
+        sd.params = {
+            "tables": [{"schema": "S", "table": "x"}, {"schema": "S", "table": "y"}, {"schema": "S", "table": "z"}]
+        }
+        sd.agent_tables_list = [
+            {"schema": "S", "table": "y"},
+            {"schema": "S", "table": "z"},
+            {"schema": "S", "table": "f"},
+        ]
+        assert sd.restriction_on_tables == {"S": {"y", "z"}}
 
-        sd.params = {'tables': [{'schema': 'S', 'table': 'x'}, {'schema': 'S', 'table': 'y'}]}
-        sd.agent_tables_list = [{'schema': 'S', 'table': 'z'}]
+        sd.params = {"tables": [{"schema": "S", "table": "x"}, {"schema": "S", "table": "y"}]}
+        sd.agent_tables_list = [{"schema": "S", "table": "z"}]
         with pytest.raises(ValueError):
             print(sd.restriction_on_tables)
 
-        self.run_sql('''
+        self.run_sql("""
             create skill test_skill
             using
             type = 'text2sql',
             database = 'example_db',
             tables = ['table_1', 'table_2'],
             description = "this is sales data";
-        ''')
+        """)
 
-        self.run_sql('''
+        self.run_sql("""
             create agent test_agent
             using
             model='gpt-3.5-turbo',
@@ -209,68 +204,64 @@ class TestAgent(BaseExecutorDummyML):
                 'name': 'test_skill',
                 'tables': ['table_2', 'table_3']
             }];
-        ''')
+        """)
 
-        resp = self.run_sql('''select * from information_schema.agents where name = 'test_agent';''')
+        resp = self.run_sql("""select * from information_schema.agents where name = 'test_agent';""")
         assert len(resp) == 1
-        assert resp['SKILLS'][0] == ['test_skill']
+        assert resp["SKILLS"][0] == ["test_skill"]
 
-        agent_response = 'how can I assist you today?'
+        agent_response = "how can I assist you today?"
         set_openai_completion(mock_openai, agent_response)
         self.run_sql("select * from test_agent where question = 'test?'")
 
-    @patch('openai.OpenAI')
+    @patch("openai.OpenAI")
     def test_agent_stream(self, mock_openai):
-        agent_response = 'how can I assist you today?'
+        agent_response = "how can I assist you today?"
         set_openai_completion(mock_openai, agent_response)
 
-        self.run_sql('''
+        self.run_sql("""
             CREATE AGENT my_agent
             USING
              provider='openai',
              model = "gpt-3.5-turbo",
              openai_api_key='--',
              prompt_template="Answer the user input in a helpful way"
-         ''')
+         """)
 
         agents_controller = self.command_executor.session.agents_controller
-        agent = agents_controller.get_agent('my_agent')
+        agent = agents_controller.get_agent("my_agent")
 
-        messages = [{'question': 'hi'}]
+        messages = [{"question": "hi"}]
         found = False
         for chunk in agents_controller.get_completion(agent, messages, stream=True):
-            if chunk.get('output') == agent_response:
+            if chunk.get("output") == agent_response:
                 found = True
         if not found:
-            raise AttributeError('Agent response is not found')
+            raise AttributeError("Agent response is not found")
 
-    @patch('openai.OpenAI')
+    @patch("openai.OpenAI")
     def test_agent_retrieval(self, mock_openai):
+        self.run_sql("""
+            create knowledge base kb_review
+            using
+                embedding_model = {
+                    "provider": "openai",
+                    "model_name": "text-embedding-ada-002",
+                    "api_key": "dummy_key"
+                }
+        """)
 
-        self.run_sql(
-            '''
-                CREATE model emb_model
-                PREDICT output
-                using
-                  column='content',
-                  engine='dummy_ml',
-                  join_learn_process=true
-            '''
-        )
-
-        self.run_sql('create knowledge base kb_review using model=emb_model')
-
-        self.run_sql('''
+        self.run_sql("""
           create skill retr_skill
           using
               type = 'retrieval',
               source = 'kb_review',
               description = 'user reviews'
-        ''')
+        """)
 
-        os.environ['OPENAI_API_KEY'] = '--'
+        os.environ["OPENAI_API_KEY"] = "--"
 
-        self.run_sql('''
+        self.run_sql("""
           create agent retrieve_agent
            using
           model='gpt-3.5-turbo',
@@ -279,29 +270,32 @@ class TestAgent(BaseExecutorDummyML):
           skills=['retr_skill'],
           max_iterations=5,
           mode='retrieval'
-        ''')
+        """)
 
-        agent_response = 'the answer is yes'
-        user_question = 'answer my question'
+        agent_response = "the answer is yes"
+        user_question = "answer my question"
         from textwrap import dedent
-        set_openai_completion(mock_openai, [
-            # first step, use kb
-            dedent(f'''
+
+        set_openai_completion(
+            mock_openai,
+            [
+                # first step, use kb
+                dedent(f"""
               Thought: Do I need to use a tool? Yes
               Action: retr_skill
               Action Input: {user_question}
-            '''),
+            """),
+                # step2, answer to user
+                agent_response,
+            ],
+        )
 
-            # step2, answer to user
-            agent_response
-        ])
-
-        with patch('mindsdb.interfaces.knowledge_base.controller.KnowledgeBaseTable.select_query') as kb_select:
+        with patch("mindsdb.interfaces.knowledge_base.controller.KnowledgeBaseTable.select_query") as kb_select:
             # kb response
-            kb_select.return_value = pd.DataFrame([{'id': 1, 'content': 'ok', 'metadata': {}}])
-            ret = self.run_sql(f'''
+            kb_select.return_value = pd.DataFrame([{"id": 1, "content": "ok", "metadata": {}}])
+            ret = self.run_sql(f"""
                 select * from retrieve_agent where question = '{user_question}'
-            ''')
+            """)
 
             # check agent output
             assert agent_response in ret.answer[0]
@@ -311,10 +305,10 @@ class TestAgent(BaseExecutorDummyML):
             assert user_question in args[0].where.args[1].value
 
     def test_drop_demo_agent(self):
-        """should not be possible to drop demo agent
-        """
+        """should not be possible to drop demo agent"""
         from mindsdb.api.executor.exceptions import ExecutorException
-        self.run_sql('''
+
+        self.run_sql("""
             CREATE AGENT my_demo_agent
             USING
                 provider='openai',
@@ -322,46 +316,71 @@ class TestAgent(BaseExecutorDummyML):
                 openai_api_key='--',
                 prompt_template="--",
                 is_demo=true;
-         ''')
+         """)
         with pytest.raises(ExecutorException):
-            self.run_sql('drop agent my_agent')
+            self.run_sql("drop agent my_agent")
 
-        self.run_sql('''
+        self.run_sql("""
             create skill my_demo_skill
             using
             type = 'text2sql',
             database = 'example_db',
             description = "",
             is_demo=true;
-        ''')
+        """)
 
         with pytest.raises(ExecutorException):
-            self.run_sql('drop skill my_demo_skill')
+            self.run_sql("drop skill my_demo_skill")
 
 
 class TestKB(BaseExecutorDummyML):
+    def _create_kb(
+        self,
+        name,
+        embedding_model=None,
+        reranking_model=None,
+        content_columns=None,
+        id_column=None,
+        metadata_columns=None,
+    ):
+        self.run_sql(f"drop knowledge base if exists {name}")
 
-    def _create_embedding_model(self, name):
+        if embedding_model is None:
+            embedding_model = {
+                "provider": "openai",
+                "model_name": "text-embedding-ada-002",
+                "api_key": "dummy_key",
+            }
 
-        self.run_sql(
-            f'''
-                CREATE model {name}
-                PREDICT predicted
-                using
-                  column='content',
-                  engine='dummy_ml',
-                  output=[1,2],
-                  join_learn_process=true
-            '''
-        )
+        kb_params = {
+            "embedding_model": embedding_model,
+        }
+        if reranking_model is not None:
+            kb_params["reranking_model"] = reranking_model
+        if content_columns is not None:
+            kb_params["content_columns"] = content_columns
+        if id_column is not None:
+            kb_params["id_column"] = id_column
+        if metadata_columns is not None:
+            kb_params["metadata_columns"] = metadata_columns
+
+        param_str = ""
+        if kb_params:
+            param_items = []
+            for k, v in kb_params.items():
+                param_items.append(f"{k}={json.dumps(v)}")
+            param_str = ",".join(param_items)
+
+        self.run_sql(f"""
+            create knowledge base {name}
+            using
+                {param_str}
+        """)
 
     def test_kb(self):
-
-        self._create_embedding_model('emb_model')
-
-        self.run_sql('create knowledge base kb_review using model=emb_model')
-        self.run_sql('drop knowledge base kb_review')  # drop chromadb left since the last failed test
-        self.run_sql('create knowledge base kb_review using model=emb_model')
+        self._create_kb("kb_review")
+        self.run_sql("drop knowledge base kb_review")  # drop chromadb left since the last failed test
+        self._create_kb("kb_review")
 
         self.run_sql("insert into kb_review (content) values ('review')")
 
@@ -372,28 +391,26 @@ class TestKB(BaseExecutorDummyML):
         # show tables in default chromadb
         ret = self.run_sql("show knowledge bases")
 
-        db_name = ret.STORAGE[0].split('.')[0]
+        db_name = ret.STORAGE[0].split(".")[0]
         ret = self.run_sql(f"show tables from {db_name}")
         # only one default collection there
         assert len(ret) == 1
 
     def test_kb_metadata(self):
-        self._create_embedding_model('emb_model')
-
         record = {
-            'review': "all is good, haven't used yet",
-            'url': 'https://laptops.com/123',
-            'product': 'probook',
-            'specs': 'Core i5; 8Gb; 1920х1080',
-            'id': 123
+            "review": "all is good, haven't used yet",
+            "url": "https://laptops.com/123",
+            "product": "probook",
+            "specs": "Core i5; 8Gb; 1920х1080",
+            "id": 123,
         }
         df = pd.DataFrame([record])
-        self.save_file('reviews', df)
+        self.save_file("reviews", df)
 
         # ---  case 1: kb with default columns settings ---
-        self.run_sql('create knowledge base kb_review using model=emb_model')
-        self.run_sql('drop knowledge base kb_review')  # drop chromadb left since the last failed test
-        self.run_sql('create knowledge base kb_review using model=emb_model')
+        self._create_kb("kb_review")
+        self.run_sql("drop knowledge base kb_review")  # drop chromadb left since the last failed test
+        self._create_kb("kb_review")
 
         self.run_sql("""
             insert into kb_review
@@ -402,7 +419,7 @@ class TestKB(BaseExecutorDummyML):
 
         ret = self.run_sql("select * from kb_review where original_doc_id = 123")
         assert len(ret) == 1
-        assert ret['chunk_content'][0] == record['review']
+        assert ret["chunk_content"][0] == record["review"]
 
         # delete by metadata
         self.run_sql("delete from kb_review where original_doc_id = 123")
@@ -422,20 +439,16 @@ class TestKB(BaseExecutorDummyML):
         # product/url in metadata
         ret = self.run_sql("select * from kb_review where product = 'probook'")
         assert len(ret) == 1
-        assert ret['metadata'][0]['product'] == record['product']
-        assert ret['metadata'][0]['url'] == record['url']
+        assert ret["metadata"][0]["product"] == record["product"]
+        assert ret["metadata"][0]["url"] == record["url"]
 
         self.run_sql("drop knowledge base kb_review")
 
         # ---  case 2: kb with defined columns ---
 
-        self.run_sql('''
-          create knowledge base kb_review
-            using model=emb_model,
-            content_columns=['review', 'product'],
-            id_column='url',
-            metadata_columns=['specs', 'id']
-        ''')
+        self._create_kb(
+            "kb_review", content_columns=["review", "product"], id_column="url", metadata_columns=["specs", "id"]
+        )
 
         self.run_sql("""
             insert into kb_review
@@ -447,23 +460,19 @@ class TestKB(BaseExecutorDummyML):
         assert len(ret) == 2  # two columns are split in two records
 
         # review/product in content
-        content = list(ret['chunk_content'])
-        assert record['review'] in content
-        assert record['product'] in content
+        content = list(ret["chunk_content"])
+        assert record["review"] in content
+        assert record["product"] in content
 
         # specs/id in metadata
-        metadata = ret['metadata'][0]
-        assert metadata['specs'] == record['specs']
-        assert str(metadata['id']) == str(record['id'])
+        metadata = ret["metadata"][0]
+        assert metadata["specs"] == record["specs"]
+        assert str(metadata["id"]) == str(record["id"])
 
         self.run_sql("drop knowledge base kb_review")
 
         # ---  case 3: content is defined, id is id, the rest goes to metadata ---
-        self.run_sql('''
-        create knowledge base kb_review
-         using model=emb_model,
-         content_columns=['review']
-        ''')
+        self._create_kb("kb_review", content_columns=["review"])
 
         self.run_sql("""
             insert into kb_review
@@ -473,34 +482,29 @@ class TestKB(BaseExecutorDummyML):
         ret = self.run_sql("select * from kb_review where original_doc_id = 123")  # id is id
         assert len(ret) == 1
         # review in content
-        assert ret['chunk_content'][0] == record['review']
+        assert ret["chunk_content"][0] == record["review"]
 
         # specs/url/product in metadata
-        metadata = ret['metadata'][0]
-        assert metadata['specs'] == record['specs']
-        assert metadata['url'] == record['url']
-        assert metadata['product'] == record['product']
+        metadata = ret["metadata"][0]
+        assert metadata["specs"] == record["specs"]
+        assert metadata["url"] == record["url"]
+        assert metadata["product"] == record["product"]
 
     def _get_ral_table(self):
         data = [
-            ['1000', 'Green beige', 'Beige verdastro'],
-            ['1004', 'Golden yellow', 'Giallo oro'],
-            ['9016', 'Traffic white', 'Bianco traffico'],
-            ['9023', 'Pearl dark grey', 'Grigio scuro perlato'],
+            ["1000", "Green beige", "Beige verdastro"],
+            ["1004", "Golden yellow", "Giallo oro"],
+            ["9016", "Traffic white", "Bianco traffico"],
+            ["9023", "Pearl dark grey", "Grigio scuro perlato"],
         ]
 
-        return pd.DataFrame(data, columns=['ral', 'english', 'italian'])
+        return pd.DataFrame(data, columns=["ral", "english", "italian"])
 
     def test_join_kb_table(self):
-        self._create_embedding_model('emb_model')
-
         df = self._get_ral_table()
-        self.save_file('ral', df)
+        self.save_file("ral", df)
 
-        self.run_sql('''
-          create knowledge base kb_ral
-            using model=emb_model
-        ''')
+        self._create_kb("kb_ral")
 
         self.run_sql("""
             insert into kb_ral
@@ -516,7 +520,7 @@ class TestKB(BaseExecutorDummyML):
 
         assert len(ret) == 2
         # values are matched
-        diff = ret[ret['ral'] != ret['id']]
+        diff = ret[ret["ral"] != ret["id"]]
         assert len(diff) == 0
 
         # =================   operators  =================
@@ -525,151 +529,135 @@ class TestKB(BaseExecutorDummyML):
             where id = '1000'
         """)
         assert len(ret) == 1
-        assert ret['id'][0] == '1000'
+        assert ret["id"][0] == "1000"
 
         ret = self.run_sql("""
             select * from kb_ral
             where id != '1000'
         """)
         assert len(ret) == 3
-        assert '1000' not in ret['id']
+        assert "1000" not in ret["id"]
 
         ret = self.run_sql("""
             select * from kb_ral
             where id in ('1000', '1004')
         """)
         assert len(ret) == 2
-        assert set(ret['id']) == {'1000', '1004'}
+        assert set(ret["id"]) == {"1000", "1004"}
 
         ret = self.run_sql("""
             select * from kb_ral
             where id not in ('1000', '1004')
         """)
         assert len(ret) == 2
-        assert set(ret['id']) == {'9016', '9023'}
+        assert set(ret["id"]) == {"9016", "9023"}
 
-    @patch('mindsdb.integrations.handlers.postgres_handler.Handler')
+    @patch("mindsdb.integrations.handlers.postgres_handler.Handler")
     def test_kb_partitions(self, mock_handler):
-        self._create_embedding_model('emb_model')
-
         df = self._get_ral_table()
-        self.save_file('ral', df)
+        self.save_file("ral", df)
 
         df = pd.concat([df] * 30)
         # unique ids
-        df['id'] = list(map(str, range(len(df))))
+        df["id"] = list(map(str, range(len(df))))
 
-        self.set_handler(mock_handler, name='pg', tables={'ral': df})
+        self.set_handler(mock_handler, name="pg", tables={"ral": df})
 
         def check_partition(insert_sql):
             # create empty kb
-            if len(self.run_sql('describe KNOWLEDGE_BASE kb_part')) > 0:
-                self.run_sql('delete from kb_part where id in (select id from kb_part)')
-                self.run_sql('DROP KNOWLEDGE_BASE kb_part')
+            if len(self.run_sql("describe KNOWLEDGE_BASE kb_part")) > 0:
+                self.run_sql("delete from kb_part where id in (select id from kb_part)")
+                self.run_sql("DROP KNOWLEDGE_BASE kb_part")
 
-            self.run_sql('create knowledge base kb_part using model=emb_model, content_columns=["english"]')
+            self._create_kb("kb_part", content_columns=["english"])
 
             # load kb
             ret = self.run_sql(insert_sql)
             # inserts returns query
-            query_id = ret['ID'][0]
+            query_id = ret["ID"][0]
 
             # wait loaded
             for i in range(1000):
                 time.sleep(0.2)
-                ret = self.run_sql(f'select * from information_schema.queries where id = {query_id}')
-                if ret['ERROR'][0] is not None:
-                    raise RuntimeError(ret['ERROR'][0])
-                if ret['FINISHED_AT'][0] is not None:
+                ret = self.run_sql(f"select * from information_schema.queries where id = {query_id}")
+                if ret["ERROR"][0] is not None:
+                    raise RuntimeError(ret["ERROR"][0])
+                if ret["FINISHED_AT"][0] is not None:
                     break
 
             # check content
-            ret = self.run_sql('select * from kb_part')
+            ret = self.run_sql("select * from kb_part")
             assert len(ret) == len(df)
 
             # check queries table
-            ret = self.run_sql(f'select * from information_schema.queries where id = {query_id}')
+            ret = self.run_sql(f"select * from information_schema.queries where id = {query_id}")
             assert len(ret) == 1
             rec = ret.iloc[0]
-            assert 'kb_part' in ret['SQL'][0]
-            assert ret['ERROR'][0] is None
-            assert ret['FINISHED_AT'][0] is not None
+            assert "kb_part" in ret["SQL"][0]
+            assert ret["ERROR"][0] is None
+            assert ret["FINISHED_AT"][0] is not None
 
             # test describe
-            ret = self.run_sql('describe knowledge base kb_part')
+            ret = self.run_sql("describe knowledge base kb_part")
             assert len(ret) == 1
             rec_d = ret.iloc[0]
-            assert rec_d['PROCESSED_ROWS'] == rec['PROCESSED_ROWS']
-            assert rec_d['INSERT_STARTED_AT'] == rec['STARTED_AT']
-            assert rec_d['INSERT_FINISHED_AT'] == rec['FINISHED_AT']
-            assert rec_d['QUERY_ID'] == query_id
+            assert rec_d["PROCESSED_ROWS"] == rec["PROCESSED_ROWS"]
+            assert rec_d["INSERT_STARTED_AT"] == rec["STARTED_AT"]
+            assert rec_d["INSERT_FINISHED_AT"] == rec["FINISHED_AT"]
+            assert rec_d["QUERY_ID"] == query_id
 
             # del query
             self.run_sql(f"SELECT query_cancel({rec['ID']})")
-            ret = self.run_sql('select * from information_schema.queries')
+            ret = self.run_sql("select * from information_schema.queries")
             assert len(ret) == 0
 
-            ret = self.run_sql('describe knowledge base kb_part')
+            ret = self.run_sql("describe knowledge base kb_part")
             assert len(ret) == 1
             rec_d = ret.iloc[0]
-            assert rec_d['PROCESSED_ROWS'] is None
-            assert rec_d['INSERT_STARTED_AT'] is None
-            assert rec_d['INSERT_FINISHED_AT'] is None
-            assert rec_d['QUERY_ID'] is None
+            assert rec_d["PROCESSED_ROWS"] is None
+            assert rec_d["INSERT_STARTED_AT"] is None
+            assert rec_d["INSERT_FINISHED_AT"] is None
+            assert rec_d["QUERY_ID"] is None
 
         with task_monitor():
+
             def stream_f(*args, **kwargs):
                 chunk_size = int(len(df) / 10) + 1
                 for i in range(10):
-                    yield df[chunk_size * i: chunk_size * (i + 1):]
+                    yield df[chunk_size * i : chunk_size * (i + 1) :]
 
             # --- stream mode ---
             mock_handler().query_stream.side_effect = stream_f
 
             # test iterate
-            check_partition('''
+            check_partition("""
                 insert into kb_part SELECT id, english FROM  pg.ral
                 using batch_size=20, track_column=id
-            ''')
+            """)
 
             # test threads
-            check_partition('''
+            check_partition("""
                 insert into kb_part SELECT id, english FROM pg.ral
                 using batch_size=20, track_column=id, threads = 3
-            ''')
+            """)
 
             # without track column
-            check_partition('''
+            check_partition("""
                 insert into kb_part SELECT id, english FROM  pg.ral
                 using batch_size=20
-            ''')
+            """)
 
             # --- general mode ---
             mock_handler().query_stream = None
 
             # test iterate
-            check_partition('''
+            check_partition("""
                 insert into kb_part SELECT id, english FROM  pg.ral
                 using batch_size=20, track_column=id
-            ''')
+            """)
 
             # test threads
-            check_partition('''
+            check_partition("""
                 insert into kb_part SELECT id, english FROM pg.ral
                 using batch_size=20, track_column=id, threads = 3
-            ''')
-
-            # --- check select join using partitions ---
-            ret = self.run_sql('''
-                SELECT * FROM  pg.ral t
-                join emb_model
-                using batch_size=20, track_column=id
-            ''')
-            assert len(ret) == len(df)
-
-            ret = self.run_sql('''
-                SELECT * FROM  pg.ral t
-                join emb_model
-                using batch_size=20, track_column=id, threads = 3
-            ''')
-            assert len(ret) == len(df)
+            """)

--- a/tests/unit/executor/test_agent.py
+++ b/tests/unit/executor/test_agent.py
@@ -1,5 +1,6 @@
 import time
 import os
+import json
 from unittest.mock import patch
 import threading
 from contextlib import contextmanager

--- a/tests/unused/integration/knowledge_bases/test_kb_sql.py
+++ b/tests/unused/integration/knowledge_bases/test_kb_sql.py
@@ -9,30 +9,27 @@ import pandas as pd
 
 
 class KBTestBase:
-
-    def __init__(self, vectordb=None, emb_model=None, mindsdb_server=None):
+    def __init__(self, vectordb=None, mindsdb_server=None):
         self.vectordb = vectordb
-        self.vectordb_engine = vectordb['engine']
+        self.vectordb_engine = vectordb["engine"]
         self.emb_model = emb_model
         if mindsdb_server is None:
             # use localhost
-            mindsdb_server = {
-                'url': 'http://127.0.0.1:47334/'
-            }
+            mindsdb_server = {"url": "http://127.0.0.1:47334/"}
 
         self.con = mindsdb_sdk.connect(**mindsdb_server)
 
         self.prepare()
 
     def create_vector_db(self, connection_args):
-        engine = connection_args.pop('engine')
+        engine = connection_args.pop("engine")
 
-        name = f'test_vectordb_{engine}'
+        name = f"test_vectordb_{engine}"
 
         try:
             self.con.databases.drop(name)
         except RuntimeError as e:
-            if 'Database does not exists' not in str(e):
+            if "Database does not exists" not in str(e):
                 raise e
         # if engine == 'pgvector':
         #     connection_args = {}
@@ -43,7 +40,7 @@ class KBTestBase:
         return name
 
     def create_db(self):
-        name = 'example_db'
+        name = "example_db"
 
         try:
             self.con.databases.get(name)
@@ -52,85 +49,76 @@ class KBTestBase:
         except AttributeError:
             pass
 
-        self.con.databases.create(name, engine='postgres', connection_args={
-            "user": "demo_user",
-            "password": "demo_password",
-            "host": "samples.mindsdb.com",
-            "port": "5432",
-            "database": "demo",
-            "schema": "demo_data"
-        })
+        self.con.databases.create(
+            name,
+            engine="postgres",
+            connection_args={
+                "user": "demo_user",
+                "password": "demo_password",
+                "host": "samples.mindsdb.com",
+                "port": "5432",
+                "database": "demo",
+                "schema": "demo_data",
+            },
+        )
         return name
 
-    def create_emb_model(self, params):
-        engine = params.pop('engine')
-
-        name = f'test_emb_model_{engine}'
-        try:
-            self.con.models.drop(name)
-        except Exception:
-            ...
-
-        if engine == 'openai':
-            model = self.con.models.create(
-                name, predict='embedding', engine=engine,
-                options=params,
-            )
-        elif engine == 'langchain_embedding':
-            model = self.con.models.create(
-                name, predict='embedding', engine=engine,
-                options=params,
-            )
-        model.wait_complete()
-        return model.name
-
     def run_sql(self, sql):
-        print('>>>', sql)
+        print(">>>", sql)
         resp = self.con.query(sql).fetch()
-        print('--- response ---')
+        print("--- response ---")
         print(resp)
         return resp
 
     def prepare(self):
         # drop existed kb:
-        for name in ('kb_crm', 'kb_crm_part', 'kb_home_rentals'):
-            self.run_sql(f'drop knowledge base if exists {name}')
+        for name in ("kb_crm", "kb_crm_part", "kb_home_rentals"):
+            self.run_sql(f"drop knowledge base if exists {name}")
 
         # create vector_db
         self.vectordb_name = self.create_vector_db(self.vectordb)
 
-        # create embedding model
-        self.emb_model = self.create_emb_model(self.emb_model)
-
         # connect database
         self.db_name = self.create_db()
 
-    def create_kb(self, name, params=None, with_model=True):
-        model_str = ''
-        if with_model:
-            model_str = f'model = {self.con.models.get(self.emb_model)}, '
+    def create_kb(self, name, reranking_model=None, embedding_model=None):
+        self.run_sql(f"drop knowledge base if exists {name}")
 
-        self.run_sql(f'drop knowledge base if exists {name}')
+        openai_api_key = os.getenv("OPENAI_API_KEY")
 
-        param_str = ''
-        if params:
+        if reranking_model is None:
+            reranking_model = {"provider": "openai", "model_name": "gpt-4", "api_key": openai_api_key}
+
+        if embedding_model is None:
+            embedding_model = {"provider": "openai", "model_name": "text-embedding-ada-002", "api_key": openai_api_key}
+
+        # prepare KB
+        kb_params = {
+            "embedding_model": embedding_model,
+            "reranking_model": reranking_model,
+            "metadata_columns": ["status", "category"],
+            "content_columns": ["message_body"],
+            "id_column": "id",
+        }
+
+        param_str = ""
+        if kb_params:
             param_items = []
-            for k, v in params.items():
-                param_items.append(f'{k}={json.dumps(v)}')
-            param_str = ',' + ','.join(param_items)
+            for k, v in kb_params.items():
+                param_items.append(f"{k}={json.dumps(v)}")
+            param_str = "," + ",".join(param_items)
 
-        self.run_sql(f'''
+        self.run_sql(f"""
             create knowledge base {name}
-            using {model_str}
-               storage = {self.vectordb_name}.tbl_{name}
-               {param_str}
-        ''')
+            using storage = {self.vectordb_name}.tbl_{name}
+                {param_str}
+        """)
 
         # clean
-        if len(self.run_sql(f'select * from {name}')) > 0:
-            self.run_sql(f'delete from {name} where id in (select id from {name})')
+        if len(self.run_sql(f"select * from {name}")) > 0:
+            self.run_sql(f"delete from {name} where id in (select id from {name})")
 
-        ret = self.run_sql(f'describe knowledge base {name}')
+        ret = self.run_sql(f"describe knowledge base {name}")
         assert len(ret) == 1
 
 
@@ -138,14 +126,14 @@ class KBTest(KBTestBase):
     def test_base_syntax(self):
         # TODO, what is "Confirm data persistence and integrity in vector store"
 
-        '''
-            Verify successful setup and operation
-            Test creation of Knowledge Bases
-        '''
-        self.create_kb('kb_crm')
+        """
+        Verify successful setup and operation
+        Test creation of Knowledge Bases
+        """
+        self.create_kb("kb_crm")
 
         # -------------- insert --------
-        print('insert from table')
+        print("insert from table")
         count_rows = 10  # content too small to be chunked
         self.run_sql(f"""
             insert into kb_crm
@@ -154,9 +142,9 @@ class KBTest(KBTestBase):
             limit {count_rows}
         """)
 
-        kb_columns = ['id', 'chunk_content', 'metadata', 'distance', 'relevance']
+        kb_columns = ["id", "chunk_content", "metadata", "distance", "relevance"]
 
-        print('insert from values')
+        print("insert from values")
         for i in range(2):
             # do it twice second time it will be updated
             self.run_sql("""
@@ -168,13 +156,13 @@ class KBTest(KBTestBase):
         # ------------  checking columns  ------------
         # Simplified SQL Syntax
 
-        print('Select all without conditions')
+        print("Select all without conditions")
         ret = self.run_sql("select * from kb_crm")
         assert len(ret) == count_rows
         for column in kb_columns:
-            assert column in ret.columns, f'Column {column} does not exist in response'
+            assert column in ret.columns, f"Column {column} does not exist in response"
 
-        print('Select one column without conditions')
+        print("Select one column without conditions")
         for column in kb_columns:
             ret = self.run_sql(f"select {column} from kb_crm")
             assert len(ret) == count_rows
@@ -182,71 +170,71 @@ class KBTest(KBTestBase):
 
         # ---------- selecting options --------
 
-        print('Limit')
+        print("Limit")
         ret = self.run_sql("select id, chunk_content from kb_crm limit 4")
         assert len(ret) == 4
 
-        print('Limit with content')
+        print("Limit with content")
         ret = self.run_sql("select id, chunk_content, distance from kb_crm where content = 'help' limit 4")
         assert len(ret) == 4
-        assert ret['id'][0] == '1000'  # id is string
+        assert ret["id"][0] == "1000"  # id is string
 
-        print('filter by id')
+        print("filter by id")
         ret = self.run_sql("select id, chunk_content from kb_crm where id = '1001'")
         assert len(ret) == 1
-        assert ret['chunk_content'][0] == 'Thank you'
+        assert ret["chunk_content"][0] == "Thank you"
 
         ret = self.run_sql("select id, chunk_content from kb_crm where id != '1000' limit 4")
         assert len(ret) == 4
-        assert '1000' not in ret['id']
+        assert "1000" not in ret["id"]
 
         # in, not in
         ret = self.run_sql("select id, chunk_content from kb_crm where id in ('1001', '1000')")
         assert len(ret) == 2
-        assert set(ret['id']) == {'1000', '1001'}
+        assert set(ret["id"]) == {"1000", "1001"}
 
         ret = self.run_sql("select id, chunk_content from kb_crm where id not in ('1001', '1000') limit 4")
         assert len(ret) == 4
-        assert '1000' not in list(ret['id'])
+        assert "1000" not in list(ret["id"])
 
-        if self.vectordb_engine != 'chromadb':
+        if self.vectordb_engine != "chromadb":
             # some operators don't work with chromadb
 
             # like / not like
             ret = self.run_sql("select id, chunk_content from kb_crm where id like '100%'")
             assert len(ret) == 2
-            assert '1001' in list(ret['id'])
+            assert "1001" in list(ret["id"])
 
             ret = self.run_sql("select id, chunk_content from kb_crm where id not like '100%' limit 4")
             assert len(ret) == 4
-            assert '1001' not in list(ret['id'])
+            assert "1001" not in list(ret["id"])
 
-        print('distinct')
+        print("distinct")
         ret = self.run_sql("select distinct id from kb_crm")
         assert len(ret) == 2
-        assert set(ret['id']) == {'1000', '1001'}
+        assert set(ret["id"]) == {"1000", "1001"}
 
-        print('group by')
+        print("group by")
         ret = self.run_sql("select id, count(*) from kb_crm group by id")
         assert len(ret) == 2
-        assert set(ret['id']) == {'1000', '1001'}
-        assert set(ret['count']) == {1}
+        assert set(ret["id"]) == {"1000", "1001"}
+        assert set(ret["count"]) == {1}
 
-        print('order by')
+        print("order by")
         ret = self.run_sql("select id, chunk_content from kb_crm order by id")
         assert len(ret) == count_rows
-        assert ret['id'][0] == '1000'
-        assert ret['id'][1] == '1001'
-        assert ret['chunk_content'][0] == 'Help'
-        assert ret['chunk_content'][1] == 'Thank you'
+        assert ret["id"][0] == "1000"
+        assert ret["id"][1] == "1001"
+        assert ret["chunk_content"][0] == "Help"
+        assert ret["chunk_content"][1] == "Thank you"
 
-        print('order by desc')
+        print("order by desc")
         ret = self.run_sql("select id, chunk_content from kb_crm order by id desc")
         assert len(ret) == count_rows
-        assert ret['id'][0] == '1001'
-        assert ret['id'][1] == '1000'
-        assert ret['chunk_content'][0] == 'Thank you'
-        assert ret['chunk_content'][1] == 'Help'
+        assert ret["id"][0] == "1001"
+        assert ret["id"][1] == "1000"
+        assert ret["chunk_content"][0] == "Thank you"
+        assert ret["chunk_content"][1] == "Help"
 
         # TODO filtering combination with content
 
@@ -260,15 +248,15 @@ class KBTest(KBTestBase):
         """)
 
         row = ret.iloc[0]
-        assert row['chunk_content'] == row['message_body']
-        assert row['id'] == str(row['pk'])
+        assert row["chunk_content"] == row["message_body"]
+        assert row["id"] == str(row["pk"])
 
         # -----------------  modify data ---------------
-        '''
+        """
         Test adding new vectors/records to the knowledge base
         Test updating existing records
         Test deleting records/vectors by ID
-        '''
+        """
 
         # delete
         self.run_sql("delete from kb_crm where id = '1'")
@@ -287,22 +275,22 @@ class KBTest(KBTestBase):
         """)
         ret = self.run_sql("select * from kb_crm where id = '2000'")
         assert len(ret) == 1
-        assert ret['chunk_content'][0] == 'OK'
-        chunk_id = ret['chunk_id'][0]
+        assert ret["chunk_content"][0] == "OK"
+        chunk_id = ret["chunk_id"][0]
 
         # update
         self.run_sql(f"update kb_crm set content = 'FINE' where chunk_id = '{chunk_id}'")
         ret = self.run_sql("select * from kb_crm where id = '2000'")
         assert len(ret) == 1
-        assert ret['chunk_content'][0] == 'FINE'
+        assert ret["chunk_content"][0] == "FINE"
 
         # TODO update by id don't work
         #   should it update all chunks?
 
         # Test deletion of Knowledge Bases
-        self.run_sql('drop knowledge base kb_crm')
+        self.run_sql("drop knowledge base kb_crm")
 
-        ret = self.run_sql('describe knowledge base kb_crm')
+        ret = self.run_sql("describe knowledge base kb_crm")
         assert len(ret) == 0
 
     def check_soft_delete(self):
@@ -320,7 +308,7 @@ class KBTest(KBTestBase):
         """
 
         def to_date(s):
-            return dt.datetime.strptime(s, '%Y-%m-%d %H:%M:%S.%f')
+            return dt.datetime.strptime(s, "%Y-%m-%d %H:%M:%S.%f")
 
         def load_kb(batch_size):
             self.run_sql(f"""
@@ -330,16 +318,16 @@ class KBTest(KBTestBase):
             """)
 
         test_set = [
-            {'batch_size': 50},
-            {'batch_size': 100},
+            {"batch_size": 50},
+            {"batch_size": 100},
         ]
 
         results = []
         for item in test_set:
             # Create KB and start load in thread
-            self.create_kb('kb_crm_part')
+            self.create_kb("kb_crm_part")
 
-            print('start loading')
+            print("start loading")
             thread = Thread(target=load_kb, kwargs=item)
             thread.start()
 
@@ -348,31 +336,36 @@ class KBTest(KBTestBase):
                 for i in range(100):  # 300 sec min max
                     time.sleep(3)
 
-                    ret = self.run_sql('describe knowledge base kb_crm_part')
+                    ret = self.run_sql("describe knowledge base kb_crm_part")
                     record = ret.iloc[0]
 
-                    if record['QUERY_ID'] is None:
-                        raise RuntimeError('Query is not partitioned')
+                    if record["QUERY_ID"] is None:
+                        raise RuntimeError("Query is not partitioned")
 
-                    if record['INSERT_FINISHED_AT'] is not None:
-                        print('loading completed')
-                        item['seconds'] = (to_date(record['INSERT_FINISHED_AT']) - to_date(record['INSERT_STARTED_AT'])).seconds
+                    if record["INSERT_FINISHED_AT"] is not None:
+                        print("loading completed")
+                        item["seconds"] = (
+                            to_date(record["INSERT_FINISHED_AT"]) - to_date(record["INSERT_STARTED_AT"])
+                        ).seconds
                         results.append(item)
                         break
 
-                    if record['ERROR'] is not None:
-                        raise RuntimeError(record['ERROR'])
+                    if record["ERROR"] is not None:
+                        raise RuntimeError(record["ERROR"])
             finally:
                 thread.join()
-        print('========= Tests summary ==========')
+        print("========= Tests summary ==========")
         print(pd.DataFrame(results))
 
     def test_metadata(self):
-        self.create_kb('kb_crm', params={
-            'metadata_columns': ['status', 'category'],
-            'content_columns': ['message_body'],
-            'id_column': 'id',
-        })
+        self.create_kb(
+            "kb_crm",
+            params={
+                "metadata_columns": ["status", "category"],
+                "content_columns": ["message_body"],
+                "id_column": "id",
+            },
+        )
 
         self.run_sql("""
             INSERT INTO kb_crm (
@@ -386,15 +379,15 @@ class KBTest(KBTestBase):
             FROM kb_crm
             WHERE category = "Battery";
         """)
-        assert set(ret.metadata.apply(lambda x: x.get('category'))) == {'Battery'}
+        assert set(ret.metadata.apply(lambda x: x.get("category"))) == {"Battery"}
 
         ret = self.run_sql("""
             SELECT *
             FROM kb_crm
             WHERE status = "solving" AND category = "Battery"
         """)
-        assert set(ret.metadata.apply(lambda x: x.get('category'))) == {'Battery'}
-        assert set(ret.metadata.apply(lambda x: x.get('status'))) == {'solving'}
+        assert set(ret.metadata.apply(lambda x: x.get("category"))) == {"Battery"}
+        assert set(ret.metadata.apply(lambda x: x.get("status"))) == {"solving"}
 
         # -- Content + metadata search
         ret = self.run_sql("""
@@ -402,8 +395,8 @@ class KBTest(KBTestBase):
             FROM kb_crm
             WHERE status = "solving" AND content = "noise";
         """)
-        assert set(ret.metadata.apply(lambda x: x.get('status'))) == {'solving'}
-        assert 'noise' in ret.chunk_content[0]
+        assert set(ret.metadata.apply(lambda x: x.get("status"))) == {"solving"}
+        assert "noise" in ret.chunk_content[0]
 
         # -- Content + metadata search with limit
         ret = self.run_sql("""
@@ -412,8 +405,8 @@ class KBTest(KBTestBase):
             WHERE status = "solving" AND content = "noise"
             LIMIT 5;
         """)
-        assert set(ret.metadata.apply(lambda x: x.get('status'))) == {'solving'}
-        assert 'noise' in ret.chunk_content[0]
+        assert set(ret.metadata.apply(lambda x: x.get("status"))) == {"solving"}
+        assert "noise" in ret.chunk_content[0]
         assert len(ret) == 5
 
         # -- Content + metadata search with limit and re-ranking threshold
@@ -423,59 +416,27 @@ class KBTest(KBTestBase):
             FROM kb_crm
             WHERE status = "solving" AND content = "noise" AND relevance_threshold=0.65
         """)
-        assert set(ret.metadata.apply(lambda x: x.get('status'))) == {'solving'}
-        assert 'noise' in ret.chunk_content[0]  # first line contents word
+        assert set(ret.metadata.apply(lambda x: x.get("status"))) == {"solving"}
+        assert "noise" in ret.chunk_content[0]  # first line contents word
         assert len(ret[ret.relevance < 0.65]) == 0
 
-    def test_dict_as_model(self, openai_api_key, reranking_model=None, embedding_model=None):
+    def test_relevance(self):
+        self.create_kb("kb_crm")
 
-        def _check_kb(kb_params):
-            self.create_kb('kb_crm', params=kb_params, with_model=False)
+        self.run_sql("""
+            INSERT INTO kb_crm (
+                SELECT * FROM example_db.crm_demo
+            );
+        """)
 
-            self.run_sql("""
-                INSERT INTO kb_crm (
-                    SELECT * FROM example_db.crm_demo
-                );
-            """)
+        threshold = 0.5
+        ret = self.run_sql(f"""
+            SELECT *
+            FROM kb_crm
+            WHERE status = "solving" AND content = "noise" AND relevance_threshold={threshold}
+        """)
+        assert set(ret.metadata.apply(lambda x: x.get("status"))) == {"solving"}
+        for item in ret.chunk_content:
+            assert "noise" in item  # all lines line contents word
 
-            threshold = 0.5
-            ret = self.run_sql(f"""
-                SELECT *
-                FROM kb_crm
-                WHERE status = "solving" AND content = "noise" AND relevance_threshold={threshold}
-            """)
-            assert set(ret.metadata.apply(lambda x: x.get('status'))) == {'solving'}
-            for item in ret.chunk_content:
-                assert 'noise' in item  # all lines line contents word
-
-            assert len(ret[ret.relevance < threshold]) == 0
-
-        if reranking_model is None:
-            reranking_model = {
-                "provider": "openai",
-                "model_name": "gpt-4",
-                "api_key": openai_api_key
-            }
-
-        if embedding_model is None:
-            embedding_model = {
-                "provider": "openai",
-                "model_name": "text-embedding-ada-002",
-                "api_key": openai_api_key
-            }
-
-        # prepare KB
-        kb_params = {
-            'embedding_model': embedding_model,
-            'reranking_model': reranking_model,
-            'metadata_columns': ['status', 'category'],
-            'content_columns': ['message_body'],
-            'id_column': 'id',
-        }
-
-        _check_kb(kb_params)
-
-        # check with model name
-        kb_params['embedding_model'] = self.emb_model
-
-        _check_kb(kb_params)
+        assert len(ret[ret.relevance < threshold]) == 0


### PR DESCRIPTION
## Description

This PR disables MindsDB models from being used as embedding models when creating knowledge bases.

Fixes https://linear.app/mindsdb/issue/UNI-24/disable-passing-models-to-kb

## Type of change

- [X] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [X] Necessary documentation updates are either made or tracked in issues.
- [X] Relevant unit and integration tests are updated or added.