### PR TITLE
fixing insert bug

### DIFF
--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -97,6 +97,17 @@ def get_reranking_model_from_params(reranking_model_params: dict):
     return BaseLLMReranker(**params_copy)
 
 
+def safe_pandas_is_datetime(value: str) -> bool:
+    """
+    Check if the value can be parsed as a datetime.
+    """
+    try:
+        result = pd.api.types.is_datetime64_any_dtype(value)
+        return result
+    except ValueError:
+        return False
+
+
 class KnowledgeBaseTable:
     """
     Knowledge base table interface
@@ -591,7 +602,7 @@ class KnowledgeBaseTable:
                 for col in metadata_columns:
                     value = row[col]
                     # Convert numpy/pandas types to Python native types
-                    if pd.api.types.is_datetime64_any_dtype(value) or isinstance(value, pd.Timestamp):
+                    if safe_pandas_is_datetime(value) or isinstance(value, pd.Timestamp):
                         value = str(value)
                     elif pd.api.types.is_integer_dtype(value):
                         value = int(value)


### PR DESCRIPTION
## Description

This fixes an insertion bug where `pd.api.types.is_datetime64_any_dtype`  throws an exception on ill formatted strings. 

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)


- [x ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



![Screenshot from 2025-05-29 12-37-34](https://github.com/user-attachments/assets/047b8e3d-7eec-4b90-8a60-ff307991c13f)