### PR TITLE
Set default prompt template and log its usage

### DIFF
--- a/mindsdb/interfaces/agents/langchain_agent.py
+++ b/mindsdb/interfaces/agents/langchain_agent.py
@@ -265,7 +265,9 @@ class LangchainAgent:
             if args.get("mode") == "retrieval":
                 args["prompt_template"] = DEFAULT_RAG_PROMPT_TEMPLATE
             else:
-                raise ValueError("Please provide a `prompt_template` or set `mode=retrieval`")
+                args["prompt_template"] = "you are an assistant, answer using the tables connected"
+
+        logger.info("using the following prompt template: " + args["prompt_template"])
 
         return args
 


### PR DESCRIPTION
When `mode` is not 'retrieval', assign a default prompt template instead of raising an error. Added a log to inform about the prompt template being used. This ensures smoother execution and better traceability.

## Description

Please include a summary of the change and the issue it solves. 

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



