### PR TITLE
KB: set created_at and updated_at in metadata

### DIFF
--- a/mindsdb/integrations/libs/vectordatabase_handler.py
+++ b/mindsdb/integrations/libs/vectordatabase_handler.py
@@ -314,9 +314,9 @@ class VectorStoreHandler(BaseHandler):
         df[id_col] = df[id_col].apply(str)
 
         # set updated_at
-        self.set_metadata_cur_time(df, '_updated_at')
+        self.set_metadata_cur_time(df, "_updated_at")
 
-        if hasattr(self, 'upsert'):
+        if hasattr(self, "upsert"):
             self.upsert(table_name, df)
             return
 
@@ -324,9 +324,7 @@ class VectorStoreHandler(BaseHandler):
         df_existed = self.select(
             table_name,
             columns=[id_col, metadata_col],
-            conditions=[
-                FilterCondition(column=id_col, op=FilterOperator.IN, value=list(df[id_col]))
-            ]
+            conditions=[FilterCondition(column=id_col, op=FilterOperator.IN, value=list(df[id_col]))],
         )
         existed_ids = list(df_existed[id_col])
 
@@ -336,15 +334,12 @@ class VectorStoreHandler(BaseHandler):
 
         if not df_update.empty:
             # get values of existed `created_at` and return them to metadata
-            created_dates = {
-                row[id_col]: row[metadata_col].get('_created_at')
-                for _, row in df_existed.iterrows()
-            }
+            created_dates = {row[id_col]: row[metadata_col].get("_created_at") for _, row in df_existed.iterrows()}
 
             def keep_created_at(row):
                 val = created_dates.get(row[id_col])
                 if val:
-                    row[metadata_col]['_created_at'] = val
+                    row[metadata_col]["_created_at"] = val
                 return row
 
             df_update.apply(keep_created_at, axis=1)
@@ -358,7 +353,7 @@ class VectorStoreHandler(BaseHandler):
                 self.insert(table_name, df_update)
         if not df_insert.empty:
             # set created_at
-            self.set_metadata_cur_time(df_insert, '_created_at')
+            self.set_metadata_cur_time(df_insert, "_created_at")
 
             self.insert(table_name, df_insert)
 


### PR DESCRIPTION
## Description

Set created_at and updated_at in knowledge base metadta

If vector db supports upsert (for example chromadb):
-  set `update_at` for every upserted record (for both create and insert)

If upsert is not supported (for example pgvector)
- set `update_at` for inserted/updated record
- set `created_at`:
  - as curent timestamp when inserted
  - get value from existed record and copy it to metadata if it is update


Fixes https://linear.app/mindsdb/issue/UNI-82/auto-populate-created-time-updated-time-in-metadata 

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



