### PR TITLE
Add /status endpoint for A2A to provide server health information

### DIFF
--- a/mindsdb/api/a2a/common/server/server.py
+++ b/mindsdb/api/a2a/common/server/server.py
@@ -20,7 +20,8 @@ from ...common.types import (
 )
 from pydantic import ValidationError
 import json
-from typing import AsyncIterable, Any
+import time
+from typing import AsyncIterable, Any, Dict
 from ...common.server.task_manager import TaskManager
 
 import logging
@@ -44,9 +45,9 @@ class A2AServer:
         self.agent_card = agent_card
         self.app = Starlette()
         self.app.add_route(self.endpoint, self._process_request, methods=["POST"])
-        self.app.add_route(
-            "/.well-known/agent.json", self._get_agent_card, methods=["GET"]
-        )
+        self.app.add_route("/.well-known/agent.json", self._get_agent_card, methods=["GET"])
+        # Add status endpoint
+        self.app.add_route("/status", self._get_status, methods=["GET"])
         # TODO: Remove this when we have a proper CORS policy
         self.app.add_middleware(
             CORSMiddleware,
@@ -55,6 +56,7 @@ class A2AServer:
             allow_methods=["*"],
             allow_headers=["*"],
         )
+        self.start_time = time.time()
 
     def start(self):
         if self.agent_card is None:
@@ -66,17 +68,29 @@ class A2AServer:
         import uvicorn
 
         # Configure uvicorn with optimized settings for streaming
-        uvicorn.run(
-            self.app,
-            host=self.host,
-            port=self.port,
-            http="h11",
-            timeout_keep_alive=65,
-            log_level="info"
-        )
+        uvicorn.run(self.app, host=self.host, port=self.port, http="h11", timeout_keep_alive=65, log_level="info")
 
     def _get_agent_card(self, request: Request) -> JSONResponse:
         return JSONResponse(self.agent_card.model_dump(exclude_none=True))
+
+    def _get_status(self, request: Request) -> JSONResponse:
+        """
+        Status endpoint that returns basic server information.
+        This endpoint can be used by the frontend to check if the A2A server is running.
+        """
+        uptime_seconds = time.time() - self.start_time
+
+        status_info: Dict[str, Any] = {
+            "status": "ok",
+            "service": "mindsdb-a2a",
+            "uptime_seconds": round(uptime_seconds, 2),
+            "host": self.host,
+            "port": self.port,
+            "agent_name": self.agent_card.name if self.agent_card else None,
+            "version": self.agent_card.version if self.agent_card else "unknown",
+        }
+
+        return JSONResponse(status_info)
 
     async def _process_request(self, request: Request):
         try:
@@ -89,23 +103,15 @@ class A2AServer:
                 result = await self.task_manager.on_send_task(json_rpc_request)
             elif isinstance(json_rpc_request, SendTaskStreamingRequest):
                 # Don't await the async generator, just pass it to _create_response
-                result = self.task_manager.on_send_task_subscribe(
-                    json_rpc_request
-                )
+                result = self.task_manager.on_send_task_subscribe(json_rpc_request)
             elif isinstance(json_rpc_request, CancelTaskRequest):
                 result = await self.task_manager.on_cancel_task(json_rpc_request)
             elif isinstance(json_rpc_request, SetTaskPushNotificationRequest):
-                result = await self.task_manager.on_set_task_push_notification(
-                    json_rpc_request
-                )
+                result = await self.task_manager.on_set_task_push_notification(json_rpc_request)
             elif isinstance(json_rpc_request, GetTaskPushNotificationRequest):
-                result = await self.task_manager.on_get_task_push_notification(
-                    json_rpc_request
-                )
+                result = await self.task_manager.on_get_task_push_notification(json_rpc_request)
             elif isinstance(json_rpc_request, TaskResubscriptionRequest):
-                result = await self.task_manager.on_resubscribe_to_task(
-                    json_rpc_request
-                )
+                result = await self.task_manager.on_resubscribe_to_task(json_rpc_request)
             else:
                 logger.warning(f"Unexpected request type: {type(json_rpc_request)}")
                 raise ValueError(f"Unexpected request type: {type(request)}")
@@ -152,10 +158,10 @@ class A2AServer:
                     "X-Accel-Buffering": "no",
                     "Connection": "keep-alive",
                     "Content-Type": "text/event-stream",
-                    "Transfer-Encoding": "chunked"
+                    "Transfer-Encoding": "chunked",
                 },
                 # Explicitly set media_type
-                media_type="text/event-stream"
+                media_type="text/event-stream",
             )
         elif isinstance(result, JSONRPCResponse):
             return JSONResponse(result.model_dump(exclude_none=True))


### PR DESCRIPTION

## Description

This new endpoint returns server status, uptime, and configuration details, enabling easier monitoring and diagnostics. The implementation includes tracking server start time and leveraging the agent card for contextual data.


`curl -v http://localhost:47338/status`


```
{
  "status": "ok",
  "service": "mindsdb-a2a",
  "uptime_seconds": 23.03,
  "host": "localhost",
  "port": 47338,
  "agent_name": "MindsDB Agent Connector",
  "version": "1.0.0"
}
```

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



