### PR TITLE
Fix: "LogDBController" has no attribute 'get_tree_tables'

### DIFF
--- a/mindsdb/interfaces/database/log.py
+++ b/mindsdb/interfaces/database/log.py
@@ -217,6 +217,9 @@ class LogDBController:
     def get_tables(self) -> OrderedDict:
         return self._tables
 
+    def get_tree_tables(self) -> OrderedDict:
+        return self._tables
+
     def get_tables_rows(self) -> List[TablesRow]:
         return [
             TablesRow(TABLE_TYPE=TABLES_ROW_TYPE.SYSTEM_VIEW, TABLE_NAME=table_name)


### PR DESCRIPTION
## Description

Fixed error `AttributeError: 'LogDBController' object has no attribute 'get_tree_tables'`  when LOG database is openned in GUI (it is in list of system databases)

To fix it: method get_tree_tables is added in LogDBController (it is used by /api/tree endpoint)


Fixes #issue_number

## Type of change


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



