### PR TITLE
Reduced Token Usage in Generating Schema Information for Agents

### DIFF
--- a/mindsdb/interfaces/data_catalog/data_catalog_loader.py
+++ b/mindsdb/interfaces/data_catalog/data_catalog_loader.py
@@ -69,6 +69,8 @@ class DataCatalogLoader(BaseDataCatalog):
             self.logger.info(f"No tables to add for {self.database_name}.")
             return []
 
+        df.columns = df.columns.str.lower()
+
         # Filter out tables that are already loaded in the data catalog
         if loaded_table_names:
             df = df[~df["table_name"].isin(loaded_table_names)]
@@ -77,7 +79,6 @@ class DataCatalogLoader(BaseDataCatalog):
             self.logger.info(f"No new tables to load for {self.database_name}.")
             return []
 
-        df.columns = df.columns.str.lower()
         tables = self._add_table_metadata(df)
         self.logger.info(f"Tables loaded for {self.database_name}.")
         return tables

--- a/mindsdb/interfaces/skills/sql_agent.py
+++ b/mindsdb/interfaces/skills/sql_agent.py
@@ -402,11 +402,13 @@ class SQLAgent:
         """
         if config.get("data_catalog", {}).get("enabled", False):
             database_table_map = {}
-            for name in self.get_usable_table_names():
+            for name in (table_names or self.get_usable_table_names()):
                 name = name.replace("`", "")
 
-                # TODO: Can there be situations where the database name is returned from the above method?
                 parts = name.split(".", 1)
+                if len(parts) == 1:
+                    raise ValueError(f"Invalid table name: {name}. Expected format is 'database.table'.")
+
                 database_table_map[parts[0]] = database_table_map.get(parts[0], []) + [parts[1]]
 
             data_catalog_str = ""
@@ -430,8 +432,8 @@ class SQLAgent:
                 else:
                     all_tables.append(Identifier(name))
 
-            # if table_names is not None:
-            #     all_tables = self._resolve_table_names(table_names, all_tables)
+            if table_names is not None:
+                all_tables = self._resolve_table_names(table_names, all_tables)
 
             tables_info = []
             for table in all_tables:

--- a/mindsdb/interfaces/skills/sql_agent.py
+++ b/mindsdb/interfaces/skills/sql_agent.py
@@ -406,6 +406,8 @@ class SQLAgent:
                 name = name.replace("`", "")
 
                 parts = name.split(".", 1)
+                # TODO: Will there be situations where parts has more than 2 elements? Like a schema?
+                # This is unlikely given that we default to a single schema per database.
                 if len(parts) == 1:
                     raise ValueError(f"Invalid table name: {name}. Expected format is 'database.table'.")
 


### PR DESCRIPTION
## Description

This PR aims to reduce LLM token usage by generating schema information only for the tables requested by the agent rather than the entire data source.

Fixes https://linear.app/mindsdb/issue/BE-1068/reduce-token-usage-by-limiting-schema-information-generated-from-data

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.