### PR TITLE
Fix `ssl` option of mysql handler

### DIFF
--- a/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
+++ b/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
@@ -179,6 +179,9 @@ class MySQLHandler(DatabaseHandler):
                 config["ssl_cert"] = ssl_cert
             if ssl_key is not None:
                 config["ssl_key"] = ssl_key
+        elif ssl is False:
+            config["ssl_disabled"] = True
+
         if "collation" not in config:
             config["collation"] = "utf8mb4_general_ci"
         if "use_pure" not in config:


### PR DESCRIPTION
## Description

Previously, only `"ssl": true` had an effect, while `"ssl": false` was treated the same as omitting the parameter - in both cases, the database's default SSL settings were used.

Now the behavior is more explicit and consistent:
- When `ssl` is omitted: Use database's default SSL settings
- When `"ssl": true`: Force SSL connection
- When `"ssl": false`: Force non-SSL connection

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



