### PR TITLE
Added the Option to Use Default LLM as the Default Re-ranking Model

### DIFF
--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -54,8 +54,10 @@ def get_model_params(model_params: dict, default_config_key: str):
     """
     # If the default config key is for reranking and the switch to use the default LLM is enabled,
     # switch to the default LLM model.
-    if default_config_key == "default_reranking_model" and config.get("default_reranking_model").get("use_default_llm", False):
-            default_config_key = "default_llm_model"
+    if default_config_key == "default_reranking_model" and config.get("default_reranking_model").get(
+        "use_default_llm", False
+    ):
+        default_config_key = "default_llm_model"
 
     combined_model_params = copy.deepcopy(config.get(default_config_key, {}))
 


### PR DESCRIPTION
## Description

This PR adds the option to use the default LLM model as the default re-ranking model via the `use_default_llm` parameter.
The relevant UI feature has been indicated in the screenshot given below.

Fixes https://linear.app/mindsdb/issue/UNI-119/knowledge-base-cannot-be-created-if-user-adds-default-models

Depends on https://github.com/mindsdb/mindsdb-frontend/pull/3141

## Type of change

- [X] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

<img width="1507" alt="image" src="https://github.com/user-attachments/assets/d309c8cd-fa3b-4809-9255-748d84c6f8ba" />

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.