### PR TITLE
Add default value and description for SF columns metadata

### DIFF
--- a/mindsdb/integrations/handlers/salesforce_handler/salesforce_tables.py
+++ b/mindsdb/integrations/handlers/salesforce_handler/salesforce_tables.py
@@ -203,6 +203,8 @@ def create_table_class(resource_name: Text) -> MetaAPIResource:
                         "column_name": field["name"],
                         "data_type": field["type"],
                         "is_nullable": field.get("nillable", False),
+                        "default_value": field.get("defaultValue", ""),
+                        "description": field.get("inlineHelpText", ""),
                     }
                 )
 


### PR DESCRIPTION
## Description

This PR adds a description and default value for Salesforce columns. Note that  inlineHelpText provides actual additional information about the field's purpose and usage but is not a required value.

Fixes https://linear.app/mindsdb/issue/BE-1146/salesforce-data-catalogue-missing-fields

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



