### PR TITLE
Don't replace backticks

### DIFF
--- a/mindsdb/interfaces/skills/sql_agent.py
+++ b/mindsdb/interfaces/skills/sql_agent.py
@@ -403,8 +403,6 @@ class SQLAgent:
         if config.get("data_catalog", {}).get("enabled", False):
             database_table_map = {}
             for name in table_names or self.get_usable_table_names():
-                name = name.replace("`", "")
-
                 parts = name.split(".", 1)
                 # TODO: Will there be situations where parts has more than 2 elements? Like a schema?
                 # This is unlikely given that we default to a single schema per database.


### PR DESCRIPTION
## Description

This PR removes the logic that replaces backticks. Note that this bug is reproducible when the data catalog is not enabled; that's why it worked on the cloud.

Fixes https://linear.app/mindsdb/issue/BE-1149/querys-cant-be-parsed

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update


## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



