### PR TITLE
Fix `InterfaceError` for Snowflake Data Catalog stats

### DIFF
--- a/mindsdb/integrations/handlers/snowflake_handler/snowflake_handler.py
+++ b/mindsdb/integrations/handlers/snowflake_handler/snowflake_handler.py
@@ -597,6 +597,11 @@ class SnowflakeHandler(MetaDatabaseHandler):
                     max_val = stats_data.get(f"max_{col}", None)
                     null_pct = (nulls / total_rows) * 100 if total_rows is not None and total_rows > 0 else None
 
+                    if min_val is not None and not isinstance(min_val, (str, int, float)):
+                        min_val = str(min_val)
+                    if max_val is not None and not isinstance(max_val, (str, int, float)):
+                        max_val = str(max_val)
+
                     all_stats.append(
                         {
                             "table_name": table_name,

--- a/mindsdb/integrations/handlers/snowflake_handler/snowflake_handler.py
+++ b/mindsdb/integrations/handlers/snowflake_handler/snowflake_handler.py
@@ -597,11 +597,6 @@ class SnowflakeHandler(MetaDatabaseHandler):
                     max_val = stats_data.get(f"max_{col}", None)
                     null_pct = (nulls / total_rows) * 100 if total_rows is not None and total_rows > 0 else None
 
-                    if min_val is not None and not isinstance(min_val, (str, int, float)):
-                        min_val = str(min_val)
-                    if max_val is not None and not isinstance(max_val, (str, int, float)):
-                        max_val = str(max_val)
-
                     all_stats.append(
                         {
                             "table_name": table_name,

--- a/mindsdb/interfaces/data_catalog/data_catalog_loader.py
+++ b/mindsdb/interfaces/data_catalog/data_catalog_loader.py
@@ -1,9 +1,7 @@
 from typing import List, Union
 import pandas as pd
 import json
-from decimal import Decimal
 import datetime
-import uuid
 from mindsdb.integrations.libs.response import RESPONSE_TYPE
 from mindsdb.interfaces.data_catalog.base_data_catalog import BaseDataCatalog
 from mindsdb.interfaces.storage import db
@@ -384,14 +382,8 @@ class DataCatalogLoader(BaseDataCatalog):
         """
         if val is None:
             return None
-        if isinstance(val, (int, float, str, bool)):
-            return str(val)
-        if isinstance(val, Decimal):
-            return str(val)
         if isinstance(val, (datetime.datetime, datetime.date)):
             return val.isoformat()
-        if isinstance(val, uuid.UUID):
-            return str(val)
         if isinstance(val, (list, dict, set, tuple)):
             return json.dumps(val, default=str)
         return str(val)

--- a/mindsdb/interfaces/data_catalog/data_catalog_loader.py
+++ b/mindsdb/interfaces/data_catalog/data_catalog_loader.py
@@ -204,6 +204,12 @@ class DataCatalogLoader(BaseDataCatalog):
                 # Convert the distinct_values_count to an integer if it is not NaN, otherwise set it to None.
                 val = row.get("distinct_values_count")
                 distinct_values_count = int(val) if pd.notna(val) else None
+                min_val = row.get("minimum_value")
+                max_val = row.get("maximum_value")
+                if min_val is not None and not isinstance(min_val, (str, int, float)):
+                    min_val = str(min_val)
+                if max_val is not None and not isinstance(max_val, (str, int, float)):
+                    max_val = str(max_val)
 
                 # Convert the most_common_frequencies to a list of strings.
                 most_common_frequencies = [str(val) for val in row.get("most_common_frequencies") or []]
@@ -214,8 +220,8 @@ class DataCatalogLoader(BaseDataCatalog):
                     most_common_frequencies=most_common_frequencies,
                     null_percentage=row.get("null_percentage"),
                     distinct_values_count=distinct_values_count,
-                    minimum_value=row.get("minimum_value"),
-                    maximum_value=row.get("maximum_value"),
+                    minimum_value=min_val,
+                    maximum_value=max_val,
                 )
                 column_statistics.append(record)
 


### PR DESCRIPTION
## Description

Cast `min_val` and `max_val` to supported types before saving.  This ensures that all values being inserted into the database are of a type that SQLite can handle, preventing the InterfaceError.


Fixes https://linear.app/mindsdb/issue/BE-1166/fix-snowflake-dc-stats

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update


## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



