### PR TITLE
Changes to `test_mysql_api.py` based on db driver features

### DIFF
--- a/tests/integration/flows/test_mysql_api.py
+++ b/tests/integration/flows/test_mysql_api.py
@@ -360,7 +360,7 @@ class TestMySqlApi(BaseStuff):
                 f"Expected type {expected_type.code} for column {column_name}, but got {column_description['type_code']}, use_binary={self.use_binary}, table_name={table_name}"
             )
 
-            if os.uname().sysname == 'Darwin':
+            if os.uname().sysname == "Darwin":
                 # It seems that flags on macos may be modified by mysql.connector on the client side.
                 continue
             assert column_description["flags"] == sum(expected_type.flags), (

--- a/tests/integration/flows/test_mysql_api.py
+++ b/tests/integration/flows/test_mysql_api.py
@@ -1,3 +1,4 @@
+import os
 import time
 import json
 import tempfile
@@ -302,7 +303,7 @@ class TestMySqlApi(BaseStuff):
             "t_char": "Test      ",
             "t_varchar": "Test",
             "t_text": "Test",
-            "t_bytea": b"Demo binary data." if self.use_binary else "Demo binary data.",
+            "t_bytea": "Demo binary data.",
             "t_json": '{"name": "test"}',
             "t_jsonb": '{"name": "test"}',
             "t_xml": "<root><element>test</element><nested><value>123</value></nested></root>",
@@ -334,7 +335,9 @@ class TestMySqlApi(BaseStuff):
         for column_name, expected_type in expected_types.items():
             column_description = description_dict[column_name]
 
-            if column_name == "dt_date" and isinstance(row[column_name], datetime.datetime):
+            if column_name == "t_bytea" and isinstance(row[column_name], (bytearray, bytes)):
+                row[column_name] = row[column_name].decode()
+            elif column_name == "dt_date" and isinstance(row[column_name], datetime.datetime):
                 # NOTE sometime mysql.connector returns datetime instead of date for dt_date. This is suspicious, but ok
                 assert row[column_name].hour == 0
                 assert row[column_name].minute == 0
@@ -356,6 +359,10 @@ class TestMySqlApi(BaseStuff):
             assert column_description["type_code"] == expected_type.code, (
                 f"Expected type {expected_type.code} for column {column_name}, but got {column_description['type_code']}, use_binary={self.use_binary}, table_name={table_name}"
             )
+
+            if os.uname().sysname == 'Darwin':
+                # It seems that flags on macos may be modified by mysql.connector on the client side.
+                continue
             assert column_description["flags"] == sum(expected_type.flags), (
                 f"Expected flags {sum(expected_type.flags)} for column {column_name}, but got {column_description['flags']}, use_binary={self.use_binary}, table_name={table_name}"
             )


### PR DESCRIPTION
## Description

Two small changes to `test_mysql_api.py` to avoid 'features' of `mysql.connector`:
 - `mysql.connector` may return values of columns with `BYTEA` type as bytes/bytearray or string depend on env
 - it seems like `mysql.connector` may set `NUM_FLAG` to numeric columns at client side

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



