### PR TITLE
Fix: Redis Service Allows Unauthorized Privilege Escalation in docker/docker-compose-testing.yml

### DIFF
--- a/docker/docker-compose-testing.yml
+++ b/docker/docker-compose-testing.yml
@@ -5,6 +5,8 @@ version: "3.2"
 services:
 
   mysql:
+    security_opt:
+      - "no-new-privileges:true"
     image: mysql:8.0
     restart: always
     environment:


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** Service 'mysql' allows for privilege escalation via setuid or setgid binaries. Add 'no-new-privileges:true' in 'security_opt' to prevent this.
- **Rule ID:** yaml.docker-compose.security.no-new-privileges.no-new-privileges
- **Severity:** HIGH
- **File:** docker/docker-compose-testing.yml
- **Lines Affected:** 7 - 7

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `docker/docker-compose-testing.yml` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.