### PR TITLE
KB Evaluate: fix when base_url is empy string

### DIFF
--- a/mindsdb/interfaces/knowledge_base/llm_client.py
+++ b/mindsdb/interfaces/knowledge_base/llm_client.py
@@ -36,8 +36,11 @@ class LLMClient:
             )
         elif self.provider == "openai":
             openai_api_key = params.get("api_key") or os.getenv("OPENAI_API_KEY")
+            kwargs = {"api_key": openai_api_key, "max_retries": 2}
             base_url = params.get("base_url")
-            self.client = OpenAI(api_key=openai_api_key, base_url=base_url, max_retries=2)
+            if base_url:
+                kwargs["base_url"] = base_url
+            self.client = OpenAI(**kwargs)
 
         else:
             # try to use litellm


### PR DESCRIPTION
## Description

If base_url is empty 'Evaluate' returns "Connection error."

empty base_url can be save in gui or set up in query:

```sql
EVALUATE KNOWLEDGE_BASE my_kb_new
USING
    test_table = files.my_test_table,
    generate_data = true,  
    llm = {
        "provider": "openai",
        "model_name": "gpt-4o",
        "api_key": 
        "base_url":""
    }
```

Fixes #issue_number

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



