### PR TITLE
KB error messages

### DIFF
--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -774,6 +774,9 @@ class KnowledgeBaseTable:
     def call_litellm_embedding(session, model_params, messages):
         args = copy.deepcopy(model_params)
 
+        if "model_name" not in args:
+            raise ValueError("'model_name' must be provided for embedding model")
+
         llm_model = args.pop("model_name")
         engine = args.pop("provider")
 
@@ -1081,7 +1084,10 @@ class KnowledgeBaseController:
         except PredictorRecordNotFound:
             pass
 
-        if params.get("provider", None) not in ("openai", "azure_openai"):
+        if "provider" not in params:
+            raise ValueError("'provider' parameter is required for embedding model")
+
+        if params["provider"] not in ("openai", "azure_openai"):
             # try use litellm
             KnowledgeBaseTable.call_litellm_embedding(self.session, params, ["test"])
             return

--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -754,8 +754,7 @@ class KnowledgeBaseTable:
         if model_id is None:
             # call litellm handler
             messages = list(df[TableField.CONTENT.value])
-            embedding_params = copy.deepcopy(config.get("default_embedding_model", {}))
-            embedding_params.update(self._kb.params["embedding_model"])
+            embedding_params = get_model_params(self._kb.params.get("embedding_model", {}), "default_embedding_model")
             results = self.call_litellm_embedding(self.session, embedding_params, messages)
             results = [[val] for val in results]
             return pd.DataFrame(results, columns=[TableField.EMBEDDINGS.value])

--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -61,7 +61,7 @@ class KnowledgeBaseInputParams(BaseModel):
     reranking_model: Dict[Text, Any] | None = None
 
     class Config:
-        extra = 'forbid'
+        extra = "forbid"
 
 
 def get_model_params(model_params: dict, default_config_key: str):
@@ -961,9 +961,9 @@ class KnowledgeBaseController:
         except ValidationError as e:
             problems = []
             for error in e.errors():
-                parameter = '.'.join([str(i) for i in error['loc']])
-                param_type = error['type']
-                if param_type == 'extra_forbidden':
+                parameter = ".".join([str(i) for i in error["loc"]])
+                param_type = error["type"]
+                if param_type == "extra_forbidden":
                     msg = f"Parameter '{parameter}' is not allowed"
                 else:
                     msg = f"Error in '{parameter}' (type: {param_type}): {error['msg']}. Input: {repr(error['input'])}"
@@ -1031,7 +1031,7 @@ class KnowledgeBaseController:
             # This is called here to check validaity of the parameters.
             try:
                 reranker = get_reranking_model_from_params(reranking_model_params)
-                reranker.get_scores('test', ['test'])
+                reranker.get_scores("test", ["test"])
             except (ValueError, RuntimeError) as e:
                 raise RuntimeError(f"Problem with reranker config: {e}")
 


### PR DESCRIPTION
## Description

Improved error messaging during creating knowledge base:

- checking 'create knowledge base' set of parameter using [pydantic model](https://github.com/mindsdb/mindsdb/pull/11198/files#diff-dbf2257347198d1e8e904591465da2f38dcbe69c9b9163809bca0b9ae237a852R53)
  - check input names and types
  - forbid using unknown parameters
-  check 'embedding_model' parameters:
   - 'provider' have to be passed 
   - for litellm models: 'model_name' have to be passed
   - for openai/azure models: 'api_key' have to be passed 
-  check 'reranking_model' parameters
   - 'model_name' have to be passed
   - 'provider' have to be passed
   - try to call reranker llm to check if parameters are OK: api key, base_url and others

Fixed problem with litellm embedding model
- if it was set in config and knowledge base is created without 'embedding_model' parameter:  it showed "embedding_model" error message


Fixes https://linear.app/mindsdb/issue/UNI-126/non-descriptive-knowledge-base-error
Fixes https://linear.app/mindsdb/issue/UNI-148/embedding-issues-with-google

Examples of error messages:
```
Problem with reranker config: Error during reranking: Error code: 401 - {'error': {'code': '401', 'message': 'Access denied due to invalid subscription key or wrong API endpoint. Make sure to provide a valid key for an active subscription and use a correct regional API endpoint for your resource.'}}

Problem with reranker config: 'model_name' must be provided for reranking model

'provider' parameter is required for embedding model

'api_key' parameter is required for embedding model

Problem with embedding model config: litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model=azure_openai1/text-embedding-ada-002
 Pass model as E.g. For 'Huggingface' inference endpoints pass in 

Problem with embedding model config: 'model_name' must be provided for embedding model
 
Problem with reranker config: Error during reranking: litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model=ollama1/gpt-4o
 Pass model as E.g. For 'Huggingface' inference endpoints pass in 
 
Problem with reranker config: Error during reranking: litellm.APIConnectionError: Error code: 404 - {'error': {'code': '404', 'message': 'Resource not found'}}
Traceback (most recent call last):
 
Problem with reranker config: Error during reranking: litellm.APIConnectionError: Error code: 401 - {'error': {'message': 'Incorrect API key provided: -
 
Problem with knowledge base params: Parameter 'content_column' is not allowed

Problem with knowledge base params: Error in 'content_columns.0' (type: string_type): Input should be a valid string. Input: 1

Problem with knowledge base params: Error in 'embedding_model' (type: dict_type): Input should be a valid dictionary. Input: [1]
```

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)


## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



