### PR TITLE
Better db error message formatting

### DIFF
--- a/mindsdb/api/executor/datahub/datanodes/integration_datanode.py
+++ b/mindsdb/api/executor/datahub/datanodes/integration_datanode.py
@@ -245,12 +245,14 @@ class IntegrationDataNode(DataNode):
             if query is not None:
                 failed_sql_query = query.to_string()
 
-            raise Exception(format_db_error_message(
-                db_name=self.integration_handler.name,
-                db_type=self.integration_handler.__class__.name,
-                db_error_msg=result.error_message,
-                failed_query=failed_sql_query
-            ))
+            raise Exception(
+                format_db_error_message(
+                    db_name=self.integration_handler.name,
+                    db_type=self.integration_handler.__class__.name,
+                    db_error_msg=result.error_message,
+                    failed_query=failed_sql_query,
+                )
+            )
 
         if result.type == RESPONSE_TYPE.OK:
             return DataHubResponse(affected_rows=result.affected_rows)

--- a/mindsdb/utilities/exception.py
+++ b/mindsdb/utilities/exception.py
@@ -4,35 +4,43 @@ from textwrap import indent
 class BaseEntityException(Exception):
     """Base exception for entitys errors
 
-        Attributes:
-            message (str): error message
-            entity_name (str): entity name
+    Attributes:
+        message (str): error message
+        entity_name (str): entity name
     """
+
     def __init__(self, message: str, entity_name: str = None) -> None:
         self.message = message
-        self.entity_name = entity_name or 'unknown'
+        self.entity_name = entity_name or "unknown"
 
     def __str__(self) -> str:
-        return f'{self.message}: {self.entity_name}'
+        return f"{self.message}: {self.entity_name}"
 
 
 class EntityExistsError(BaseEntityException):
     """Raise when entity exists, but should not"""
+
     def __init__(self, message: str = None, entity_name: str = None) -> None:
         if message is None:
-            message = 'Entity exists error'
+            message = "Entity exists error"
         super().__init__(message, entity_name)
 
 
 class EntityNotExistsError(BaseEntityException):
     """Raise when entity not exists, but should"""
+
     def __init__(self, message: str = None, entity_name: str = None) -> None:
         if message is None:
-            message = 'Entity does not exists error'
+            message = "Entity does not exists error"
         super().__init__(message, entity_name)
 
 
-def format_db_error_message(db_name: str | None = None, db_type: str | None = None, db_error_msg: str | None = None, failed_query: str | None = None) -> str:
+def format_db_error_message(
+    db_name: str | None = None,
+    db_type: str | None = None,
+    db_error_msg: str | None = None,
+    failed_query: str | None = None,
+) -> str:
     """Format the error message for the database query.
 
     Args:


### PR DESCRIPTION
## Description

Improved error message for db errors and added function for message formatting.
Example of error message:
```sql
select * from local_pg (select unexisting_fn());
```
```txt

Failed to execute external database query during query processing.

Database Details:
- Name: local_pg
- Type: postgres

Error:
    function unexisting_fn() does not exist
    LINE 1: select unexisting_fn()
                   ^
    HINT:  No function matches the given name and argument types. You might need to add explicit type casts.

Failed Query:
    select unexisting_fn()
```

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



