### PR TITLE
fix: convert minimum and maximum values to strings in DataCatalogLoader

### DIFF
--- a/mindsdb/interfaces/data_catalog/data_catalog_loader.py
+++ b/mindsdb/interfaces/data_catalog/data_catalog_loader.py
@@ -208,14 +208,20 @@ class DataCatalogLoader(BaseDataCatalog):
                 # Convert the most_common_frequencies to a list of strings.
                 most_common_frequencies = [str(val) for val in row.get("most_common_frequencies") or []]
 
+                # Convert minimum_value and maximum_value to strings to handle Timestamp objects and other non-string types
+                min_val = row.get("minimum_value")
+                max_val = row.get("maximum_value")
+                minimum_value = str(min_val) if min_val is not None and pd.notna(min_val) else None
+                maximum_value = str(max_val) if max_val is not None and pd.notna(max_val) else None
+
                 record = db.MetaColumnStatistics(
                     column_id=column_id,
                     most_common_values=row.get("most_common_values"),
                     most_common_frequencies=most_common_frequencies,
                     null_percentage=row.get("null_percentage"),
                     distinct_values_count=distinct_values_count,
-                    minimum_value=row.get("minimum_value"),
-                    maximum_value=row.get("maximum_value"),
+                    minimum_value=minimum_value,
+                    maximum_value=maximum_value,
                 )
                 column_statistics.append(record)
 


### PR DESCRIPTION
## Description

Fix errors creating the data catalog while creating agent.

```
2025-07-01 04:20:31,800            http INFO     snowflake.connector.connection: Snowflake Connector for Python Version: 3.15.0, Python Version: 3.10.18, Platform: Linux-6.8.0-1029-aws-x86_64-with-glibc2.36
2025-07-01 04:20:31,801            http INFO     snowflake.connector.connection: Connecting to GLOBAL Snowflake domain
2025-07-01 04:20:32,226            http INFO     mindsdb: Loading tables for prod_db
2025-07-01 04:20:34,130            http INFO     mindsdb: Tables loaded for prod_db.
2025-07-01 04:20:34,130            http INFO     mindsdb: Loading columns for prod_db
2025-07-01 04:20:35,949            http INFO     mindsdb: Columns loaded for prod_db.
2025-07-01 04:20:35,950            http INFO     mindsdb: Loading column statistics for prod_db
2025-07-01 04:20:49,438            http ERROR    mindsdb: Failed to add column statistics: (sqlite3.InterfaceError) Error binding parameter 5 - probably unsupported type.
[SQL: INSERT INTO meta_column_statistics (column_id, most_common_values, most_common_frequencies, null_percentage, distinct_values_count, minimum_value, maximum_value) VALUES (?, ?, ?, ?, ?, ?, ?)]

2025-07-01 04:20:49,446            http ERROR    mindsdb.api.http.namespaces.sql: Error query processing: 
Traceback (most recent call last):
  File "/venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1936, in _exec_single_context
    self.dialect.do_executemany(
  File "/venv/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 938, in do_executemany
    cursor.executemany(statement, parameters)
sqlite3.InterfaceError: Error binding parameter 5 - probably unsupported type.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/mindsdb/./mindsdb/api/http/namespaces/sql.py", line 60, in post
    result: SQLAnswer = mysql_proxy.process_query(query)
  File "/mindsdb/./mindsdb/utilities/profiler/profiler.py", line 141, in wrapper
    result = function(*args, **kwargs)
  File "/mindsdb/./mindsdb/api/mysql/mysql_proxy/mysql_proxy.py", line 506, in process_query
    executor.query_execute(sql)
  File "/mindsdb/./mindsdb/utilities/profiler/profiler.py", line 141, in wrapper
    result = function(*args, **kwargs)
  File "/mindsdb/./mindsdb/api/mysql/mysql_proxy/executor/mysql_executor.py", line 83, in query_execute
    self.do_execute()
  File "/mindsdb/./mindsdb/utilities/profiler/profiler.py", line 141, in wrapper
    result = function(*args, **kwargs)
  File "/mindsdb/./mindsdb/api/mysql/mysql_proxy/executor/mysql_executor.py", line 111, in do_execute
    executor_answer: ExecuteAnswer = self.command_executor.execute_command(self.query)
  File "/mindsdb/./mindsdb/utilities/profiler/profiler.py", line 141, in wrapper
    result = function(*args, **kwargs)
  File "/mindsdb/./mindsdb/api/executor/command_executor.py", line 618, in execute_command
    return self.answer_create_agent(statement, database_name)
  File "/mindsdb/./mindsdb/api/executor/command_executor.py", line 1421, in answer_create_agent
    _ = self.session.agents_controller.add_agent(
  File "/mindsdb/./mindsdb/interfaces/agents/agents_controller.py", line 342, in add_agent
    data_catalog_loader.load_metadata()
  File "/mindsdb/./mindsdb/interfaces/data_catalog/data_catalog_loader.py", line 29, in load_metadata
    self._load_column_statistics(tables, columns)
  File "/mindsdb/./mindsdb/interfaces/data_catalog/data_catalog_loader.py", line 185, in _load_column_statistics
    self._add_column_statistics(df, tables, columns)
  File "/mindsdb/./mindsdb/interfaces/data_catalog/data_catalog_loader.py", line 223, in _add_column_statistics
    db.session.commit()
  File "/venv/lib/python3.10/site-packages/sqlalchemy/orm/scoping.py", line 597, in commit
    return self._proxied.commit()
  File "/venv/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 2028, in commit
    trans.commit(_to_root=True)
  File "<string>", line 2, in commit
  File "/venv/lib/python3.10/site-packages/sqlalchemy/orm/state_changes.py", line 139, in _go
    ret_value = fn(self, *arg, **kw)
  File "/venv/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 1313, in commit
    self._prepare_impl()
  File "<string>", line 2, in _prepare_impl
  File "/venv/lib/python3.10/site-packages/sqlalchemy/orm/state_changes.py", line 139, in _go
    ret_value = fn(self, *arg, **kw)
  File "/venv/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 1288, in _prepare_impl
    self.session.flush()
  File "/venv/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 4352, in flush
    self._flush(objects)
  File "/venv/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 4487, in _flush
    with util.safe_reraise():
  File "/venv/lib/python3.10/site-packages/sqlalchemy/util/langhelpers.py", line 146, in __exit__
    raise exc_value.with_traceback(exc_tb)
  File "/venv/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 4448, in _flush
    flush_context.execute()
  File "/venv/lib/python3.10/site-packages/sqlalchemy/orm/unitofwork.py", line 466, in execute
    rec.execute(self)
  File "/venv/lib/python3.10/site-packages/sqlalchemy/orm/unitofwork.py", line 642, in execute
    util.preloaded.orm_persistence.save_obj(
  File "/venv/lib/python3.10/site-packages/sqlalchemy/orm/persistence.py", line 93, in save_obj
    _emit_insert_statements(
  File "/venv/lib/python3.10/site-packages/sqlalchemy/orm/persistence.py", line 1048, in _emit_insert_statements
    result = connection.execute(
  File "/venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1418, in execute
    return meth(
  File "/venv/lib/python3.10/site-packages/sqlalchemy/sql/elements.py", line 515, in _execute_on_connection
    return connection._execute_clauseelement(
  File "/venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1640, in _execute_clauseelement
    ret = self._execute_context(
  File "/venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1846, in _execute_context
    return self._exec_single_context(
  File "/venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1986, in _exec_single_context
    self._handle_dbapi_exception(
  File "/venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 2355, in _handle_dbapi_exception
    raise sqlalchemy_exception.with_traceback(exc_info[2]) from e
  File "/venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1936, in _exec_single_context
    self.dialect.do_executemany(
  File "/venv/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 938, in do_executemany
    cursor.executemany(statement, parameters)
sqlalchemy.exc.InterfaceError: (sqlite3.InterfaceError) Error binding parameter 5 - probably unsupported type.
[SQL: INSERT INTO meta_column_statistics (column_id, most_common_values, most_common_frequencies, null_percentage, distinct_values_count, minimum_value, maximum_value) VALUES (?, ?, ?, ?, ?, ?, ?)]

(Background on this error at: https://sqlalche.me/e/20/rvf5)
```


## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [x]   Test Location: Specify the URL or path for testing.
 - [x]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



