### PR TITLE
Changed Config Update Behavior to Overwrite Default Model Parameters

### DIFF
--- a/mindsdb/api/http/namespaces/config.py
+++ b/mindsdb/api/http/namespaces/config.py
@@ -53,6 +53,15 @@ class GetConfig(Resource):
                         HTTPStatus.BAD_REQUEST, "Wrong arguments", f"Unknown argumens: {unknown_arguments}"
                     )
 
+        overwrite_arguments = {"default_llm", "default_embedding_model", "default_reranking_model"}
+        overwrite_data = {k: data[k] for k in overwrite_arguments if k in data}
+        merge_data = {k: data[k] for k in data if k not in overwrite_arguments}
+
+        if len(overwrite_data) > 0:
+            Config().update(overwrite_data, overwrite=True)
+        if len(merge_data) > 0:
+            Config().update(merge_data)
+
         Config().update(data)
 
         return "", 200

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -28,6 +28,13 @@ def _merge_configs(original_config: dict, override_config: dict) -> dict:
     return original_config
 
 
+def _overwrite_configs(original_config: dict, override_config: dict) -> dict:
+    """Overwrite original config with override config."""
+    for key in list(override_config.keys()):
+        original_config[key] = override_config[key]
+    return original_config
+
+
 def create_data_dir(path: Path) -> None:
     """Create a directory and checks that it is writable.
 
@@ -522,11 +529,23 @@ class Config:
         self.ensure_auto_config_is_relevant()
         return self._config
 
-    def update(self, data: dict) -> None:
-        """Update calues in `auto` config"""
+    def update(self, data: dict, overwrite: bool = False) -> None:
+        """
+        Update values in `auto` config.
+        Args:
+            data (dict): data to update in `auto` config.
+            overwrite (bool): if True, overwrite existing keys, otherwise merge them.
+                - False (default): Merge recursively. Existing nested dictionaries are preserved 
+                and only the specified keys in `data` are updated.
+                - True: Overwrite completely. Existing keys are replaced entirely with values 
+                from `data`, discarding any nested structure not present in `data`.
+        """
         self.ensure_auto_config_is_relevant()
 
-        _merge_configs(self._auto_config, data)
+        if overwrite:
+            _overwrite_configs(self._auto_config, data)
+        else:
+            _merge_configs(self._auto_config, data)
 
         self.auto_config_path.write_text(json.dumps(self._auto_config, indent=4))
 

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -535,9 +535,9 @@ class Config:
         Args:
             data (dict): data to update in `auto` config.
             overwrite (bool): if True, overwrite existing keys, otherwise merge them.
-                - False (default): Merge recursively. Existing nested dictionaries are preserved 
+                - False (default): Merge recursively. Existing nested dictionaries are preserved
                 and only the specified keys in `data` are updated.
-                - True: Overwrite completely. Existing keys are replaced entirely with values 
+                - True: Overwrite completely. Existing keys are replaced entirely with values
                 from `data`, discarding any nested structure not present in `data`.
         """
         self.ensure_auto_config_is_relevant()


### PR DESCRIPTION
## Description

This PR updates the PUT /config endpoint to overwrite the configuration items related to default models rather than merge them.

The reason for this to handle situations where users change between model providers and the first provider contains parameters that are not compatible with the second. For example, if the user first sets the default model to Azure OpenAI, which expects an `api_version` parameter and then switches to OpenAI, if the configs are merged, `api_version` will still be passed when running OpenAI. This will result in errors.

Fixes https://linear.app/mindsdb/issue/UNI-121/to-markdown-function-fails-when-default-model-settings-are-applied

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added - N/A