### PR TITLE
remove redundant OpenAI API key injection logic in agents

### DIFF
--- a/mindsdb/api/http/namespaces/agents.py
+++ b/mindsdb/api/http/namespaces/agents.py
@@ -377,13 +377,6 @@ class AgentCompletions(Resource):
                 HTTPStatus.NOT_FOUND, "Project not found", f"Project with name {project_name} does not exist"
             )
 
-        # Add OpenAI API key to agent params if not already present.
-        if not existing_agent.params:
-            existing_agent.params = {}
-        existing_agent.params["openai_api_key"] = existing_agent.params.get(
-            "openai_api_key", os.getenv("OPENAI_API_KEY")
-        )
-
         # set mode to `retrieval` if agent has a skill of type `retrieval` and mode is not set
         if "mode" not in existing_agent.params and any(
             rel.skill.type == "retrieval" for rel in existing_agent.skills_relationships


### PR DESCRIPTION
## Description


Small patch to fix agent completion endpoint

It was causing rest api for agent completion to fail if user is passing in api_key in create

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



