### PR TITLE
Fix inserting to vectordb handler 

### DIFF
--- a/mindsdb/api/executor/datahub/datanodes/integration_datanode.py
+++ b/mindsdb/api/executor/datahub/datanodes/integration_datanode.py
@@ -164,7 +164,11 @@ class IntegrationDataNode(DataNode):
             df = result_set.to_df()
 
             result: HandlerResponse = self.integration_handler.insert(table_name.parts[-1], df)
-            return DataHubResponse(affected_rows=result.affected_rows)
+            if result is not None:
+                affected_rows = result.affected_rows
+            else:
+                affected_rows = None
+            return DataHubResponse(affected_rows=affected_rows)
 
         insert_columns = [Identifier(parts=[x.alias]) for x in result_set.columns]
 


### PR DESCRIPTION
## Description

When vector handler (for example pgvector) is used as data handler there is error appears during insert into vectordb table:
`AttributeError: 'NoneType' object has no attribute 'affected_rows'`
This PR fixes it

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



