### PR TITLE
Support of SQL `TABLE` statement

### DIFF
--- a/tests/unit/executor/test_executor.py
+++ b/tests/unit/executor/test_executor.py
@@ -92,15 +92,16 @@ class Test(BaseExecutorMockPredictor):
 
     @patch("mindsdb.integrations.handlers.postgres_handler.Handler")
     def test_integration_select(self, mock_handler):
-        data = [[1, "x"], [1, "y"]]
+        data = [[1, "x"], [2, "y"], [3, "z"]]
         df = pd.DataFrame(data, columns=["a", "b"])
         self.set_handler(mock_handler, name="pg", tables={"tasks": df})
 
         ret = self.execute("select * from pg.tasks")
         assert ret.data.to_lists() == data
-
-        # check sql in query method
         assert mock_handler().query.call_args[0][0].to_string() == "SELECT * FROM tasks"
+
+        ret = self.execute("table pg.tasks order by a desc limit 2 offset 1")
+        assert ret.data.to_lists() == [[2, "y"], [1, "x"]]
 
     def test_predictor_1_row(self):
         predicted_value = 3.14


### PR DESCRIPTION
## Description

Added support of SQL `TABLE` statement:
```sql
TABLE table_name 
    [ORDER BY column_name] 
    [LIMIT number [OFFSET number]]
```
Require https://github.com/mindsdb/mindsdb_sql_parser/pull/52

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



