### PR TITLE
Correct error message for `DELETE TABLE` if database not exists

### DIFF
--- a/mindsdb/api/executor/command_executor.py
+++ b/mindsdb/api/executor/command_executor.py
@@ -1221,9 +1221,11 @@ class ExecuteCommands:
                 db_name = database_name
 
             dn = self.session.datahub[db_name]
+            if dn is None:
+                raise ExecutorException(f"Cannot delete a table from database '{db_name}': the database does not exist")
+
             if db_name is not None:
                 dn.drop_table(table, if_exists=statement.if_exists)
-
             elif db_name in self.session.database_controller.get_dict(filter_type="project"):
                 # TODO do we need feature: delete object from project via drop table?
 


### PR DESCRIPTION
## Description

Set a correct error message when executing the "DELETE TABLE" command in case the database does not exist.
<img width="1209" height="360" alt="image" src="https://github.com/user-attachments/assets/9a66a553-2e6a-49c5-a050-a343b1b11be4" />

Fixes #11081

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



