### PR TITLE
fix(oracle): Add support for thick_mode with configurable Oracle clie…

### DIFF
--- a/mindsdb/integrations/handlers/oracle_handler/oracle_handler.py
+++ b/mindsdb/integrations/handlers/oracle_handler/oracle_handler.py
@@ -188,7 +188,21 @@ class OracleHandler(DatabaseHandler):
             raise ValueError("Required parameters (user, password) must be provided.")
 
         if self.connection_data.get("thick_mode", False):
-            oracledb.init_oracle_client()
+            try:
+                lib_dir = self.connection_data.get("oracle_client_path")
+                if lib_dir:
+                    logger.debug(f"Initializing Oracle client in thick mode with lib_dir: {lib_dir}")
+                    oracledb.init_oracle_client(lib_dir=lib_dir)
+                else:
+                    logger.debug("Initializing Oracle client in thick mode with system default paths.")
+                    oracledb.init_oracle_client()
+            except Exception as e:
+                logger.error(
+                    f"Failed to initialize Oracle client in thick mode. "
+                    f"Ensure Oracle Instant Client is installed. Error: {e}"
+                    )
+                logger.error("See: https://python-oracledb.readthedocs.io/en/latest/user_guide/initialization.html")
+                raise
 
         config = {
             "user": self.connection_data["user"],


### PR DESCRIPTION
### Description

This PR adds support for connecting to Oracle databases in **thick mode** using the `oracledb` driver with Oracle Instant Client. It improves error handling and flexibility when using `thick_mode: true` and allows users to optionally pass a custom path to the Oracle client library.

### What was happening?

When users enabled `thick_mode: true` in their Oracle connection configuration, the code attempted to use Oracle Instant Client, but failed with:
```bash
DPI-1047: Cannot locate a 64-bit Oracle Client library: "libclntsh.so: cannot open shared object file
```

This happened because `oracledb.init_oracle_client()` was called without specifying the path to the Oracle client (`libclntsh.so`), which must either be available in system paths or explicitly passed.

---

###  What’s fixed

- Updated `oracle_handler.py` to detect and initialize thick mode with:

 ```python
  if self.connection_data.get("thick_mode", False):
      try:
          lib_dir = self.connection_data.get("oracle_client_path")
          if lib_dir:
              oracledb.init_oracle_client(lib_dir=lib_dir)
          else:
              oracledb.init_oracle_client()
      except Exception as e:
          logger.error(f"Failed to initialize Oracle client in thick mode: {e}")
          raise
```
- Added logging for better traceability and user guidance.
- Preserves behavior when `thick_mode` is disabled (defaults to thin mode).
- Adds flexibility via the optional `oracle_client_path` key.

###  Example Usage
SQL Configuration
```sql
CREATE DATABASE oracle_thick
WITH ENGINE = "oracle",
PARAMETERS = {
    "user": "admin",
    "password": "yourpassword",
    "dsn": "adb.us-phoenix-1.oraclecloud.com/mydb_high",
    "thick_mode": true,
    "oracle_client_path": "/opt/oracle_client"  -- optional path to libclntsh.so
};
```
YAML Equivalent
```yaml
user: admin
password: yourpassword
dsn: adb.us-phoenix-1.oraclecloud.com/mydb_high
thick_mode: true
oracle_client_path: /opt/oracle_client
```
### Type of Change
 - Bug fix (non-breaking change which fixes an issue)

### Checklist
- Code uses proper error handling and fallback logic.
- Logging added to trace `thick_mode` behavior and failures.
- The change is backward-compatible with thin mode.
- Manual testing done against Oracle ADB thick mode scenarios.

 Fixes #11289 