### PR TITLE
Pgvector: render queries with sqlalchemy render

### DIFF
--- a/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
+++ b/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
@@ -5,7 +5,19 @@ from urllib.parse import urlparse
 
 import pandas as pd
 import psycopg
-from mindsdb_sql_parser.ast import Parameter, Identifier, Update, BinaryOperation
+from mindsdb_sql_parser.ast import (
+    Parameter,
+    Identifier,
+    BinaryOperation,
+    Tuple as AstTuple,
+    Constant,
+    Select,
+    OrderBy,
+    TypeCast,
+    Delete,
+    Update,
+    Function,
+)
 from pgvector.psycopg import register_vector
 
 from mindsdb.integrations.handlers.postgres_handler.postgres_handler import (
@@ -170,16 +182,19 @@ class PgVectorHandler(PostgresHandler, VectorStoreHandler, KeywordSearchBase):
         embedding_condition = None
 
         for condition in conditions:
+            is_embedding = condition.column == "embeddings"
+
             parts = condition.column.split(".")
-            key = parts[0]
+            key = Identifier(parts[0])
+
             # converts 'col.el1.el2' to col->'el1'->>'el2'
             if len(parts) > 1:
                 # intermediate elements
                 for el in parts[1:-1]:
-                    key += f" -> '{el}'"
+                    key = BinaryOperation(op="->", args=[key, Constant(el)])
 
                 # last element
-                key += f" ->> '{parts[-1]}'"
+                key = BinaryOperation(op="->>", args=[key, Constant(parts[-1])])
 
             type_cast = None
             value = condition.value
@@ -195,14 +210,14 @@ class PgVectorHandler(PostgresHandler, VectorStoreHandler, KeywordSearchBase):
             elif isinstance(value, float):
                 type_cast = "float"
             if type_cast is not None:
-                key = f"({key})::{type_cast}"
+                key = TypeCast(type_cast, key)
 
             item = {
                 "name": key,
                 "op": condition.op.value,
                 "value": condition.value,
             }
-            if key == "embeddings":
+            if is_embedding:
                 embedding_condition = item
             else:
                 filter_conditions.append(item)
@@ -214,64 +229,24 @@ class PgVectorHandler(PostgresHandler, VectorStoreHandler, KeywordSearchBase):
         """
         Construct where clauses from filter conditions
         """
-        if filter_conditions is None:
-            return ""
 
-        where_clauses = []
+        where_clause = None
 
         for item in filter_conditions:
             key = item["name"]
 
             if item["op"].lower() in ("in", "not in"):
-                values = list(repr(i) for i in item["value"])
-                item["value"] = "({})".format(", ".join(values))
+                values = [Constant(i) for i in item["value"]]
+                value = AstTuple(values)
             else:
-                if item["value"] is None:
-                    item["value"] = "null"
-                else:
-                    item["value"] = repr(item["value"])
-            where_clauses.append(f"{key} {item['op']} {item['value']}")
+                value = Constant(item["value"])
+            condition = BinaryOperation(op=item["op"], args=[key, value])
 
-        if len(where_clauses) > 1:
-            return f"WHERE {' AND '.join(where_clauses)}"
-        elif len(where_clauses) == 1:
-            return f"WHERE {where_clauses[0]}"
-        else:
-            return ""
-
-    @staticmethod
-    def _construct_where_clause_with_keywords(filter_conditions=None, keyword_query=None, content_column_name=None):
-        if not keyword_query or not content_column_name:
-            return PgVectorHandler._construct_where_clause(filter_conditions)
-
-        keyword_query_condition = (
-            f"""to_tsvector('english', {content_column_name}) @@ websearch_to_tsquery('english', '{keyword_query}')"""
-        )
-        if filter_conditions is None:
-            return ""
-
-        where_clauses = []
-
-        for item in filter_conditions:
-            key = item["name"]
-
-            if item["op"].lower() in ("in", "not in"):
-                values = list(repr(i) for i in item["value"])
-                item["value"] = "({})".format(", ".join(values))
+            if where_clause is None:
+                where_clause = condition
             else:
-                if item["value"] is None:
-                    item["value"] = "null"
-                else:
-                    item["value"] = repr(item["value"])
-            where_clauses.append(f"{key} {item['op']} {item['value']}")
-
-        where_clauses.append(keyword_query_condition)
-        if len(where_clauses) > 1:
-            return f"WHERE {' AND '.join(where_clauses)}"
-        elif len(where_clauses) == 1:
-            return f"WHERE {where_clauses[0]}"
-        else:
-            return ""
+                where_clause = BinaryOperation(op="AND", args=[where_clause, condition])
+        return where_clause
 
     @staticmethod
     def _construct_full_after_from_clause(
@@ -284,9 +259,8 @@ class PgVectorHandler(PostgresHandler, VectorStoreHandler, KeywordSearchBase):
     def _build_keyword_bm25_query(
         self,
         table_name: str,
-        query: str,
+        keyword_search_args: KeywordSearchArgs,
         columns: List[str] = None,
-        content_column_name: str = "content",
         conditions: List[FilterCondition] = None,
         limit: int = None,
         offset: int = None,
@@ -295,21 +269,42 @@ class PgVectorHandler(PostgresHandler, VectorStoreHandler, KeywordSearchBase):
             columns = ["id", "content", "metadata"]
 
         filter_conditions, _ = self._translate_conditions(conditions)
+        where_clause = self._construct_where_clause(filter_conditions)
 
-        # given filter conditions, construct where clause
-        where_clause = self._construct_where_clause_with_keywords(filter_conditions, query, content_column_name)
+        if keyword_search_args:
+            keyword_query_condition = BinaryOperation(
+                op="@@",
+                args=[
+                    Function("to_tsvector", args=[Constant("english"), Identifier(keyword_search_args.column)]),
+                    Function("websearch_to_tsquery", args=[Constant("english"), Constant(keyword_search_args.query)]),
+                ],
+            )
 
-        query = f"""
-            SELECT
-                {", ".join(columns)},
-                ts_rank_cd(to_tsvector('english', {content_column_name}), websearch_to_tsquery('english', '{query}')) as distance
-            FROM
-                {table_name}
-            {where_clause if where_clause else ""}
-            {f"LIMIT {limit}" if limit else ""}
-            {f"OFFSET {offset}" if offset else ""};"""
+            if where_clause:
+                where_clause = BinaryOperation(op="AND", args=[where_clause, keyword_query_condition])
 
-        return query
+        distance = Function(
+            "ts_rank_cd",
+            args=[
+                Function("to_tsvector", args=[Constant("english"), Identifier(keyword_search_args.column)]),
+                Function("websearch_to_tsquery", args=[Constant("english"), Constant(keyword_search_args.query)]),
+            ],
+            alias=Identifier("distance"),
+        )
+
+        targets = [Identifier(col) for col in columns]
+        targets.append(distance)
+
+        limit_clause = Constant(limit) if limit else None
+        offset_clause = Constant(offset) if offset else None
+
+        return Select(
+            targets=targets,
+            from_table=Identifier(table_name),
+            where=where_clause,
+            limit=limit_clause,
+            offset=offset_clause,
+        )
 
     def _build_select_query(
         self,
@@ -318,12 +313,12 @@ class PgVectorHandler(PostgresHandler, VectorStoreHandler, KeywordSearchBase):
         conditions: List[FilterCondition] = None,
         limit: int = None,
         offset: int = None,
-    ) -> str:
+    ) -> Select:
         """
         given inputs, build string query
         """
-        limit_clause = f"LIMIT {limit}" if limit else ""
-        offset_clause = f"OFFSET {offset}" if offset else ""
+        limit_clause = Constant(limit) if limit else None
+        offset_clause = Constant(offset) if offset else None
 
         # translate filter conditions to dictionary
         filter_conditions, embedding_search = self._translate_conditions(conditions)
@@ -344,7 +339,15 @@ class PgVectorHandler(PostgresHandler, VectorStoreHandler, KeywordSearchBase):
             modified_columns = ["id", "content", "embeddings", "metadata"]
             has_distance = True
 
-        targets = ", ".join(modified_columns)
+        targets = [Identifier(col) for col in modified_columns]
+
+        query = Select(
+            targets=targets,
+            from_table=Identifier(table_name),
+            where=where_clause,
+            limit=limit_clause,
+            offset=offset_clause,
+        )
 
         if embedding_search:
             search_vector = embedding_search["value"]
@@ -361,15 +364,18 @@ class PgVectorHandler(PostgresHandler, VectorStoreHandler, KeywordSearchBase):
                 if isinstance(search_vector, list):
                     search_vector = f"[{','.join(str(x) for x in search_vector)}]"
 
+            vector_op = BinaryOperation(
+                op=self.distance_op,
+                args=[Identifier("embeddings"), Constant(search_vector)],
+                alias=Identifier("distance"),
+            )
             # Calculate distance as part of the query if needed
             if has_distance:
-                targets = f"{targets}, (embeddings {self.distance_op} '{search_vector}') as distance"
+                query.targets.append(vector_op)
 
-            return f"SELECT {targets} FROM {table_name} {where_clause} ORDER BY embeddings {self.distance_op} '{search_vector}' ASC {limit_clause} {offset_clause} "
+            query.order_by = [OrderBy(vector_op, direction="ASC")]
 
-        else:
-            # if filter conditions, return rows that satisfy the conditions
-            return f"SELECT {targets} FROM {table_name} {where_clause} {limit_clause} {offset_clause}"
+        return query
 
     def _check_table(self, table_name: str):
         # Apply namespace for a user
@@ -395,8 +401,8 @@ class PgVectorHandler(PostgresHandler, VectorStoreHandler, KeywordSearchBase):
             columns = ["id", "content", "embeddings", "metadata"]
 
         query = self._build_select_query(table_name, columns, conditions, limit, offset)
-
-        result = self.raw_query(query)
+        query_str = self.renderer.get_string(query, with_failback=True)
+        result = self.raw_query(query_str)
 
         # ensure embeddings are returned as string so they can be parsed by mindsdb
         if "embeddings" in columns:
@@ -417,12 +423,10 @@ class PgVectorHandler(PostgresHandler, VectorStoreHandler, KeywordSearchBase):
 
         if columns is None:
             columns = ["id", "content", "embeddings", "metadata"]
-        content_column_name = keyword_search_args.column
-        query = self._build_keyword_bm25_query(
-            table_name, keyword_search_args.query, columns, content_column_name, conditions, limit, offset
-        )
 
-        result = self.raw_query(query)
+        query = self._build_keyword_bm25_query(table_name, keyword_search_args, columns, conditions, limit, offset)
+        query_str = self.renderer.get_string(query, with_failback=True)
+        result = self.raw_query(query_str)
 
         # ensure embeddings are returned as string so they can be parsed by mindsdb
         if "embeddings" in columns:
@@ -631,8 +635,9 @@ class PgVectorHandler(PostgresHandler, VectorStoreHandler, KeywordSearchBase):
         filter_conditions, _ = self._translate_conditions(conditions)
         where_clause = self._construct_where_clause(filter_conditions)
 
-        query = f"DELETE FROM {table_name} {where_clause}"
-        self.raw_query(query)
+        query = Delete(table=Identifier(table_name), where=where_clause)
+        query_str = self.renderer.get_string(query, with_failback=True)
+        self.raw_query(query_str)
 
     def drop_table(self, table_name: str, if_exists=True):
         """

--- a/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
+++ b/mindsdb/integrations/handlers/pgvector_handler/pgvector_handler.py
@@ -282,6 +282,8 @@ class PgVectorHandler(PostgresHandler, VectorStoreHandler, KeywordSearchBase):
 
             if where_clause:
                 where_clause = BinaryOperation(op="AND", args=[where_clause, keyword_query_condition])
+            else:
+                where_clause = keyword_query_condition
 
         distance = Function(
             "ts_rank_cd",


### PR DESCRIPTION
## Description

Use sqlalchemy render  for rendering queries instead of composing strings manually. It should solve many issues with qouting, special caracters, reserved keywords and so on
Updated functions:
- select
- delete
- keyword_select

`hybrid_search` was skipped because the query composed there is pretty heavy.


Fixes https://linear.app/mindsdb/issue/CONN-298/kb-insert-fails-in-pgvector-due-to-invalid-column-name-formatting-eg

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



