### PR TITLE
Replace deprecated `psutil.Process().connections()` to `net_connections()`

### DIFF
--- a/mindsdb/utilities/ps.py
+++ b/mindsdb/utilities/ps.py
@@ -19,7 +19,7 @@ def net_connections():
     for p in psutil.process_iter(['pid']):
         try:
             process = psutil.Process(p.pid)
-            connections = process.connections()
+            connections = process.net_connections()
             if connections:
                 for conn in connections:
                     # Adding pid to the returned instance
@@ -66,7 +66,7 @@ def wait_port(port_num, timeout):
 def get_listen_ports(pid):
     try:
         p = psutil.Process(pid)
-        cons = p.connections()
+        cons = p.net_connections()
         cons = [x.laddr.port for x in cons]
     except Exception:
         return []

--- a/mindsdb/utilities/ps.py
+++ b/mindsdb/utilities/ps.py
@@ -11,12 +11,12 @@ def get_child_pids(pid):
 
 def net_connections():
     """Cross-platform psutil.net_connections like interface"""
-    if sys.platform.lower().startswith('linux'):
+    if sys.platform.lower().startswith("linux"):
         return psutil.net_connections()
 
     all_connections = []
     Pconn = None
-    for p in psutil.process_iter(['pid']):
+    for p in psutil.process_iter(["pid"]):
         try:
             process = psutil.Process(p.pid)
             connections = process.net_connections()
@@ -26,8 +26,8 @@ def net_connections():
                     # for consistency with psutil.net_connections()
                     if Pconn is None:
                         fields = list(conn._fields)
-                        fields.append('pid')
-                        _conn = namedtuple('Pconn', fields)
+                        fields.append("pid")
+                        _conn = namedtuple("Pconn", fields)
                     for attr in conn._fields:
                         setattr(_conn, attr, getattr(conn, attr))
                     _conn.pid = p.pid
@@ -43,7 +43,7 @@ def is_port_in_use(port_num):
     parent_process = psutil.Process()
     child_pids = [x.pid for x in parent_process.children(recursive=True)]
     conns = net_connections()
-    portsinuse = [x.laddr[1] for x in conns if x.pid in child_pids and x.status == 'LISTEN']
+    portsinuse = [x.laddr[1] for x in conns if x.pid in child_pids and x.status == "LISTEN"]
     portsinuse.sort()
     return int(port_num) in portsinuse
 


### PR DESCRIPTION
## Description

`psutil.Process().connections()`  is [deprecated](https://psutil.readthedocs.io/en/latest/#psutil.Process.connections)  and will be removed. Replaced to `psutil.Process().net_connections()`

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



