### PR TITLE
Replace deprecated `utcfromtimestamp`

### DIFF
--- a/mindsdb/integrations/handlers/google_calendar_handler/google_calendar_tables.py
+++ b/mindsdb/integrations/handlers/google_calendar_handler/google_calendar_tables.py
@@ -100,8 +100,8 @@ class GoogleCalendarEventsTable(APITable):
             else:
                 raise NotImplementedError
 
-        st = datetime.datetime.utcfromtimestamp(event_data['start_time'] / 1000).isoformat() + 'Z'
-        et = datetime.datetime.utcfromtimestamp(event_data['end_time'] / 1000).isoformat() + 'Z'
+        st = datetime.datetime.fromtimestamp(event_data['start_time'] / 1000, datetime.timezone.utc).isoformat() + 'Z'
+        et = datetime.datetime.fromtimestamp(event_data['end_time'] / 1000, datetime.timezone.utc).isoformat() + 'Z'
 
         event_data['start'] = {
             'dateTime': st,

--- a/mindsdb/utilities/functions.py
+++ b/mindsdb/utilities/functions.py
@@ -41,10 +41,10 @@ def cast_row_types(row, field_types):
     for key in keys:
         t = field_types[key]
         if t == 'Timestamp' and isinstance(row[key], (int, float)):
-            timestamp = datetime.datetime.utcfromtimestamp(row[key])
+            timestamp = datetime.datetime.fromtimestamp(row[key], datetime.timezone.utc)
             row[key] = timestamp.strftime('%Y-%m-%d %H:%M:%S')
         elif t == 'Date' and isinstance(row[key], (int, float)):
-            timestamp = datetime.datetime.utcfromtimestamp(row[key])
+            timestamp = datetime.datetime.fromtimestamp(row[key], datetime.timezone.utc)
             row[key] = timestamp.strftime('%Y-%m-%d')
         elif t == 'Int' and isinstance(row[key], (int, float, str)):
             try:


### PR DESCRIPTION
## Description

`utcfromtimestamp` deprecated since py 3.12
Replaced to `fromtimestamp(x, datetime.timezone.utc)`

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



