### PR TITLE
Redefine agent's parameters with query `using`

### DIFF
--- a/mindsdb/api/executor/sql_query/steps/apply_predictor_step.py
+++ b/mindsdb/api/executor/sql_query/steps/apply_predictor_step.py
@@ -43,6 +43,7 @@ class ApplyPredictorBaseCall(BaseStepCall):
                 agent,
                 messages=messages,
                 project_name=project_name,
+                params=params
             )
 
         else:

--- a/mindsdb/integrations/handlers/langchain_handler/langchain_handler.py
+++ b/mindsdb/integrations/handlers/langchain_handler/langchain_handler.py
@@ -259,7 +259,12 @@ AI: {response}'''
             for future in as_completed(futures, timeout=agent_timeout_seconds):
                 completions.append(future.result())
         except TimeoutError:
-            completions.append("I'm sorry! I couldn't come up with a response in time. Please try again.")
+            completions.append(
+                f"I'm sorry! I couldn't generate a response within the allotted time ({agent_timeout_seconds} seconds). "
+                "If you need more time for processing, you can adjust the timeout settings. "
+                "Please refer to the documentation for instructions on how to change the timeout value. "
+                "Feel free to try your request again."
+            )
         # Can't use ThreadPoolExecutor as context manager since we need wait=False.
         executor.shutdown(wait=False)
 

--- a/mindsdb/interfaces/agents/agents_controller.py
+++ b/mindsdb/interfaces/agents/agents_controller.py
@@ -585,20 +585,22 @@ class AgentsController:
     def get_completion(
         self,
         agent: db.Agents,
-        messages: List[Dict[str, str]],
+        messages: list[Dict[str, str]],
         project_name: str = default_project,
-        tools: List[BaseTool] = None,
+        tools: list[BaseTool] = None,
         stream: bool = False,
+        params: dict | None = None
     ) -> Union[Iterator[object], pd.DataFrame]:
         """
         Queries an agent to get a completion.
 
         Parameters:
             agent (db.Agents): Existing agent to get completion from
-            messages (List[Dict[str, str]]): Chat history to send to the agent
+            messages (list[Dict[str, str]]): Chat history to send to the agent
             project_name (str): Project the agent belongs to (default mindsdb)
-            tools (List[BaseTool]): Tools to use while getting the completion
+            tools (list[BaseTool]): Tools to use while getting the completion
             stream (bool): Whether to stream the response
+            params (dict | None): params to redefine agent params
 
         Returns:
             response (Union[Iterator[object], pd.DataFrame]): Completion as a DataFrame or iterator of completion chunks
@@ -607,7 +609,7 @@ class AgentsController:
             ValueError: Agent's model does not exist.
         """
         if stream:
-            return self._get_completion_stream(agent, messages, project_name=project_name, tools=tools)
+            return self._get_completion_stream(agent, messages, project_name=project_name, tools=tools, params=params)
         from .langchain_agent import LangchainAgent
 
         model, provider = self.check_model_provider(agent.model_name, agent.provider)
@@ -620,25 +622,27 @@ class AgentsController:
         llm_params = self.get_agent_llm_params(agent.params)
 
         lang_agent = LangchainAgent(agent, model, llm_params=llm_params)
-        return lang_agent.get_completion(messages)
+        return lang_agent.get_completion(messages, params=params)
 
     def _get_completion_stream(
         self,
         agent: db.Agents,
-        messages: List[Dict[str, str]],
+        messages: list[Dict[str, str]],
         project_name: str = default_project,
-        tools: List[BaseTool] = None,
+        tools: list[BaseTool] = None,
+        params: dict | None = None
     ) -> Iterator[object]:
         """
         Queries an agent to get a stream of completion chunks.
 
         Parameters:
             agent (db.Agents): Existing agent to get completion from
-            messages (List[Dict[str, str]]): Chat history to send to the agent
+            messages (list[Dict[str, str]]): Chat history to send to the agent
             trace_id (str): ID of Langfuse trace to use
             observation_id (str): ID of parent Langfuse observation to use
             project_name (str): Project the agent belongs to (default mindsdb)
-            tools (List[BaseTool]): Tools to use while getting the completion
+            tools (list[BaseTool]): Tools to use while getting the completion
+            params (dict | None): params to redefine agent params
 
         Returns:
             chunks (Iterator[object]): Completion chunks as an iterator
@@ -660,4 +664,4 @@ class AgentsController:
         llm_params = self.get_agent_llm_params(agent.params)
 
         lang_agent = LangchainAgent(agent, model=model, llm_params=llm_params)
-        return lang_agent.get_completion(messages, stream=True)
+        return lang_agent.get_completion(messages, stream=True, params=params)

--- a/mindsdb/interfaces/agents/langchain_agent.py
+++ b/mindsdb/interfaces/agents/langchain_agent.py
@@ -321,7 +321,7 @@ class LangchainAgent:
             self.provider,
         ]
 
-    def get_completion(self, messages, stream: bool = False):
+    def get_completion(self, messages, stream: bool = False, params: dict | None = None):
         # Get metadata and tags to be used in the trace
         metadata = self.get_metadata()
         tags = self.get_tags()
@@ -342,7 +342,9 @@ class LangchainAgent:
         if stream:
             return self._get_completion_stream(messages)
 
-        args = self.args
+        args = {}
+        args.update(self.args)
+        args.update(params or {})
 
         df = pd.DataFrame(messages)
 
@@ -598,7 +600,12 @@ AI: {response}"""
                     completions.append(result[ASSISTANT_COLUMN])
                     contexts.append(result[CONTEXT_COLUMN])
             except TimeoutError:
-                timeout_message = "I'm sorry! I couldn't come up with a response in time. Please try again."
+                timeout_message = (
+                    f"I'm sorry! I couldn't generate a response within the allotted time ({agent_timeout_seconds} seconds). "
+                    "If you need more time for processing, you can adjust the timeout settings. "
+                    "Please refer to the documentation for instructions on how to change the timeout value. "
+                    "Feel free to try your request again."
+                )
                 logger.warning(f"Agent execution timed out after {agent_timeout_seconds} seconds")
                 for _ in range(len(futures) - len(completions)):
                     completions.append(timeout_message)


### PR DESCRIPTION
## Description

Redefine the agent's parameters based on the parameters provided in the query. 
Example:
```sql
CREATE AGENT my_agent
USING
    model = 'gpt-4o',
    openai_api_key = 'sk-zzzzzzz',
    prompt_template='Answer questions',
    timeout=60;

SELECT * FROM my_agent
WHERE question = 'How are you?'
USING timeout=5;  -- the agent will use this timeout for the query
```

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



