### PR TITLE
Openai handler: fix normal completion

### DIFF
--- a/mindsdb/integrations/handlers/langchain_handler/langchain_handler.py
+++ b/mindsdb/integrations/handlers/langchain_handler/langchain_handler.py
@@ -31,7 +31,6 @@ from mindsdb.integrations.handlers.langchain_handler.tools import setup_tools
 from mindsdb.integrations.libs.base import BaseMLEngine
 from mindsdb.interfaces.storage.model_fs import HandlerStorage, ModelStorage
 from mindsdb.integrations.handlers.langchain_embedding_handler.langchain_embedding_handler import construct_model_from_args
-from mindsdb.integrations.handlers.openai_handler.constants import CHAT_MODELS  # noqa, for dependency checker
 
 from mindsdb.utilities import log
 from mindsdb.utilities.context_executor import ContextThreadPoolExecutor

--- a/mindsdb/integrations/handlers/openai_handler/constants.py
+++ b/mindsdb/integrations/handlers/openai_handler/constants.py
@@ -1,38 +1,19 @@
-OPENAI_API_BASE = 'https://api.openai.com/v1'
+OPENAI_API_BASE = "https://api.openai.com/v1"
 
-CHAT_MODELS = (
-    'gpt-3.5-turbo',
-    'gpt-3.5-turbo-16k',
-    'gpt-3.5-turbo-instruct',
-    'gpt-4',
-    'gpt-4-32k',
-    'gpt-4-1106-preview',
-    'gpt-4-0125-preview',
-    'gpt-4o',
-    'o3-mini',
-    'o1-mini'
-)
-COMPLETION_MODELS = ('babbage-002', 'davinci-002')
-FINETUNING_MODELS = ('gpt-3.5-turbo', 'babbage-002', 'davinci-002', 'gpt-4')
-COMPLETION_LEGACY_BASE_MODELS = ('davinci', 'curie', 'babbage', 'ada')
-DEFAULT_CHAT_MODEL = 'gpt-3.5-turbo'
+CHAT_MODELS_PREFIXES = ("gpt-3.5", "gpt-3.5", "gpt-3.5", "gpt-4", "o3-mini", "o1-mini")
+COMPLETION_MODELS = ("babbage-002", "davinci-002")
+FINETUNING_MODELS = ("gpt-3.5-turbo", "babbage-002", "davinci-002", "gpt-4")
+COMPLETION_LEGACY_BASE_MODELS = ("davinci", "curie", "babbage", "ada")
+DEFAULT_CHAT_MODEL = "gpt-4o-mini"
 
 FINETUNING_LEGACY_MODELS = FINETUNING_MODELS
 COMPLETION_LEGACY_MODELS = (
     COMPLETION_LEGACY_BASE_MODELS
-    + tuple(f'text-{model}-001' for model in COMPLETION_LEGACY_BASE_MODELS)
-    + ('text-davinci-002', 'text-davinci-003')
+    + tuple(f"text-{model}-001" for model in COMPLETION_LEGACY_BASE_MODELS)
+    + ("text-davinci-002", "text-davinci-003")
 )
 
-EMBEDDING_MODELS = (
-    ('text-embedding-ada-002',)
-    + tuple(f'text-similarity-{model}-001' for model in COMPLETION_LEGACY_BASE_MODELS)
-    + tuple(f'text-search-{model}-query-001' for model in COMPLETION_LEGACY_BASE_MODELS)
-    + tuple(f'text-search-{model}-doc-001' for model in COMPLETION_LEGACY_BASE_MODELS)
-    + tuple(f'code-search-{model}-text-001' for model in COMPLETION_LEGACY_BASE_MODELS)
-    + tuple(f'code-search-{model}-code-001' for model in COMPLETION_LEGACY_BASE_MODELS)
-)
-DEFAULT_EMBEDDING_MODEL = 'text-embedding-ada-002'
+DEFAULT_EMBEDDING_MODEL = "text-embedding-ada-002"
 
-IMAGE_MODELS = ('dall-e-2', 'dall-e-3')
-DEFAULT_IMAGE_MODEL = 'dall-e-2'
+IMAGE_MODELS = ("dall-e-2", "dall-e-3")
+DEFAULT_IMAGE_MODEL = "dall-e-2"


### PR DESCRIPTION
Updates:
- use prefixes (CHAT_MODELS_PREFIXES) to define chat model (instead of list of models, CHAT_MODELS)
- removed unused EMBEDDING_MODELS constant. embedding model is defined by mode='embeddings'
- updated DEFAULT_CHAT_MODEL to 'gpt-4o-mini'
- fixed `client.completions`: make several calls per prompt instead of passing list of prompts

use prefixes of chat models

## Description

Please include a summary of the change and the issue it solves. 

Fixes https://linear.app/mindsdb/issue/CONN-668/modify-the-openai-handler-to-accept-different-models-and-base-urls

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



