### PR TITLE
Fixed Date and DateTime Handling in Salesforce Integration

### DIFF
--- a/mindsdb/integrations/handlers/salesforce_handler/salesforce_tables.py
+++ b/mindsdb/integrations/handlers/salesforce_handler/salesforce_tables.py
@@ -70,7 +70,7 @@ def create_table_class(resource_name: Text) -> MetaAPIResource:
                         continue
                     except (ValueError, TypeError):
                         # Try inserting colon in timezone offset if format is like +0000 or -0530
-                        if len(arg2) >= 5 and (arg2[-5] in ['+', '-'] and arg2[-2:].isdigit()):
+                        if arg2 and len(arg2) >= 5 and (arg2[-5] in ['+', '-'] and arg2[-2:].isdigit()):
                             try:
                                 fixed = arg2[:-2] + ':' + arg2[-2:]
                                 datetime.fromisoformat(fixed)

--- a/mindsdb/integrations/handlers/salesforce_handler/salesforce_tables.py
+++ b/mindsdb/integrations/handlers/salesforce_handler/salesforce_tables.py
@@ -1,4 +1,3 @@
-
 from datetime import datetime
 import re
 from typing import Dict, List, Text
@@ -79,15 +78,15 @@ def create_table_class(resource_name: Text) -> MetaAPIResource:
             df.rename(columns=column_aliases, inplace=True)
 
             return df
-        
+
         def _is_datetime_literal(self, date_str: str) -> bool:
             try:
                 datetime.fromisoformat(date_str)
                 return True
             except ValueError:
-                if len(date_str) >= 5 and (date_str[-5] in ['+', '-'] and date_str[-2:].isdigit()):
+                if len(date_str) >= 5 and (date_str[-5] in ["+", "-"] and date_str[-2:].isdigit()):
                     try:
-                        fixed = date_str[:-2] + ':' + date_str[-2:]
+                        fixed = date_str[:-2] + ":" + date_str[-2:]
                         datetime.fromisoformat(fixed)
                         return True
                     except ValueError:

--- a/mindsdb/integrations/handlers/salesforce_handler/salesforce_tables.py
+++ b/mindsdb/integrations/handlers/salesforce_handler/salesforce_tables.py
@@ -68,14 +68,14 @@ def create_table_class(resource_name: Text) -> MetaAPIResource:
                         datetime.fromisoformat(arg2)
                         datetime_literals.append(arg2)
                         continue
-                    except ValueError:
+                    except (ValueError, TypeError):
                         # Try inserting colon in timezone offset if format is like +0000 or -0530
                         if len(arg2) >= 5 and (arg2[-5] in ['+', '-'] and arg2[-2:].isdigit()):
                             try:
                                 fixed = arg2[:-2] + ':' + arg2[-2:]
                                 datetime.fromisoformat(fixed)
                                 datetime_literals.append(arg2)
-                            except ValueError:
+                            except (ValueError, TypeError):
                                 pass
 
             client = self.handler.connect()


### PR DESCRIPTION
## Description

This PR handles queries that include quoted dates/datetimes in the `WHERE` clause; SOQL expects arguments to be passed  unquoted.

Fixes https://linear.app/mindsdb/issue/CONN-1305/handle-quotes-dates-in-salesforce

Given below are some example queries that now work:
```
SELECT Id, Name FROM sf_datasource.Account WHERE CreatedDate = 2025-04-03
SELECT Id, Name FROM sf_datasource.Account WHERE CreatedDate = '2025-05-19T12:44:50.000+00:00'
SELECT Id, Name FROM sf_datasource.Account WHERE CreatedDate = '2025-05-19T12:44:50.000+0000'
```

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added.