### PR TITLE
Fix CTE issue

### DIFF
--- a/mindsdb/api/executor/sql_query/steps/fetch_dataframe.py
+++ b/mindsdb/api/executor/sql_query/steps/fetch_dataframe.py
@@ -50,29 +50,26 @@ def get_table_alias(table_obj, default_db_name):
 
 def get_fill_param_fnc(steps_data):
     def fill_params(node, callstack=None, **kwargs):
-        if isinstance(node, Parameter):
-            rs = steps_data[node.value.step_num]
-            items = [Constant(i) for i in rs.get_column_values(col_idx=0)]
+        if not isinstance(node, Parameter):
+            return
 
-            is_single_item = True
-            if callstack:
-                node_prev = callstack[0]
-                if isinstance(node_prev, BinaryOperation):
-                    # Check case: 'something IN Parameter()'
-                    if node_prev.op.lower() == "in" and node_prev.args[1] is node:
-                        is_single_item = False
+        rs = steps_data[node.value.step_num]
+        items = [Constant(i) for i in rs.get_column_values(col_idx=0)]
 
-            if is_single_item and len(items) == 1:
-                # extract one value for option 'col=(subselect)'
-                node = items[0]
-            else:
-                node = Tuple(items)
-            return node
+        is_single_item = True
+        if callstack:
+            node_prev = callstack[0]
+            if isinstance(node_prev, BinaryOperation):
+                # Check case: 'something IN Parameter()'
+                if node_prev.op.lower() == "in" and node_prev.args[1] is node:
+                    is_single_item = False
 
-        if isinstance(node, Parameter):
-            rs = steps_data[node.value.step_num]
-            items = [Constant(i) for i in rs.get_column_values(col_idx=0)]
-            return Tuple(items)
+        if is_single_item and len(items) == 1:
+            # extract one value for option 'col=(subselect)'
+            node = items[0]
+        else:
+            node = Tuple(items)
+        return node
 
     return fill_params
 

--- a/mindsdb/api/executor/sql_query/steps/subselect_step.py
+++ b/mindsdb/api/executor/sql_query/steps/subselect_step.py
@@ -52,11 +52,14 @@ class SubSelectStepCall(BaseStepCall):
 
         # inject previous step values
         if isinstance(query, Select):
-
             def inject_values(node, **kwargs):
                 if isinstance(node, Parameter) and isinstance(node.value, Result):
                     prev_result = self.steps_data[node.value.step_num]
-                    return Constant(prev_result.get_column_values(col_idx=0)[0])
+                    match kwargs['callstack']:
+                        case [BinaryOperation(op='in'), *_]:
+                            return Constant(prev_result.get_column_values(col_idx=0)[0], parentheses=True)
+                        case _:
+                            return Constant(prev_result.get_column_values(col_idx=0)[0])
 
             query_traversal(query, inject_values)
 

--- a/mindsdb/api/executor/sql_query/steps/subselect_step.py
+++ b/mindsdb/api/executor/sql_query/steps/subselect_step.py
@@ -7,11 +7,9 @@ from mindsdb_sql_parser.ast import (
     Select,
     Star,
     Constant,
-    Parameter,
     Function,
     Variable,
     BinaryOperation,
-    Tuple,
 )
 
 from mindsdb.api.mysql.mysql_proxy.libs.constants.mysql import SERVER_VARIABLES

--- a/mindsdb/api/executor/sql_query/steps/subselect_step.py
+++ b/mindsdb/api/executor/sql_query/steps/subselect_step.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 import pandas as pd
 
-from mindsdb_sql_parser.ast import Identifier, Select, Star, Constant, Parameter, Function, Variable, BinaryOperation
+from mindsdb_sql_parser.ast import Identifier, Select, Star, Constant, Parameter, Function, Variable, BinaryOperation, Tuple
 
 from mindsdb.api.mysql.mysql_proxy.libs.constants.mysql import SERVER_VARIABLES
 from mindsdb.api.executor.planner.step_result import Result
@@ -57,7 +57,9 @@ class SubSelectStepCall(BaseStepCall):
                     prev_result = self.steps_data[node.value.step_num]
                     match kwargs['callstack']:
                         case [BinaryOperation(op='in'), *_]:
-                            return Constant(prev_result.get_column_values(col_idx=0)[0], parentheses=True)
+                            return Tuple(items=[
+                                Constant(value) for value in prev_result.get_column_values(col_idx=0)
+                            ])
                         case _:
                             return Constant(prev_result.get_column_values(col_idx=0)[0])
 

--- a/mindsdb/api/executor/sql_query/steps/subselect_step.py
+++ b/mindsdb/api/executor/sql_query/steps/subselect_step.py
@@ -2,7 +2,17 @@ from collections import defaultdict
 
 import pandas as pd
 
-from mindsdb_sql_parser.ast import Identifier, Select, Star, Constant, Parameter, Function, Variable, BinaryOperation, Tuple
+from mindsdb_sql_parser.ast import (
+    Identifier,
+    Select,
+    Star,
+    Constant,
+    Parameter,
+    Function,
+    Variable,
+    BinaryOperation,
+    Tuple,
+)
 
 from mindsdb.api.mysql.mysql_proxy.libs.constants.mysql import SERVER_VARIABLES
 from mindsdb.api.executor.planner.step_result import Result
@@ -52,14 +62,13 @@ class SubSelectStepCall(BaseStepCall):
 
         # inject previous step values
         if isinstance(query, Select):
+
             def inject_values(node, **kwargs):
                 if isinstance(node, Parameter) and isinstance(node.value, Result):
                     prev_result = self.steps_data[node.value.step_num]
-                    match kwargs['callstack']:
-                        case [BinaryOperation(op='in'), *_]:
-                            return Tuple(items=[
-                                Constant(value) for value in prev_result.get_column_values(col_idx=0)
-                            ])
+                    match kwargs["callstack"]:
+                        case [BinaryOperation(op="in"), *_]:
+                            return Tuple(items=[Constant(value) for value in prev_result.get_column_values(col_idx=0)])
                         case _:
                             return Constant(prev_result.get_column_values(col_idx=0)[0])
 

--- a/mindsdb/api/executor/sql_query/steps/subselect_step.py
+++ b/mindsdb/api/executor/sql_query/steps/subselect_step.py
@@ -62,17 +62,8 @@ class SubSelectStepCall(BaseStepCall):
 
         # inject previous step values
         if isinstance(query, Select):
-
-            def inject_values(node, **kwargs):
-                if isinstance(node, Parameter) and isinstance(node.value, Result):
-                    prev_result = self.steps_data[node.value.step_num]
-                    match kwargs["callstack"]:
-                        case [BinaryOperation(op="in"), *_]:
-                            return Tuple(items=[Constant(value) for value in prev_result.get_column_values(col_idx=0)])
-                        case _:
-                            return Constant(prev_result.get_column_values(col_idx=0)[0])
-
-            query_traversal(query, inject_values)
+            fill_params = get_fill_param_fnc(self.steps_data)
+            query_traversal(query, fill_params)
 
         df = result.to_df()
         res = query_df(df, query, session=self.session)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -16,7 +16,7 @@ redis >=5.0.0, < 6.0.0
 walrus==0.9.3
 flask-compress >= 1.0.0
 appdirs >= 1.0.0
-mindsdb-sql-parser ~= 0.11.1
+mindsdb-sql-parser ~= 0.11.3
 pydantic == 2.9.2
 mindsdb-evaluator == 0.0.18
 duckdb ~= 1.2.1

--- a/tests/unit/executor/test_executor.py
+++ b/tests/unit/executor/test_executor.py
@@ -6,6 +6,7 @@ import json
 import os
 
 import pandas as pd
+import pandas.testing as pdt
 import numpy as np
 
 from mindsdb.utilities.render.sqlalchemy_render import SqlalchemyRender
@@ -897,6 +898,209 @@ class TestComplexQueries(BaseExecutorMockPredictor):
         sql = "update pg.tasks set a = 0"
         resp = self.execute(sql)
         assert resp.affected_rows == 3
+
+    @patch("mindsdb.integrations.handlers.mysql_handler.Handler")
+    def test_cte(self, mock_handler):
+        test_df_1 = pd.DataFrame([
+            [1, 'a'],
+            [1, 'b'],
+            [2, 'b'],
+            [3, 'c'],
+        ], columns=['a', 'b'])
+
+        test_df_2 = pd.DataFrame([
+            [1, 'a'],
+            [2, 'b'],
+            [2, 'b'],
+            [3, 'c'],
+        ], columns=['a', 'c'])
+        self.set_handler(mock_handler, name="pg", tables={"test_t1": test_df_1, "test_t2": test_df_2}, engine="mysql")
+
+        # NOTE important to test joins with different count of rows (0, 1, many),
+        # as this can affect the actual query that is executed.
+        sql = """
+            WITH ta AS (
+                SELECT 'a' AS a, 2 AS b
+            ), tb AS (
+                SELECT 'a' AS a, 'b' AS c
+            )
+            SELECT ta.a, ta.b, tb.c
+            FROM ta
+            LEFT JOIN tb ON ta.a = tb.a;
+        """
+        resp = self.execute(sql)
+        pdt.assert_frame_equal(
+            resp.data.to_df(),
+            pd.DataFrame(
+                [['a', 2, 'b']],
+                columns=['a', 'b', 'c']
+            ),
+            check_dtype=False
+        )
+
+        sql = """
+            WITH ta AS (
+                SELECT 'a' AS a, 2 AS b
+                UNION ALL
+                SELECT 'b' AS a, 2 AS b
+            ), tb AS (
+                SELECT 'a' AS a, 'b' AS c
+            )
+            SELECT ta.a, ta.b, tb.c
+            FROM ta
+            LEFT JOIN tb ON ta.a = tb.a;
+        """
+        resp = self.execute(sql)
+        pdt.assert_frame_equal(
+            resp.data.to_df().sort_values(by=['a', 'b', 'c'], ignore_index=True),
+            pd.DataFrame([
+                    ['a', 2, 'b'],
+                    ['b', 2, None]
+                ],
+                columns=['a', 'b', 'c']
+            ).sort_values(by=['a', 'b', 'c'], ignore_index=True),
+            check_dtype=False
+        )
+
+        # NOTE error CONN-1340
+        # sql = """
+        #     WITH ta AS (
+        #         SELECT 'a' AS a, 2 AS b
+        #         UNION ALL
+        #         SELECT 'b' AS a, 2 AS b
+        #     ), tb AS (
+        #         SELECT 'a' AS a, 'b' AS c
+        #         UNION ALL
+        #         SELECT 'a' AS a, 'c' AS c
+        #     )
+        #     SELECT ta.a, ta.b, tb.c
+        #     FROM ta
+        #     LEFT JOIN tb ON ta.a = tb.a;
+        # """
+        # resp = self.execute(sql)
+        # pdt.assert_frame_equal(
+        #     resp.data.to_df(),
+        #     pd.DataFrame([
+        #             ['a', 2, 'b'],
+        #             ['a', 2, 'c']
+        #         ],
+        #         columns=['a', 'b', 'c']
+        #     ),
+        #     check_dtype=False
+        # )
+
+        sql = """
+            WITH ta AS (
+                SELECT 1 as a, 'a' AS b
+                UNION ALL
+                SELECT 1 as a, 'b' AS b
+            ), tb AS (
+                select * from pg.test_t1
+            )
+            SELECT ta.a, ta.b, tb.b as c
+            FROM ta
+            LEFT JOIN tb ON ta.a = tb.a;
+        """
+        resp = self.execute(sql)
+        pdt.assert_frame_equal(
+            resp.data.to_df().sort_values(by=['a', 'b', 'c'], ignore_index=True),
+            pd.DataFrame([
+                    [1, 'a', 'a'],
+                    [1, 'a', 'b'],
+                    [1, 'b', 'a'],
+                    [1, 'b', 'b']
+                ],
+                columns=['a', 'b', 'c']
+            ).sort_values(by=['a', 'b', 'c'], ignore_index=True),
+            check_dtype=False
+        )
+
+        sql = """
+            WITH ta AS (
+                SELECT 1 as a, 'a' AS b
+                UNION ALL
+                SELECT 1 as a, 'b' AS b
+            ), tb AS (
+                select * from pg.test_t1
+            )
+            SELECT ta.a as a, ta.b as b, tb.b as c
+            FROM ta
+            LEFT JOIN tb ON ta.a = tb.a
+            order by a, b, c;
+        """
+        resp = self.execute(sql)
+        pdt.assert_frame_equal(
+            resp.data.to_df(),
+            pd.DataFrame([
+                    [1, 'a', 'a'],
+                    [1, 'a', 'b'],
+                    [1, 'b', 'a'],
+                    [1, 'b', 'b']
+                ],
+                columns=['a', 'b', 'c']
+            ),
+            check_dtype=False
+        )
+
+        sql = """
+            WITH ta AS (
+                select * from pg.test_t1 where 1 = 0
+            ), tb AS (
+                select * from pg.test_t2 where c = 'c'
+            )
+            SELECT ta.a, ta.b, tb.c as c
+            FROM ta
+            LEFT JOIN tb ON ta.a = tb.a;
+        """
+        resp = self.execute(sql)
+        assert len(resp.data) == 0
+
+        sql = """
+            WITH ta AS (
+                select * from pg.test_t1 where b = 'b'
+            ), tb AS (
+                select * from pg.test_t2 where 1 = 0
+            )
+            SELECT ta.a, ta.b, tb.c as c
+            FROM ta
+            LEFT JOIN tb ON ta.a = tb.a;
+        """
+        resp = self.execute(sql)
+        pdt.assert_frame_equal(
+            resp.data.to_df().sort_values(by=['a', 'b', 'c'], ignore_index=True),
+            pd.DataFrame([
+                    [1, 'b', None],
+                    [2, 'b', None]
+                ],
+                columns=['a', 'b', 'c']
+            ).sort_values(by=['a', 'b', 'c'], ignore_index=True),
+            check_dtype=False
+        )
+
+        sql = """
+            WITH ta AS (
+                select * from pg.test_t1
+            ), tb AS (
+                select * from pg.test_t2 where c = 'c'
+            )
+            SELECT ta.a, ta.b, tb.c as c
+            FROM ta
+            LEFT JOIN tb ON ta.a = tb.a;
+        """
+        resp = self.execute(sql)
+        pdt.assert_frame_equal(
+            resp.data.to_df().sort_values(by=['a', 'b', 'c'], ignore_index=True),
+            pd.DataFrame([
+                    [1, 'a', None],
+                    [1, 'b', None],
+                    [2, 'b', None],
+                    [3, 'c', 'c']
+                ],
+                columns=['a', 'b', 'c']
+            ).sort_values(by=['a', 'b', 'c'], ignore_index=True),
+            check_dtype=False
+        )
+
 
     # @patch('mindsdb.integrations.handlers.postgres_handler.Handler')
     # def test_union_type_mismatch(self, mock_handler):

--- a/tests/unit/executor/test_executor.py
+++ b/tests/unit/executor/test_executor.py
@@ -960,32 +960,32 @@ class TestComplexQueries(BaseExecutorMockPredictor):
             check_dtype=False,
         )
 
-        # NOTE error CONN-1340
-        # sql = """
-        #     WITH ta AS (
-        #         SELECT 'a' AS a, 2 AS b
-        #         UNION ALL
-        #         SELECT 'b' AS a, 2 AS b
-        #     ), tb AS (
-        #         SELECT 'a' AS a, 'b' AS c
-        #         UNION ALL
-        #         SELECT 'a' AS a, 'c' AS c
-        #     )
-        #     SELECT ta.a, ta.b, tb.c
-        #     FROM ta
-        #     LEFT JOIN tb ON ta.a = tb.a;
-        # """
-        # resp = self.execute(sql)
-        # pdt.assert_frame_equal(
-        #     resp.data.to_df(),
-        #     pd.DataFrame([
-        #             ['a', 2, 'b'],
-        #             ['a', 2, 'c']
-        #         ],
-        #         columns=['a', 'b', 'c']
-        #     ),
-        #     check_dtype=False
-        # )
+        sql = """
+            WITH ta AS (
+                SELECT 'a' AS a, 2 AS b
+                UNION ALL
+                SELECT 'b' AS a, 2 AS b
+            ), tb AS (
+                SELECT 'a' AS a, 'b' AS c
+                UNION ALL
+                SELECT 'a' AS a, 'c' AS c
+            )
+            SELECT ta.a, ta.b, tb.c
+            FROM ta
+            LEFT JOIN tb ON ta.a = tb.a;
+        """
+        resp = self.execute(sql)
+        pdt.assert_frame_equal(
+            resp.data.to_df(),
+            pd.DataFrame([
+                    ['a', 2, 'b'],
+                    ['a', 2, 'c'],
+                    ['b', 2, None]
+                ],
+                columns=['a', 'b', 'c']
+            ),
+            check_dtype=False
+        )
 
         sql = """
             WITH ta AS (

--- a/tests/unit/executor/test_executor.py
+++ b/tests/unit/executor/test_executor.py
@@ -901,19 +901,25 @@ class TestComplexQueries(BaseExecutorMockPredictor):
 
     @patch("mindsdb.integrations.handlers.mysql_handler.Handler")
     def test_cte(self, mock_handler):
-        test_df_1 = pd.DataFrame([
-            [1, 'a'],
-            [1, 'b'],
-            [2, 'b'],
-            [3, 'c'],
-        ], columns=['a', 'b'])
+        test_df_1 = pd.DataFrame(
+            [
+                [1, "a"],
+                [1, "b"],
+                [2, "b"],
+                [3, "c"],
+            ],
+            columns=["a", "b"],
+        )
 
-        test_df_2 = pd.DataFrame([
-            [1, 'a'],
-            [2, 'b'],
-            [2, 'b'],
-            [3, 'c'],
-        ], columns=['a', 'c'])
+        test_df_2 = pd.DataFrame(
+            [
+                [1, "a"],
+                [2, "b"],
+                [2, "b"],
+                [3, "c"],
+            ],
+            columns=["a", "c"],
+        )
         self.set_handler(mock_handler, name="pg", tables={"test_t1": test_df_1, "test_t2": test_df_2}, engine="mysql")
 
         # NOTE important to test joins with different count of rows (0, 1, many),
@@ -930,12 +936,7 @@ class TestComplexQueries(BaseExecutorMockPredictor):
         """
         resp = self.execute(sql)
         pdt.assert_frame_equal(
-            resp.data.to_df(),
-            pd.DataFrame(
-                [['a', 2, 'b']],
-                columns=['a', 'b', 'c']
-            ),
-            check_dtype=False
+            resp.data.to_df(), pd.DataFrame([["a", 2, "b"]], columns=["a", "b", "c"]), check_dtype=False
         )
 
         sql = """
@@ -952,14 +953,11 @@ class TestComplexQueries(BaseExecutorMockPredictor):
         """
         resp = self.execute(sql)
         pdt.assert_frame_equal(
-            resp.data.to_df().sort_values(by=['a', 'b', 'c'], ignore_index=True),
-            pd.DataFrame([
-                    ['a', 2, 'b'],
-                    ['b', 2, None]
-                ],
-                columns=['a', 'b', 'c']
-            ).sort_values(by=['a', 'b', 'c'], ignore_index=True),
-            check_dtype=False
+            resp.data.to_df().sort_values(by=["a", "b", "c"], ignore_index=True),
+            pd.DataFrame([["a", 2, "b"], ["b", 2, None]], columns=["a", "b", "c"]).sort_values(
+                by=["a", "b", "c"], ignore_index=True
+            ),
+            check_dtype=False,
         )
 
         # NOTE error CONN-1340
@@ -1003,16 +1001,11 @@ class TestComplexQueries(BaseExecutorMockPredictor):
         """
         resp = self.execute(sql)
         pdt.assert_frame_equal(
-            resp.data.to_df().sort_values(by=['a', 'b', 'c'], ignore_index=True),
-            pd.DataFrame([
-                    [1, 'a', 'a'],
-                    [1, 'a', 'b'],
-                    [1, 'b', 'a'],
-                    [1, 'b', 'b']
-                ],
-                columns=['a', 'b', 'c']
-            ).sort_values(by=['a', 'b', 'c'], ignore_index=True),
-            check_dtype=False
+            resp.data.to_df().sort_values(by=["a", "b", "c"], ignore_index=True),
+            pd.DataFrame(
+                [[1, "a", "a"], [1, "a", "b"], [1, "b", "a"], [1, "b", "b"]], columns=["a", "b", "c"]
+            ).sort_values(by=["a", "b", "c"], ignore_index=True),
+            check_dtype=False,
         )
 
         sql = """
@@ -1031,15 +1024,8 @@ class TestComplexQueries(BaseExecutorMockPredictor):
         resp = self.execute(sql)
         pdt.assert_frame_equal(
             resp.data.to_df(),
-            pd.DataFrame([
-                    [1, 'a', 'a'],
-                    [1, 'a', 'b'],
-                    [1, 'b', 'a'],
-                    [1, 'b', 'b']
-                ],
-                columns=['a', 'b', 'c']
-            ),
-            check_dtype=False
+            pd.DataFrame([[1, "a", "a"], [1, "a", "b"], [1, "b", "a"], [1, "b", "b"]], columns=["a", "b", "c"]),
+            check_dtype=False,
         )
 
         sql = """
@@ -1067,14 +1053,11 @@ class TestComplexQueries(BaseExecutorMockPredictor):
         """
         resp = self.execute(sql)
         pdt.assert_frame_equal(
-            resp.data.to_df().sort_values(by=['a', 'b', 'c'], ignore_index=True),
-            pd.DataFrame([
-                    [1, 'b', None],
-                    [2, 'b', None]
-                ],
-                columns=['a', 'b', 'c']
-            ).sort_values(by=['a', 'b', 'c'], ignore_index=True),
-            check_dtype=False
+            resp.data.to_df().sort_values(by=["a", "b", "c"], ignore_index=True),
+            pd.DataFrame([[1, "b", None], [2, "b", None]], columns=["a", "b", "c"]).sort_values(
+                by=["a", "b", "c"], ignore_index=True
+            ),
+            check_dtype=False,
         )
 
         sql = """
@@ -1089,18 +1072,12 @@ class TestComplexQueries(BaseExecutorMockPredictor):
         """
         resp = self.execute(sql)
         pdt.assert_frame_equal(
-            resp.data.to_df().sort_values(by=['a', 'b', 'c'], ignore_index=True),
-            pd.DataFrame([
-                    [1, 'a', None],
-                    [1, 'b', None],
-                    [2, 'b', None],
-                    [3, 'c', 'c']
-                ],
-                columns=['a', 'b', 'c']
-            ).sort_values(by=['a', 'b', 'c'], ignore_index=True),
-            check_dtype=False
+            resp.data.to_df().sort_values(by=["a", "b", "c"], ignore_index=True),
+            pd.DataFrame(
+                [[1, "a", None], [1, "b", None], [2, "b", None], [3, "c", "c"]], columns=["a", "b", "c"]
+            ).sort_values(by=["a", "b", "c"], ignore_index=True),
+            check_dtype=False,
         )
-
 
     # @patch('mindsdb.integrations.handlers.postgres_handler.Handler')
     # def test_union_type_mismatch(self, mock_handler):

--- a/tests/unit/executor/test_executor.py
+++ b/tests/unit/executor/test_executor.py
@@ -977,14 +977,8 @@ class TestComplexQueries(BaseExecutorMockPredictor):
         resp = self.execute(sql)
         pdt.assert_frame_equal(
             resp.data.to_df(),
-            pd.DataFrame([
-                    ['a', 2, 'b'],
-                    ['a', 2, 'c'],
-                    ['b', 2, None]
-                ],
-                columns=['a', 'b', 'c']
-            ),
-            check_dtype=False
+            pd.DataFrame([["a", 2, "b"], ["a", 2, "c"], ["b", 2, None]], columns=["a", "b", "c"]),
+            check_dtype=False,
         )
 
         sql = """


### PR DESCRIPTION
## Description

Fixed a bug in processing queries with multiple CTEs.

This query:
```sql
WITH ta AS (
    SELECT 'a' AS a, 2 AS b
), tb AS (
    SELECT 'a' AS a, 3 AS c
)
SELECT ta.a, ta.b, tb.c
FROM ta
LEFT JOIN tb ON test_a.a = tb.a;
```
Failed with error:
```
syntax error at or near "'a'"
```

Also fixed inconsistent results for queries with multiple CTEs.
This query:
```sql
WITH ta AS (
    SELECT 'a' AS a, 2 AS b
    UNION ALL
    SELECT 'b' AS a, 2 AS b
), tb AS (
    SELECT 'a' AS a, 'b' AS c
)
SELECT ta.a, ta.b, tb.c
FROM ta
LEFT JOIN tb ON ta.a = tb.a;
```
returned different set of values for column `tb.c`.

Fixes CONN-846

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



