### PR TITLE
Update the GUI during docker build

### DIFF
--- a/docker/mindsdb.Dockerfile
+++ b/docker/mindsdb.Dockerfile
@@ -126,4 +126,7 @@ ENTRYPOINT [ "bash", "-c", "watchfiles --filter python 'python -Im mindsdb --con
 # Make sure the regular image is the default
 FROM extras
 
+# Run GUI update during build so the final image already contains it
+RUN python -Im mindsdb --config=/root/mindsdb_config.json --update-gui
+
 ENTRYPOINT [ "bash", "-c", "python -Im mindsdb --config=/root/mindsdb_config.json --api=http,mysql,a2a,mcp" ]

--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -335,6 +335,12 @@ if __name__ == "__main__":
         print(f"MindsDB {mindsdb_version}")
         sys.exit(0)
 
+    if config.cmd_args.update_gui:
+        from mindsdb.api.http.initialize import initialize_static
+        logger.info("Updating the GUI version")
+        initialize_static()
+        sys.exit(0)
+
     config.raise_warnings(logger=logger)
     os.environ["MINDSDB_RUNTIME"] = "1"
 

--- a/mindsdb/api/http/initialize.py
+++ b/mindsdb/api/http/initialize.py
@@ -203,7 +203,8 @@ def initialize_static():
         logger.debug("Updating gui..")
         success = update_static(last_gui_version_lv)
 
-    db.session.close()
+    if db.session:
+        db.session.close()
     return success
 
 

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -599,6 +599,7 @@ class Config:
                 ml_task_queue_consumer=None,
                 agent=None,
                 project=None,
+                update_gui=False
             )
             return
 
@@ -635,6 +636,7 @@ class Config:
             help="MindsDB agent name to connect to",
         )
         parser.add_argument("--project-name", type=str, default=None, help="MindsDB project name")
+        parser.add_argument("--update-gui", action="store_true", default=False, help="Update GUI and exit")
 
         self._cmd_args = parser.parse_args()
 


### PR DESCRIPTION
## Description

## Changes
 - CLI: added option to refresh GUI: `python -m mindsdb --update-gui`. In this case process exits immediately after GUI update (does not start the server).
 - Dockerfile: The image now ships with preloaded GUI, no network required at runtime and faster container startup .

Fixes CONN-644

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



