### PR TITLE
Fix psutil: update method name in psutils

### DIFF
--- a/mindsdb/utilities/ps.py
+++ b/mindsdb/utilities/ps.py
@@ -19,7 +19,7 @@ def net_connections():
     for p in psutil.process_iter(["pid"]):
         try:
             process = psutil.Process(p.pid)
-            connections = process.net_connections()
+            connections = process.connections()
             if connections:
                 for conn in connections:
                     # Adding pid to the returned instance
@@ -66,7 +66,7 @@ def wait_port(port_num, timeout):
 def get_listen_ports(pid):
     try:
         p = psutil.Process(pid)
-        cons = p.net_connections()
+        cons = p.connections()
         cons = [x.laddr.port for x in cons]
     except Exception:
         return []


### PR DESCRIPTION
## Description

Mindsdb shows error on startup because psutils version was updated and method name was changed `net_connections` -> `connections`
```
MainProcess ERROR    mindsdb: ERROR: http API cant start on 47334
```


Fixes https://linear.app/mindsdb/issue/CONN-1335/port-error-bug

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



