### PR TITLE
Fix error message when creating BYOM

### DIFF
--- a/mindsdb/api/executor/command_executor.py
+++ b/mindsdb/api/executor/command_executor.py
@@ -1195,11 +1195,17 @@ class ExecuteCommands:
                 msg = dedent(
                     f"""\
                     The '{handler_module_meta["name"]}' handler cannot be used. Reason is:
-                        {handler_module_meta["import"]["error_message"]}
+                        {handler_module_meta["import"]["error_message"] or msg}
                 """
                 )
                 is_cloud = self.session.config.get("cloud", False)
-                if is_cloud is False and "No module named" in handler_module_meta["import"]["error_message"]:
+                if (
+                    is_cloud is False
+                    # NOTE: BYOM may raise these errors if there is an error in the user's code,
+                    # therefore error_message will be None
+                    and handler_module_meta['name'] != 'byom'
+                    and "No module named" in handler_module_meta["import"]["error_message"]
+                ):
                     logger.info(get_handler_install_message(handler_module_meta["name"]))
             ast_drop = DropMLEngine(name=Identifier(name))
             self.answer_drop_ml_engine(ast_drop)

--- a/mindsdb/api/executor/command_executor.py
+++ b/mindsdb/api/executor/command_executor.py
@@ -1203,7 +1203,7 @@ class ExecuteCommands:
                     is_cloud is False
                     # NOTE: BYOM may raise these errors if there is an error in the user's code,
                     # therefore error_message will be None
-                    and handler_module_meta['name'] != 'byom'
+                    and handler_module_meta["name"] != "byom"
                     and "No module named" in handler_module_meta["import"]["error_message"]
                 ):
                     logger.info(get_handler_install_message(handler_module_meta["name"]))


### PR DESCRIPTION
## Description

If try to create a BYOM engine with error in model file, then exception may appear when do check `"No module named" in handler_module_meta["import"]["error_message"]` because there is no import error in BYOM handler itself.  In this case ml-engine will be created (because `self.answer_drop_ml_engine(ast_drop)` never reached) and irrelevant error message showed to the user.
Also changed the error message itself (added `or msg}`) because for BYOM there is no error message in `handler_module_meta["import"]["error_message"]` if the error is in the user's code.
`
Fixes CONN-1357

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



