### PR TITLE
Auth a2a

### DIFF
--- a/docs/a2a/a2a_authentication.md
+++ b/docs/a2a/a2a_authentication.md
@@ -25,6 +25,7 @@ Since services like the A2A server run as separate processes from the main Minds
 - **External Services**: Validate tokens by making HTTP requests to the HTTP server
 - **Communication**: External services call `/api/auth_tokens/token/validate` endpoint to verify tokens
 - **Configuration**: External services automatically read the HTTP API configuration from the MindsDB config file
+- **Agent Card**: A2A server includes authentication information in its agent card when authentication is required
 
 This design allows external services to be completely independent while still maintaining secure token-based authentication, with no additional configuration required.
 
@@ -162,6 +163,37 @@ The MCP server supports two authentication modes:
 External services automatically read the HTTP API configuration from the MindsDB config file. They use the same `api.http.host` and `api.http.port` settings that the main MindsDB server uses.
 
 No additional configuration is required - external services will automatically connect to the correct HTTP API endpoint.
+
+### Agent Card Authentication Information
+
+The A2A server automatically includes authentication information in its agent card when authentication is required:
+
+**When HTTP Auth is Disabled:**
+```json
+{
+  "name": "MindsDB Agent Connector",
+  "version": "1.0.0",
+  "capabilities": { ... },
+  "skills": [ ... ]
+  // No authentication field
+}
+```
+
+**When HTTP Auth is Enabled:**
+```json
+{
+  "name": "MindsDB Agent Connector",
+  "version": "1.0.0",
+  "capabilities": { ... },
+  "skills": [ ... ],
+  "authentication": {
+    "schemes": ["bearer"],
+    "credentials": "Authentication token required. Generate token via /api/auth_tokens/token endpoint."
+  }
+}
+```
+
+This allows A2A clients to automatically discover authentication requirements and provide appropriate credentials.
 
 ## Usage Examples
 

--- a/docs/a2a_authentication.md
+++ b/docs/a2a_authentication.md
@@ -1,0 +1,253 @@
+# Authentication Token Management
+
+This document describes the authentication token management system in MindsDB, which provides token-based authentication for various services including A2A (Agent-to-Agent) servers.
+
+## Overview
+
+The authentication token management system provides token-based authentication for various services (including A2A servers), with the authentication requirement being tied to the HTTP API authentication configuration. This means:
+
+- If HTTP authentication is **enabled** in MindsDB, then token authentication is **required**
+- If HTTP authentication is **disabled** in MindsDB, then token authentication is **not required**
+
+## Architecture
+
+The implementation consists of several components:
+
+1. **HTTP API Endpoints** (`/api/auth_tokens/*`) - For token management
+2. **Authentication Middleware** - For validating tokens on server requests
+3. **Shared Authentication Utilities** - For token storage and validation logic
+
+### Separate Server Architecture
+
+Since services like the A2A server run as separate processes from the main MindsDB HTTP server, token validation is performed via HTTP API calls:
+
+- **HTTP Server**: Stores tokens in memory and provides token management endpoints
+- **External Services**: Validate tokens by making HTTP requests to the HTTP server
+- **Communication**: External services call `/api/auth_tokens/token/validate` endpoint to verify tokens
+- **Configuration**: External services automatically read the HTTP API configuration from the MindsDB config file
+
+This design allows external services to be completely independent while still maintaining secure token-based authentication, with no additional configuration required.
+
+## HTTP API Endpoints
+
+### Generate Token
+```
+POST /api/auth_tokens/token
+```
+
+Generates a new authentication token. If HTTP authentication is enabled, the user must be authenticated to generate tokens.
+
+**Request Body:**
+```json
+{
+  "description": "Optional description for the token"
+}
+```
+
+**Response:**
+```json
+{
+  "token": "generated_token_here",
+  "expires_in": 86400,
+  "description": "Optional description"
+}
+```
+
+### Validate Token
+```
+POST /api/auth_tokens/token/validate
+```
+
+Validates an existing authentication token.
+
+**Request Body:**
+```json
+{
+  "token": "token_to_validate"
+}
+```
+
+**Response:**
+```json
+{
+  "valid": true,
+  "created_at": 1234567890.123,
+  "description": "Token description",
+  "user_id": "username"
+}
+```
+
+### List Tokens
+```
+GET /api/auth_tokens/tokens
+```
+
+Lists all active authentication tokens (admin only). Only available when HTTP authentication is enabled.
+
+**Response:**
+```json
+{
+  "tokens": [
+    {
+      "token_preview": "abc123...xyz789",
+      "created_at": 1234567890.123,
+      "description": "Token description",
+      "user_id": "username"
+    }
+  ],
+  "count": 1
+}
+```
+
+### Revoke Token
+```
+DELETE /api/auth_tokens/token/{token}
+```
+
+Revokes an authentication token. Only available when HTTP authentication is enabled.
+
+**Response:**
+```json
+{
+  "message": "Token revoked successfully"
+}
+```
+
+### Get Status
+```
+GET /api/auth_tokens/status
+```
+
+Returns the current authentication configuration.
+
+**Response:**
+```json
+{
+  "http_auth_enabled": true,
+  "a2a_auth_required": true,
+  "active_tokens_count": 1
+}
+```
+
+## Service Authentication
+
+External services (like the A2A server) automatically check for authentication based on the HTTP API configuration. Since these services run as separate processes, they validate tokens by making HTTP requests to the main MindsDB HTTP API.
+
+### When HTTP Auth is Disabled
+- No authentication required
+- All requests to external services are allowed
+
+### When HTTP Auth is Enabled
+- Authentication is required
+- Requests must include a valid `Authorization: Bearer <token>` header
+- Invalid or missing tokens return 401 Unauthorized
+- Token validation is performed by calling the HTTP API endpoint `/api/auth_tokens/token/validate`
+
+### Configuration
+
+External services automatically read the HTTP API configuration from the MindsDB config file. They use the same `api.http.host` and `api.http.port` settings that the main MindsDB server uses.
+
+No additional configuration is required - external services will automatically connect to the correct HTTP API endpoint.
+
+## Usage Examples
+
+### 1. Generate a Token (when HTTP auth is disabled)
+```bash
+curl -X POST http://localhost:47334/api/auth_tokens/token \
+  -H "Content-Type: application/json" \
+  -d '{"description": "My authentication token"}'
+```
+
+### 2. Generate a Token (when HTTP auth is enabled)
+```bash
+# First, login to get a session
+curl -X POST http://localhost:47334/api/login \
+  -H "Content-Type: application/json" \
+  -d '{"username": "mindsdb", "password": "mindsdb"}' \
+  -c cookies.txt
+
+# Then generate authentication token
+curl -X POST http://localhost:47334/api/auth_tokens/token \
+  -H "Content-Type: application/json" \
+  -d '{"description": "My authentication token"}' \
+  -b cookies.txt
+```
+
+### 3. Start A2A Server
+```bash
+# Start A2A server (automatically uses HTTP API config)
+python -m mindsdb.api.a2a
+```
+
+### 4. Use Token with A2A Server
+```bash
+# Get A2A server status with token
+curl -X GET http://localhost:10002/status \
+  -H "Authorization: Bearer your_a2a_token_here"
+```
+
+### 5. Validate a Token
+```bash
+curl -X POST http://localhost:47334/api/auth_tokens/token/validate \
+  -H "Content-Type: application/json" \
+  -d '{"token": "your_authentication_token_here"}'
+```
+
+## Configuration
+
+The A2A authentication behavior is controlled by the HTTP authentication configuration in MindsDB:
+
+```json
+{
+  "auth": {
+    "http_auth_enabled": true,
+    "username": "mindsdb",
+    "password": "mindsdb"
+  }
+}
+```
+
+- `http_auth_enabled: true` → A2A authentication required
+- `http_auth_enabled: false` → A2A authentication not required
+
+## Token Security
+
+- Tokens are generated using `secrets.token_urlsafe(32)` for high entropy
+- Tokens expire after 24 hours
+- Tokens are stored in memory (in production, consider using a database)
+- Token previews in listings only show first 8 and last 8 characters for security
+
+## Testing
+
+Use the provided test script to verify the implementation:
+
+```bash
+python test_a2a_auth.py
+```
+
+This script tests:
+1. A2A status endpoint
+2. Token generation
+3. Token validation
+4. Token listing
+5. A2A server access with valid token
+6. A2A server access with invalid token
+
+## Implementation Details
+
+### Files Modified/Created
+
+1. **`mindsdb/utilities/a2a_auth.py`** - Shared authentication utilities
+2. **`mindsdb/api/http/namespaces/configs/a2a.py`** - A2A namespace configuration
+3. **`mindsdb/api/http/namespaces/a2a.py`** - A2A HTTP API endpoints
+4. **`mindsdb/api/a2a/common/server/auth_middleware.py`** - A2A authentication middleware
+5. **`mindsdb/api/a2a/common/server/server.py`** - Updated to use auth middleware
+6. **`mindsdb/api/http/initialize.py`** - Added A2A namespace to HTTP API
+
+### Key Features
+
+- **Conditional Authentication**: A2A auth requirement tied to HTTP auth configuration
+- **Token Management**: Full CRUD operations for A2A tokens
+- **Security**: Secure token generation and validation
+- **Logging**: Comprehensive logging for debugging and monitoring
+- **Error Handling**: Proper HTTP status codes and error messages

--- a/docs/a2a_authentication.md
+++ b/docs/a2a_authentication.md
@@ -131,7 +131,7 @@ Returns the current authentication configuration.
 
 ## Service Authentication
 
-External services (like the A2A server) automatically check for authentication based on the HTTP API configuration. Since these services run as separate processes, they validate tokens by making HTTP requests to the main MindsDB HTTP API.
+External services (like the A2A server and MCP server) automatically check for authentication based on the HTTP API configuration. Since these services run as separate processes, they validate tokens by making HTTP requests to the main MindsDB HTTP API.
 
 ### When HTTP Auth is Disabled
 - No authentication required
@@ -142,6 +142,20 @@ External services (like the A2A server) automatically check for authentication b
 - Requests must include a valid `Authorization: Bearer <token>` header
 - Invalid or missing tokens return 401 Unauthorized
 - Token validation is performed by calling the HTTP API endpoint `/api/auth_tokens/token/validate`
+
+### MCP Server Authentication
+
+The MCP server supports two authentication modes:
+
+1. **Environment-based MCP token** (priority):
+   - Set `MINDSDB_MCP_ACCESS_TOKEN` environment variable
+   - Uses the exact token value for authentication
+   - Overrides HTTP auth configuration
+
+2. **HTTP auth-based token validation** (fallback):
+   - When `MINDSDB_MCP_ACCESS_TOKEN` is not set
+   - Uses the same authentication token system as other services
+   - Respects HTTP auth configuration (enabled/disabled)
 
 ### Configuration
 
@@ -186,7 +200,17 @@ curl -X GET http://localhost:10002/status \
   -H "Authorization: Bearer your_a2a_token_here"
 ```
 
-### 5. Validate a Token
+### 5. Use Token with MCP Server
+```bash
+# Connect to MCP server with authentication token
+# (when MINDSDB_MCP_ACCESS_TOKEN is not set and HTTP auth is enabled)
+curl -X POST http://localhost:47337/ \
+  -H "Authorization: Bearer your_authentication_token_here" \
+  -H "Content-Type: application/json" \
+  -d '{"method": "tools/list", "params": {}}'
+```
+
+### 6. Validate a Token
 ```bash
 curl -X POST http://localhost:47334/api/auth_tokens/token/validate \
   -H "Content-Type: application/json" \

--- a/mindsdb/api/a2a/__main__.py
+++ b/mindsdb/api/a2a/__main__.py
@@ -8,11 +8,13 @@ from mindsdb.api.a2a.common.types import (
     AgentCard,
     AgentCapabilities,
     AgentSkill,
+    AgentAuthentication,
     MissingAPIKeyError,
 )
 from mindsdb.api.a2a.common.server.server import A2AServer
 from mindsdb.api.a2a.task_manager import AgentTaskManager
 from mindsdb.api.a2a.agent import MindsDBAgent
+from mindsdb.utilities.a2a_auth import get_auth_required_status
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
@@ -71,6 +73,16 @@ def main(
             outputModes=MindsDBAgent.SUPPORTED_CONTENT_TYPES,
         )
 
+        # Check if authentication is required
+        auth_required = get_auth_required_status()
+        authentication = None
+        
+        if auth_required:
+            authentication = AgentAuthentication(
+                schemes=["bearer"],
+                credentials="Authentication token required. Generate token via /api/auth_tokens/token endpoint."
+            )
+        
         agent_card = AgentCard(
             name="MindsDB Agent Connector",
             description=(f"A2A connector that proxies requests to MindsDB agents in project '{project_name}'."),
@@ -79,6 +91,7 @@ def main(
             defaultInputModes=MindsDBAgent.SUPPORTED_CONTENT_TYPES,
             defaultOutputModes=MindsDBAgent.SUPPORTED_CONTENT_TYPES,
             capabilities=capabilities,
+            authentication=authentication,
             skills=[skill],
         )
 

--- a/mindsdb/api/a2a/common/server/auth_middleware.py
+++ b/mindsdb/api/a2a/common/server/auth_middleware.py
@@ -1,0 +1,61 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.status import HTTP_401_UNAUTHORIZED
+
+from mindsdb.utilities.a2a_auth import validate_auth_token_remote, get_auth_required_status
+from mindsdb.utilities import log
+
+logger = log.getLogger(__name__)
+
+
+class A2AAuthMiddleware(BaseHTTPMiddleware):
+    """Middleware to handle A2A authentication based on HTTP auth configuration"""
+
+    async def dispatch(self, request: Request, call_next):
+        # Check if authentication is required
+        if not get_auth_required_status():
+            # No authentication required, proceed
+            response = await call_next(request)
+            return response
+
+        # Check for Authorization header
+        auth_header = request.headers.get("Authorization")
+        if not auth_header:
+            logger.warning("A2A request without Authorization header")
+            return JSONResponse(
+                status_code=HTTP_401_UNAUTHORIZED,
+                content={
+                    "error": "Unauthorized",
+                    "message": "Authorization header is required"
+                }
+            )
+
+        # Extract token from Authorization header
+        if not auth_header.startswith("Bearer "):
+            logger.warning("A2A request with invalid Authorization header format")
+            return JSONResponse(
+                status_code=HTTP_401_UNAUTHORIZED,
+                content={
+                    "error": "Unauthorized",
+                    "message": "Authorization header must start with 'Bearer '"
+                }
+            )
+
+        token = auth_header[7:]  # Remove "Bearer " prefix
+        
+        # Validate token remotely via HTTP API
+        if not validate_auth_token_remote(token):
+            logger.warning(f"A2A request with invalid token: {token[:8]}...{token[-8:] if len(token) > 16 else '***'}")
+            return JSONResponse(
+                status_code=HTTP_401_UNAUTHORIZED,
+                content={
+                    "error": "Unauthorized",
+                    "message": "Invalid or expired token"
+                }
+            )
+
+        # Token is valid, proceed with request
+        logger.debug(f"A2A request authenticated with token: {token[:8]}...{token[-8:]}")
+        response = await call_next(request)
+        return response

--- a/mindsdb/api/a2a/common/server/server.py
+++ b/mindsdb/api/a2a/common/server/server.py
@@ -7,6 +7,7 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.responses import JSONResponse
 from sse_starlette.sse import EventSourceResponse
 from starlette.requests import Request
+from .auth_middleware import A2AAuthMiddleware
 from ...common.types import (
     A2ARequest,
     JSONRPCResponse,
@@ -50,6 +51,10 @@ class A2AServer:
         self.app.add_route("/.well-known/agent.json", self._get_agent_card, methods=["GET"])
         # Add status endpoint
         self.app.add_route("/status", self._get_status, methods=["GET"])
+        
+        # Add authentication middleware
+        self.app.add_middleware(A2AAuthMiddleware)
+        
         # TODO: Remove this when we have a proper CORS policy
         self.app.add_middleware(
             CORSMiddleware,

--- a/mindsdb/api/http/initialize.py
+++ b/mindsdb/api/http/initialize.py
@@ -20,6 +20,7 @@ from packaging.version import Version, parse as parse_version
 from mindsdb.__about__ import __version__ as mindsdb_version
 from mindsdb.api.http.gui import update_static
 from mindsdb.api.http.utils import http_error
+from mindsdb.api.http.namespaces.auth_tokens import ns_conf as auth_tokens_ns
 from mindsdb.api.http.namespaces.agents import ns_conf as agents_ns
 from mindsdb.api.http.namespaces.analysis import ns_conf as analysis_ns
 from mindsdb.api.http.namespaces.auth import ns_conf as auth_ns
@@ -258,6 +259,7 @@ def initialize_app(config, no_studio):
             return send_from_directory(static_root, "index.html")
 
     protected_namespaces = [
+        auth_tokens_ns,
         tab_ns,
         utils_ns,
         conf_ns,

--- a/mindsdb/api/http/namespaces/a2a.py
+++ b/mindsdb/api/http/namespaces/a2a.py
@@ -1,0 +1,216 @@
+import time
+from typing import Dict, Any
+
+from flask import request, session
+from flask_restx import Resource, fields
+
+from mindsdb.api.http.namespaces.configs.auth_tokens import ns_conf
+from mindsdb.api.http.namespaces.default import check_auth
+from mindsdb.api.http.utils import http_error
+from mindsdb.metrics.metrics import api_endpoint_metrics
+from mindsdb.utilities.config import Config
+from mindsdb.utilities import log
+from mindsdb.utilities.a2a_auth import (
+    generate_a2a_token,
+    store_a2a_token,
+    is_a2a_token_valid,
+    get_a2a_auth_status,
+    cleanup_expired_tokens,
+    get_all_a2a_tokens,
+    revoke_a2a_token
+)
+
+logger = log.getLogger(__name__)
+
+
+@ns_conf.route('/token', methods=['POST'])
+class AuthTokenRoute(Resource):
+    @ns_conf.doc(
+        responses={
+            200: 'Success',
+            401: 'Unauthorized - HTTP authentication required',
+            403: 'Forbidden - Invalid credentials'
+        },
+        body=ns_conf.model('request_a2a_token', {
+            'description': fields.String(description='Optional description for the token', required=False)
+        })
+    )
+    @api_endpoint_metrics('POST', '/auth_tokens/token')
+    def post(self):
+        ''' Generate an A2A token for authenticated users
+        
+        This endpoint generates a token that can be used to authenticate with the A2A server.
+        The token is only generated if the user is authenticated to the HTTP API.
+        If HTTP authentication is disabled, tokens are generated without authentication.
+        '''
+        config = Config()
+        
+        # Check if HTTP auth is enabled
+        if config['auth']['http_auth_enabled'] is True:
+            # Require authentication
+            if not check_auth():
+                return http_error(
+                    401, 'Unauthorized',
+                    'HTTP authentication is required to generate A2A tokens'
+                )
+        
+        # Generate token
+        token = generate_a2a_token()
+        description = request.json.get('description', '') if request.json else ''
+        user_id = session.get('username', 'unknown') if config['auth']['http_auth_enabled'] else 'no_auth'
+        
+        # Store token with metadata
+        store_a2a_token(token, user_id, description)
+        
+        logger.info(f"Generated A2A token for user: {user_id}")
+        
+        return {
+            'token': token,
+            'expires_in': 86400,  # 24 hours in seconds
+            'description': description
+        }, 200
+
+
+@ns_conf.route('/token/validate', methods=['POST'])
+class AuthTokenValidateRoute(Resource):
+    @ns_conf.doc(
+        responses={
+            200: 'Success',
+            400: 'Bad Request - Token not provided',
+            401: 'Unauthorized - Invalid or expired token'
+        },
+        body=ns_conf.model('validate_a2a_token', {
+            'token': fields.String(description='A2A token to validate', required=True)
+        })
+    )
+    @api_endpoint_metrics('POST', '/auth_tokens/token/validate')
+    def post(self):
+        ''' Validate an A2A token
+        
+        This endpoint validates if an A2A token is valid and not expired.
+        '''
+        if not request.json or 'token' not in request.json:
+            return http_error(
+                400, 'Bad Request',
+                'Token is required'
+            )
+        
+        token = request.json['token']
+        
+        if not is_a2a_token_valid(token):
+            return http_error(
+                401, 'Unauthorized',
+                'Invalid or expired token'
+            )
+        
+        from mindsdb.utilities.a2a_auth import get_a2a_token_data
+        token_data = get_a2a_token_data(token)
+        return {
+            'valid': True,
+            'created_at': token_data['created_at'],
+            'description': token_data['description'],
+            'user_id': token_data['user_id']
+        }, 200
+
+
+@ns_conf.route('/tokens', methods=['GET'])
+class AuthTokensListRoute(Resource):
+    @ns_conf.doc(
+        responses={
+            200: 'Success',
+            401: 'Unauthorized - HTTP authentication required'
+        }
+    )
+    @api_endpoint_metrics('GET', '/auth_tokens/tokens')
+    def get(self):
+        ''' List all active A2A tokens (admin only)
+        
+        This endpoint lists all active A2A tokens. Only available when HTTP authentication is enabled.
+        '''
+        config = Config()
+        
+        # Only allow if HTTP auth is enabled and user is authenticated
+        if config['auth']['http_auth_enabled'] is True:
+            if not check_auth():
+                return http_error(
+                    401, 'Unauthorized',
+                    'HTTP authentication is required to list A2A tokens'
+                )
+        
+        # Clean up expired tokens and get all tokens
+        cleanup_expired_tokens()
+        all_tokens = get_all_a2a_tokens()
+        
+        # Return active tokens (without the actual token value for security)
+        tokens_list = []
+        for token, data in all_tokens.items():
+            tokens_list.append({
+                'token_preview': f"{token[:8]}...{token[-8:]}",
+                'created_at': data['created_at'],
+                'description': data['description'],
+                'user_id': data['user_id']
+            })
+        
+        return {
+            'tokens': tokens_list,
+            'count': len(tokens_list)
+        }, 200
+
+
+@ns_conf.route('/token/<token>', methods=['DELETE'])
+class AuthTokenDeleteRoute(Resource):
+    @ns_conf.doc(
+        responses={
+            200: 'Success',
+            401: 'Unauthorized - HTTP authentication required',
+            404: 'Not Found - Token not found'
+        }
+    )
+    @api_endpoint_metrics('DELETE', '/auth_tokens/token/<token>')
+    def delete(self, token):
+        ''' Revoke an A2A token
+        
+        This endpoint revokes an A2A token. Only available when HTTP authentication is enabled.
+        '''
+        config = Config()
+        
+        # Only allow if HTTP auth is enabled and user is authenticated
+        if config['auth']['http_auth_enabled'] is True:
+            if not check_auth():
+                return http_error(
+                    401, 'Unauthorized',
+                    'HTTP authentication is required to revoke A2A tokens'
+                )
+        
+        if not revoke_a2a_token(token):
+            return http_error(
+                404, 'Not Found',
+                'Token not found'
+            )
+        
+        logger.info(f"Revoked A2A token: {token[:8]}...{token[-8:]}")
+        
+        return {'message': 'Token revoked successfully'}, 200
+
+
+@ns_conf.route('/status', methods=['GET'])
+class AuthTokensStatusRoute(Resource):
+    @ns_conf.doc(
+        responses={
+            200: 'Success'
+        }
+    )
+    @api_endpoint_metrics('GET', '/auth_tokens/status')
+    def get(self):
+        ''' Get A2A authentication status
+        
+        This endpoint returns the current A2A authentication configuration.
+        '''
+        config = Config()
+        
+        all_tokens = get_all_a2a_tokens()
+        return {
+            'http_auth_enabled': config['auth']['http_auth_enabled'],
+            'a2a_auth_required': get_a2a_auth_status(),
+            'active_tokens_count': len(all_tokens)
+        }, 200

--- a/mindsdb/api/http/namespaces/auth_tokens.py
+++ b/mindsdb/api/http/namespaces/auth_tokens.py
@@ -1,0 +1,216 @@
+import time
+from typing import Dict, Any
+
+from flask import request, session
+from flask_restx import Resource, fields
+
+from mindsdb.api.http.namespaces.configs.auth_tokens import ns_conf
+from mindsdb.api.http.namespaces.default import check_auth
+from mindsdb.api.http.utils import http_error
+from mindsdb.metrics.metrics import api_endpoint_metrics
+from mindsdb.utilities.config import Config
+from mindsdb.utilities import log
+from mindsdb.utilities.a2a_auth import (
+    generate_auth_token,
+    store_auth_token,
+    is_auth_token_valid,
+    get_auth_required_status,
+    cleanup_expired_tokens,
+    get_all_auth_tokens,
+    revoke_auth_token
+)
+
+logger = log.getLogger(__name__)
+
+
+@ns_conf.route('/token', methods=['POST'])
+class AuthTokenRoute(Resource):
+    @ns_conf.doc(
+        responses={
+            200: 'Success',
+            401: 'Unauthorized - HTTP authentication required',
+            403: 'Forbidden - Invalid credentials'
+        },
+        body=ns_conf.model('request_a2a_token', {
+            'description': fields.String(description='Optional description for the token', required=False)
+        })
+    )
+    @api_endpoint_metrics('POST', '/auth_tokens/token')
+    def post(self):
+        ''' Generate an A2A token for authenticated users
+        
+        This endpoint generates a token that can be used to authenticate with the A2A server.
+        The token is only generated if the user is authenticated to the HTTP API.
+        If HTTP authentication is disabled, tokens are generated without authentication.
+        '''
+        config = Config()
+        
+        # Check if HTTP auth is enabled
+        if config['auth']['http_auth_enabled'] is True:
+            # Require authentication
+            if not check_auth():
+                return http_error(
+                    401, 'Unauthorized',
+                    'HTTP authentication is required to generate A2A tokens'
+                )
+        
+        # Generate token
+        token = generate_auth_token()
+        description = request.json.get('description', '') if request.json else ''
+        user_id = session.get('username', 'unknown') if config['auth']['http_auth_enabled'] else 'no_auth'
+        
+        # Store token with metadata
+        store_auth_token(token, user_id, description)
+        
+        logger.info(f"Generated authentication token for user: {user_id}")
+        
+        return {
+            'token': token,
+            'expires_in': 86400,  # 24 hours in seconds
+            'description': description
+        }, 200
+
+
+@ns_conf.route('/token/validate', methods=['POST'])
+class AuthTokenValidateRoute(Resource):
+    @ns_conf.doc(
+        responses={
+            200: 'Success',
+            400: 'Bad Request - Token not provided',
+            401: 'Unauthorized - Invalid or expired token'
+        },
+        body=ns_conf.model('validate_a2a_token', {
+            'token': fields.String(description='A2A token to validate', required=True)
+        })
+    )
+    @api_endpoint_metrics('POST', '/auth_tokens/token/validate')
+    def post(self):
+        ''' Validate an A2A token
+        
+        This endpoint validates if an A2A token is valid and not expired.
+        '''
+        if not request.json or 'token' not in request.json:
+            return http_error(
+                400, 'Bad Request',
+                'Token is required'
+            )
+        
+        token = request.json['token']
+        
+        if not is_auth_token_valid(token):
+            return http_error(
+                401, 'Unauthorized',
+                'Invalid or expired token'
+            )
+        
+        from mindsdb.utilities.a2a_auth import get_auth_token_data
+        token_data = get_auth_token_data(token)
+        return {
+            'valid': True,
+            'created_at': token_data['created_at'],
+            'description': token_data['description'],
+            'user_id': token_data['user_id']
+        }, 200
+
+
+@ns_conf.route('/tokens', methods=['GET'])
+class AuthTokensListRoute(Resource):
+    @ns_conf.doc(
+        responses={
+            200: 'Success',
+            401: 'Unauthorized - HTTP authentication required'
+        }
+    )
+    @api_endpoint_metrics('GET', '/auth_tokens/tokens')
+    def get(self):
+        ''' List all active A2A tokens (admin only)
+        
+        This endpoint lists all active A2A tokens. Only available when HTTP authentication is enabled.
+        '''
+        config = Config()
+        
+        # Only allow if HTTP auth is enabled and user is authenticated
+        if config['auth']['http_auth_enabled'] is True:
+            if not check_auth():
+                return http_error(
+                    401, 'Unauthorized',
+                    'HTTP authentication is required to list A2A tokens'
+                )
+        
+        # Clean up expired tokens and get all tokens
+        cleanup_expired_tokens()
+        all_tokens = get_all_auth_tokens()
+        
+        # Return active tokens (without the actual token value for security)
+        tokens_list = []
+        for token, data in all_tokens.items():
+            tokens_list.append({
+                'token_preview': f"{token[:8]}...{token[-8:]}",
+                'created_at': data['created_at'],
+                'description': data['description'],
+                'user_id': data['user_id']
+            })
+        
+        return {
+            'tokens': tokens_list,
+            'count': len(tokens_list)
+        }, 200
+
+
+@ns_conf.route('/token/<token>', methods=['DELETE'])
+class AuthTokenDeleteRoute(Resource):
+    @ns_conf.doc(
+        responses={
+            200: 'Success',
+            401: 'Unauthorized - HTTP authentication required',
+            404: 'Not Found - Token not found'
+        }
+    )
+    @api_endpoint_metrics('DELETE', '/auth_tokens/token/<token>')
+    def delete(self, token):
+        ''' Revoke an A2A token
+        
+        This endpoint revokes an A2A token. Only available when HTTP authentication is enabled.
+        '''
+        config = Config()
+        
+        # Only allow if HTTP auth is enabled and user is authenticated
+        if config['auth']['http_auth_enabled'] is True:
+            if not check_auth():
+                return http_error(
+                    401, 'Unauthorized',
+                    'HTTP authentication is required to revoke A2A tokens'
+                )
+        
+        if not revoke_auth_token(token):
+            return http_error(
+                404, 'Not Found',
+                'Token not found'
+            )
+        
+        logger.info(f"Revoked authentication token: {token[:8]}...{token[-8:]}")
+        
+        return {'message': 'Token revoked successfully'}, 200
+
+
+@ns_conf.route('/status', methods=['GET'])
+class AuthTokensStatusRoute(Resource):
+    @ns_conf.doc(
+        responses={
+            200: 'Success'
+        }
+    )
+    @api_endpoint_metrics('GET', '/auth_tokens/status')
+    def get(self):
+        ''' Get A2A authentication status
+        
+        This endpoint returns the current A2A authentication configuration.
+        '''
+        config = Config()
+        
+        all_tokens = get_all_auth_tokens()
+        return {
+            'http_auth_enabled': config['auth']['http_auth_enabled'],
+            'auth_required': get_auth_required_status(),
+            'active_tokens_count': len(all_tokens)
+        }, 200

--- a/mindsdb/api/http/namespaces/auth_tokens.py
+++ b/mindsdb/api/http/namespaces/auth_tokens.py
@@ -205,12 +205,20 @@ class AuthTokensStatusRoute(Resource):
         ''' Get A2A authentication status
         
         This endpoint returns the current A2A authentication configuration.
+        For unauthenticated users, only basic configuration is returned.
         '''
         config = Config()
         
-        all_tokens = get_all_auth_tokens()
-        return {
+        # Base response with configuration info
+        response = {
             'http_auth_enabled': config['auth']['http_auth_enabled'],
-            'auth_required': get_auth_required_status(),
-            'active_tokens_count': len(all_tokens)
-        }, 200
+            'auth_required': get_auth_required_status()
+        }
+        
+        # Only include token count if user is authenticated
+        if config['auth']['http_auth_enabled'] is True:
+            if check_auth():
+                all_tokens = get_all_auth_tokens()
+                response['active_tokens_count'] = len(all_tokens)
+        
+        return response, 200

--- a/mindsdb/api/http/namespaces/configs/a2a.py
+++ b/mindsdb/api/http/namespaces/configs/a2a.py
@@ -1,0 +1,4 @@
+from flask_restx import Namespace
+
+
+ns_conf = Namespace('auth_tokens', description='Authentication token management routes')

--- a/mindsdb/api/http/namespaces/configs/auth_tokens.py
+++ b/mindsdb/api/http/namespaces/configs/auth_tokens.py
@@ -1,0 +1,4 @@
+from flask_restx import Namespace
+
+
+ns_conf = Namespace('auth_tokens', description='Authentication token management routes')

--- a/mindsdb/utilities/a2a_auth.py
+++ b/mindsdb/utilities/a2a_auth.py
@@ -1,0 +1,101 @@
+import secrets
+import time
+import requests
+from typing import Dict, Any, Optional
+
+from mindsdb.utilities.config import Config
+from mindsdb.utilities import log
+
+logger = log.getLogger(__name__)
+
+# In-memory storage for A2A tokens (in production, this should be a database)
+_a2a_tokens: Dict[str, Dict[str, Any]] = {}
+
+
+def generate_auth_token() -> str:
+    """Generate a secure authentication token"""
+    return secrets.token_urlsafe(32)
+
+
+def store_auth_token(token: str, user_id: str, description: str = "") -> None:
+    """Store an authentication token with metadata"""
+    _a2a_tokens[token] = {
+        'created_at': time.time(),
+        'description': description,
+        'user_id': user_id
+    }
+
+
+def is_auth_token_valid(token: str) -> bool:
+    """Check if an authentication token is valid and not expired"""
+    if token not in _a2a_tokens:
+        return False
+    
+    token_data = _a2a_tokens[token]
+    # Check if token is expired (24 hours)
+    if time.time() - token_data['created_at'] > 86400:
+        del _a2a_tokens[token]
+        return False
+    
+    return True
+
+
+def validate_auth_token_remote(token: str, http_api_url: str = None) -> bool:
+    """Validate authentication token by calling the HTTP API (for separate servers)"""
+    if http_api_url is None:
+        # Get from config
+        config = Config()
+        http_host = config.get('api', {}).get('http', {}).get('host', 'localhost')
+        http_port = config.get('api', {}).get('http', {}).get('port', 47334)
+        http_api_url = f"http://{http_host}:{http_port}/api"
+    
+    try:
+        response = requests.post(
+            f"{http_api_url}/auth_tokens/token/validate",
+            json={"token": token},
+            timeout=5
+        )
+        return response.status_code == 200
+    except Exception as e:
+        logger.warning(f"Failed to validate A2A token remotely: {e}")
+        return False
+
+
+def get_auth_token_data(token: str) -> Optional[Dict[str, Any]]:
+    """Get authentication token data if valid"""
+    if is_auth_token_valid(token):
+        return _a2a_tokens[token]
+    return None
+
+
+def revoke_auth_token(token: str) -> bool:
+    """Revoke an authentication token"""
+    if token in _a2a_tokens:
+        del _a2a_tokens[token]
+        return True
+    return False
+
+
+def get_auth_required_status() -> bool:
+    """Check if authentication is required based on HTTP auth configuration"""
+    config = Config()
+    return config['auth']['http_auth_enabled'] is True
+
+
+def cleanup_expired_tokens() -> int:
+    """Clean up expired tokens and return count of cleaned tokens"""
+    current_time = time.time()
+    expired_tokens = [
+        token for token, data in _a2a_tokens.items()
+        if current_time - data['created_at'] > 86400
+    ]
+    for token in expired_tokens:
+        del _a2a_tokens[token]
+    return len(expired_tokens)
+
+
+def get_all_auth_tokens() -> Dict[str, Dict[str, Any]]:
+    """Get all authentication tokens (for admin purposes)"""
+    # Clean up expired tokens first
+    cleanup_expired_tokens()
+    return _a2a_tokens.copy()


### PR DESCRIPTION
Description

This PR implements a unified authentication token management system for MindsDB that provides secure token-based authentication for external services like A2A (Agent-to-Agent) and MCP servers. The system ties authentication requirements to the HTTP API configuration, ensuring consistent security across all services.

Key Features:
Generic authentication token management with /api/auth_tokens/* endpoints
Automatic token validation for external services via HTTP API calls
Support for both A2A and MCP server authentication
Backward compatibility with existing MCP token configurations
Conditional authentication based on HTTP auth configuration

Problem Solved:
Previously, external services like A2A and MCP servers had inconsistent authentication mechanisms. A2A servers had no authentication, while MCP servers only supported environment-based tokens. This created security gaps and configuration complexity.

Type of change
[x] ⚡ New feature (non-breaking change which adds functionality)
[x] 📄 This change requires a documentation update
Verification Process
Test Location:
HTTP API: http://localhost:47334/api/auth_tokens/*
A2A Server: http://localhost:10002/*
MCP Server: http://localhost:47337/*
Verification Steps:
1. Test Token Management (HTTP Auth Disabled)
status
2. Test A2A Server Authentication
"
3. Test MCP Server Authentication
'
4. Test HTTP Auth Integration
txt
5. Test MCP Environment Token Priority
'
Additional Media:
[ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.
Checklist:
[x] My code follows the style guidelines(PEP 8) of MindsDB.
[x] I have appropriately commented on my code, especially in complex areas.
[x] Necessary documentation updates are either made or tracked in issues.
[x] Relevant unit and integration tests are updated or added.
Files Changed
New Files:
mindsdb/utilities/a2a_auth.py - Shared authentication utilities
mindsdb/api/http/namespaces/configs/auth_tokens.py - Auth tokens namespace config
mindsdb/api/http/namespaces/auth_tokens.py - HTTP API endpoints
mindsdb/api/a2a/common/server/auth_middleware.py - A2A authentication middleware
docs/a2a_authentication.md - Comprehensive documentation
Modified Files:
mindsdb/api/a2a/common/server/server.py - Added auth middleware
mindsdb/api/a2a/__main__.py - Updated A2A server initialization
mindsdb/api/mcp/start.py - Enhanced MCP authentication
mindsdb/api/http/initialize.py - Added auth_tokens namespace
Architecture
The implementation uses a separate server architecture where:
HTTP Server: Stores tokens in memory and provides management endpoints
External Services: Validate tokens via HTTP API calls to /api/auth_tokens/token/validate
Configuration: Services automatically read HTTP API config from MindsDB config file
Authentication Logic: Tied to HTTP auth configuration (enabled/disabled)
This design ensures secure, consistent authentication across all MindsDB services while maintaining flexibility and backward compatibility.
