### PR TITLE
Combine  view's query with outer query

### DIFF
--- a/tests/unit/executor/test_base_queires.py
+++ b/tests/unit/executor/test_base_queires.py
@@ -73,7 +73,7 @@ class TestSelect(BaseExecutorDummyML):
 
         data_handler.reset_mock()
         ret = self.run_sql("select * from v1 where b=2")
-        assert len(ret) == 1 and ret['b'][0] == 2
+        assert len(ret) == 1 and ret["b"][0] == 2
         calls = data_handler().query.call_args_list
         sql = calls[0][0][0].to_string()
 

--- a/tests/unit/executor/test_base_queires.py
+++ b/tests/unit/executor/test_base_queires.py
@@ -60,6 +60,27 @@ class TestSelect(BaseExecutorDummyML):
         assert ret.value[0] == ret.VALUE[0]
 
     @patch("mindsdb.integrations.handlers.postgres_handler.Handler")
+    def test_view_conditions(self, data_handler):
+        # test view optimisations
+        df = pd.DataFrame(
+            [
+                {"a": 1, "b": 1},
+                {"a": 1, "b": 2},
+            ]
+        )
+        self.set_handler(data_handler, name="pg", tables={"tbl1": df})
+        self.run_sql("create view v1 (select * from pg.tbl1 where a=1)")
+
+        data_handler.reset_mock()
+        ret = self.run_sql("select * from v1 where b=2")
+        assert len(ret) == 1 and ret['b'][0] == 2
+        calls = data_handler().query.call_args_list
+        sql = calls[0][0][0].to_string()
+
+        # both conditions are used in query to database
+        assert "a = 1" in sql and "b = 2" in sql
+
+    @patch("mindsdb.integrations.handlers.postgres_handler.Handler")
     def test_complex_joins(self, data_handler):
         df1 = pd.DataFrame(
             [


### PR DESCRIPTION
## Description

Added optimization for querying views:
View's query is wrapped into outer query of the view (instead of getting all data of the view and then filtering it in mindsdb server's memory)

For example:
```sql
create view v1 (
SELECT * FROM example_db.car_info where year=2010
);

select mpg from v1 where fueltype='Petrol';
```

This query will be sent to database:
```sql
SELECT mpg FROM ( 
   SELECT * 
   FROM car_info 
   WHERE year = 2010
) 
WHERE fueltype = 'Petrol'
```


Fixes https://linear.app/mindsdb/issue/CONN-1371/queries-against-mindsdb-are-simply-not-returning

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)


## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



