### PR TITLE
Update vectorstore response type

### DIFF
--- a/mindsdb/integrations/libs/vectordatabase_handler.py
+++ b/mindsdb/integrations/libs/vectordatabase_handler.py
@@ -563,7 +563,7 @@ class VectorStoreHandler(BaseHandler):
         data = pd.DataFrame(self.SCHEMA)
         data.columns = ["COLUMN_NAME", "DATA_TYPE"]
         return HandlerResponse(
-            resp_type=RESPONSE_TYPE.DATA,
+            resp_type=RESPONSE_TYPE.COLUMNS_TABLE,
             data_frame=data,
         )
 


### PR DESCRIPTION
It looks like RESPONSE_TYPE.DATA was removed. I updated the value to what I think is appropriate based off other handlers in the codebase