### PR TITLE
Fix of calculation processed rows 

### DIFF
--- a/mindsdb/api/executor/sql_query/steps/fetch_dataframe.py
+++ b/mindsdb/api/executor/sql_query/steps/fetch_dataframe.py
@@ -112,7 +112,7 @@ class FetchDataframeStepCall(BaseStepCall):
 
         # if query registered, set progress
         if self.sql_query.run_query is not None:
-            self.sql_query.run_query.set_progress(df, None)
+            self.sql_query.run_query.set_progress(processed_rows=len(df))
         return ResultSet.from_df(
             df,
             table_name=table_alias[1],


### PR DESCRIPTION
## Description

Changed the way of counting processed rows:
- the function that proccesed a chunk of data is updating count processed rows 
- also after shutdowning thread pool (in case of error) - wait till all worker finish their chunk data to calculate all successful results

Fixes https://linear.app/mindsdb/issue/CONN-600/bug-incorrect-reporting-in-describe-kb

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



