### PR TITLE
added pwd to reflect existing folder path

### DIFF
--- a/docs/setup/self-hosted/docker.mdx
+++ b/docs/setup/self-hosted/docker.mdx
@@ -201,10 +201,10 @@ The default configuration for MindsDB's Docker image is stored as a JSON code, a
 
 ### Custom configuration
 
-To override the default configuration, you can mount a config file over `/root/mindsdb_config.json`, as below.
+To override the default configuration, you can mount a config file created in your host machine over `/root/mindsdb_config.json`, as below.
 
 ```bash
-docker run --name mindsdb_container -e MINDSDB_APIS=http -d -p 47334:47334 -v mdb_config.json:/root/mindsdb_config.json mindsdb/mindsdb
+docker run --name mindsdb_container -e MINDSDB_APIS=http -d -p 47334:47334 -v $(pwd)/mdb_config.json:/root/mindsdb_config.json mindsdb/mindsdb
 ```
 
 <Tip>


### PR DESCRIPTION
## Description

This PR resolves the error that comes up when the [docker command](https://docs.mindsdb.com/setup/self-hosted/docker#:~:text=docker%20run%20%2D%2Dname%20mindsdb_container%20%2De%20MINDSDB_APIS%3Dhttp%20%2Dd%20%2Dp%2047334%3A47334%20%2Dv%20mdb_config.json%3A/root/mindsdb_config.json%20mindsdb/mindsdb) in the documentation is run

Fixes #11405 

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [x]   Test Location: Specify the URL or path for testing.
`mindsdb/docs/setup/self-hosted/docker.mdx`
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.