### PR TITLE
Fix KB unit tests

### DIFF
--- a/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
@@ -55,7 +55,7 @@ class ChromaDBHandler(VectorStoreHandler):
 
     def __init__(self, name: str, **kwargs):
         super().__init__(name)
-        self.handler_storage = HandlerStorage(kwargs.get("integration_id"))
+        self.handler_storage = kwargs['handler_storage']
         self._client = None
         self.persist_directory = None
         self.is_connected = False

--- a/mindsdb/interfaces/database/integrations.py
+++ b/mindsdb/interfaces/database/integrations.py
@@ -198,6 +198,11 @@ class IntegrationController:
             ml_handler = self.get_ml_handler(name)
             ml_handler.create_engine(connection_args, integration_id)
 
+        if engine == "chromadb":
+            # sqlite reuse ids and a new db can see files from a previous one
+            handler_storage = HandlerStorage(integration_id)
+            handler_storage.delete()
+
         return integration_id
 
     def modify(self, name, data):

--- a/mindsdb/interfaces/storage/model_fs.py
+++ b/mindsdb/interfaces/storage/model_fs.py
@@ -11,18 +11,16 @@ from .fs import RESOURCE_GROUP, FileStorageFactory, SERVICE_FILES_NAMES
 from .json import get_json_storage, get_encrypted_json_storage
 
 
-JSON_STORAGE_FILE = 'json_storage.json'
+JSON_STORAGE_FILE = "json_storage.json"
 
 
 class ModelStorage:
     """
     This class deals with all model-related storage requirements, from setting status to storing artifacts.
     """
+
     def __init__(self, predictor_id):
-        storageFactory = FileStorageFactory(
-            resource_group=RESOURCE_GROUP.PREDICTOR,
-            sync=True
-        )
+        storageFactory = FileStorageFactory(resource_group=RESOURCE_GROUP.PREDICTOR, sync=True)
         self.fileStorage = storageFactory(predictor_id)
         self.predictor_id = predictor_id
 
@@ -43,15 +41,12 @@ class ModelStorage:
         """
         model_record = db.Predictor.query.get(self.predictor_id)
         if check_exists is True and model_record is None:
-            raise KeyError('Model does not exists')
+            raise KeyError("Model does not exists")
         return model_record
 
     def get_info(self):
         rec = self._get_model_record(self.predictor_id)
-        return dict(status=rec.status,
-                    to_predict=rec.to_predict,
-                    data=rec.data,
-                    learn_args=rec.learn_args)
+        return dict(status=rec.status, to_predict=rec.to_predict, data=rec.data, learn_args=rec.learn_args)
 
     def status_set(self, status, status_info=None):
         rec = self._get_model_record(self.predictor_id)
@@ -95,67 +90,52 @@ class ModelStorage:
 
     def folder_get(self, name):
         # pull folder and return path
-        name = name.lower().replace(' ', '_')
-        name = re.sub(r'([^a-z^A-Z^_\d]+)', '_', name)
+        name = name.lower().replace(" ", "_")
+        name = re.sub(r"([^a-z^A-Z^_\d]+)", "_", name)
 
         self.fileStorage.pull_path(name)
         return str(self.fileStorage.get_path(name))
 
     def folder_sync(self, name):
         # sync abs path
-        name = name.lower().replace(' ', '_')
-        name = re.sub(r'([^a-z^A-Z^_\d]+)', '_', name)
+        name = name.lower().replace(" ", "_")
+        name = re.sub(r"([^a-z^A-Z^_\d]+)", "_", name)
 
         self.fileStorage.push_path(name)
 
-    def file_list(self):
-        ...
+    def file_list(self): ...
 
-    def file_del(self, name):
-        ...
+    def file_del(self, name): ...
 
     # jsons
 
     def json_set(self, name, data):
-        json_storage = get_json_storage(
-            resource_id=self.predictor_id,
-            resource_group=RESOURCE_GROUP.PREDICTOR
-        )
+        json_storage = get_json_storage(resource_id=self.predictor_id, resource_group=RESOURCE_GROUP.PREDICTOR)
         return json_storage.set(name, data)
 
     def encrypted_json_set(self, name: str, data: dict) -> None:
         json_storage = get_encrypted_json_storage(
-            resource_id=self.predictor_id,
-            resource_group=RESOURCE_GROUP.PREDICTOR
+            resource_id=self.predictor_id, resource_group=RESOURCE_GROUP.PREDICTOR
         )
         return json_storage.set(name, data)
 
     def json_get(self, name):
-        json_storage = get_json_storage(
-            resource_id=self.predictor_id,
-            resource_group=RESOURCE_GROUP.PREDICTOR
-        )
+        json_storage = get_json_storage(resource_id=self.predictor_id, resource_group=RESOURCE_GROUP.PREDICTOR)
         return json_storage.get(name)
 
     def encrypted_json_get(self, name: str) -> dict:
         json_storage = get_encrypted_json_storage(
-            resource_id=self.predictor_id,
-            resource_group=RESOURCE_GROUP.PREDICTOR
+            resource_id=self.predictor_id, resource_group=RESOURCE_GROUP.PREDICTOR
         )
         return json_storage.get(name)
 
-    def json_list(self):
-        ...
+    def json_list(self): ...
 
-    def json_del(self, name):
-        ...
+    def json_del(self, name): ...
 
     def delete(self):
         self.fileStorage.delete()
-        json_storage = get_json_storage(
-            resource_id=self.predictor_id,
-            resource_group=RESOURCE_GROUP.PREDICTOR
-        )
+        json_storage = get_json_storage(resource_id=self.predictor_id, resource_group=RESOURCE_GROUP.PREDICTOR)
         json_storage.clean()
 
 
@@ -164,29 +144,26 @@ class HandlerStorage:
     This class deals with all handler-related storage requirements, from storing metadata to synchronizing folders
     across instances.
     """
+
     def __init__(self, integration_id: int, root_dir: str = None, is_temporal=False):
         args = {}
         if root_dir is not None:
-            args['root_dir'] = root_dir
-        storageFactory = FileStorageFactory(
-            resource_group=RESOURCE_GROUP.INTEGRATION,
-            sync=False,
-            **args
-        )
+            args["root_dir"] = root_dir
+        storageFactory = FileStorageFactory(resource_group=RESOURCE_GROUP.INTEGRATION, sync=False, **args)
         self.fileStorage = storageFactory(integration_id)
         self.integration_id = integration_id
         self.is_temporal = is_temporal
         # do not sync with remote storage
 
     def __convert_name(self, name):
-        name = name.lower().replace(' ', '_')
-        return re.sub(r'([^a-z^A-Z^_\d]+)', '_', name)
+        name = name.lower().replace(" ", "_")
+        return re.sub(r"([^a-z^A-Z^_\d]+)", "_", name)
 
     def is_empty(self):
-        """ check if storage directory is empty
+        """check if storage directory is empty
 
-            Returns:
-                bool: true if dir is empty
+        Returns:
+            bool: true if dir is empty
         """
         for path in self.fileStorage.folder_path.iterdir():
             if path.is_file() and path.name in SERVICE_FILES_NAMES:
@@ -221,19 +198,17 @@ class HandlerStorage:
         if not self.is_temporal:
             self.fileStorage.push_path(name)
 
-    def file_list(self):
-        ...
+    def file_list(self): ...
 
-    def file_del(self, name):
-        ...
+    def file_del(self, name): ...
 
     # folder
 
     def folder_get(self, name):
-        ''' Copies folder from remote to local file system and returns its path
+        """Copies folder from remote to local file system and returns its path
 
         :param name: name of the folder
-        '''
+        """
         name = self.__convert_name(name)
 
         self.fileStorage.pull_path(name)
@@ -249,38 +224,28 @@ class HandlerStorage:
     # jsons
 
     def json_set(self, name, content):
-        json_storage = get_json_storage(
-            resource_id=self.integration_id,
-            resource_group=RESOURCE_GROUP.INTEGRATION
-        )
+        json_storage = get_json_storage(resource_id=self.integration_id, resource_group=RESOURCE_GROUP.INTEGRATION)
         return json_storage.set(name, content)
 
     def encrypted_json_set(self, name: str, content: dict) -> None:
         json_storage = get_encrypted_json_storage(
-            resource_id=self.integration_id,
-            resource_group=RESOURCE_GROUP.INTEGRATION
+            resource_id=self.integration_id, resource_group=RESOURCE_GROUP.INTEGRATION
         )
         return json_storage.set(name, content)
 
     def json_get(self, name):
-        json_storage = get_json_storage(
-            resource_id=self.integration_id,
-            resource_group=RESOURCE_GROUP.INTEGRATION
-        )
+        json_storage = get_json_storage(resource_id=self.integration_id, resource_group=RESOURCE_GROUP.INTEGRATION)
         return json_storage.get(name)
 
     def encrypted_json_get(self, name: str) -> dict:
         json_storage = get_encrypted_json_storage(
-            resource_id=self.integration_id,
-            resource_group=RESOURCE_GROUP.INTEGRATION
+            resource_id=self.integration_id, resource_group=RESOURCE_GROUP.INTEGRATION
         )
         return json_storage.get(name)
 
-    def json_list(self):
-        ...
+    def json_list(self): ...
 
-    def json_del(self, name):
-        ...
+    def json_del(self, name): ...
 
     def export_files(self) -> bytes:
         json_storage = self.export_json_storage()
@@ -288,11 +253,11 @@ class HandlerStorage:
         if self.is_empty() and not json_storage:
             return None
 
-        folder_path = self.folder_get('')
+        folder_path = self.folder_get("")
 
         zip_fd = io.BytesIO()
 
-        with zipfile.ZipFile(zip_fd, 'w', zipfile.ZIP_DEFLATED) as zipf:
+        with zipfile.ZipFile(zip_fd, "w", zipfile.ZIP_DEFLATED) as zipf:
             for root, dirs, files in os.walk(folder_path):
                 for file_name in files:
                     if file_name in SERVICE_FILES_NAMES:
@@ -309,14 +274,13 @@ class HandlerStorage:
         return zip_fd.read()
 
     def import_files(self, content: bytes):
-
-        folder_path = self.folder_get('')
+        folder_path = self.folder_get("")
 
         zip_fd = io.BytesIO()
         zip_fd.write(content)
         zip_fd.seek(0)
 
-        with zipfile.ZipFile(zip_fd, 'r') as zip_ref:
+        with zipfile.ZipFile(zip_fd, "r") as zip_ref:
             for name in zip_ref.namelist():
                 # If JSON storage file is in the zip file, import the content to the JSON storage.
                 # Thereafter, remove the file from the folder.
@@ -327,38 +291,36 @@ class HandlerStorage:
                 else:
                     zip_ref.extract(name, folder_path)
 
-        self.folder_sync('')
+        self.folder_sync("")
 
     def export_json_storage(self) -> list[dict]:
-        json_storage = get_json_storage(
-            resource_id=self.integration_id,
-            resource_group=RESOURCE_GROUP.INTEGRATION
-        )
+        json_storage = get_json_storage(resource_id=self.integration_id, resource_group=RESOURCE_GROUP.INTEGRATION)
 
         records = []
         for record in json_storage.get_all_records():
             record_dict = record.to_dict()
-            if record_dict.get('encrypted_content'):
-                record_dict['encrypted_content'] = record_dict['encrypted_content'].decode()
+            if record_dict.get("encrypted_content"):
+                record_dict["encrypted_content"] = record_dict["encrypted_content"].decode()
             records.append(record_dict)
 
         return records
 
     def import_json_storage(self, records: bytes) -> None:
-        json_storage = get_json_storage(
-            resource_id=self.integration_id,
-            resource_group=RESOURCE_GROUP.INTEGRATION
-        )
+        json_storage = get_json_storage(resource_id=self.integration_id, resource_group=RESOURCE_GROUP.INTEGRATION)
 
         encrypted_json_storage = get_encrypted_json_storage(
-            resource_id=self.integration_id,
-            resource_group=RESOURCE_GROUP.INTEGRATION
+            resource_id=self.integration_id, resource_group=RESOURCE_GROUP.INTEGRATION
         )
 
         records = json.loads(records.decode())
 
         for record in records:
-            if record['encrypted_content']:
-                encrypted_json_storage.set_str(record['name'], record['encrypted_content'])
+            if record["encrypted_content"]:
+                encrypted_json_storage.set_str(record["name"], record["encrypted_content"])
             else:
-                json_storage.set(record['name'], record['content'])
+                json_storage.set(record["name"], record["content"])
+
+    def delete(self):
+        self.fileStorage.delete()
+        json_storage = get_json_storage(resource_id=self.integration_id, resource_group=RESOURCE_GROUP.INTEGRATION)
+        json_storage.clean()

--- a/tests/integration/flows/test_knowledge_base.py
+++ b/tests/integration/flows/test_knowledge_base.py
@@ -184,7 +184,7 @@ class KBTestBase:
         """)
 
 
-class Disable_TestKB(KBTestBase):
+class TestKB(KBTestBase):
     @pytest.mark.parametrize("storage, embedding_model", get_configurations())
     def test_base_syntax(self, storage, embedding_model):
         self.create_kb("test_kb_crm", storage, embedding_model)


### PR DESCRIPTION
## Description

Changes for chromadb handler:
- don't initialize client at handler's import
- removed condition with `handler_storage.is_temporal` because it should be used for temporal storage too.
- when chomadb database is created clear its storage (because sqlite reuses ids and a new database can see files from a previous one.)

Fixes https://linear.app/mindsdb/issue/CONN-1427/fix-kb-integration-tests

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



