### PR TITLE
Fix Agent works with KB

### DIFF
--- a/mindsdb/interfaces/agents/langchain_agent.py
+++ b/mindsdb/interfaces/agents/langchain_agent.py
@@ -299,7 +299,9 @@ class LangchainAgent:
             logger.info(f"Using prompt template: {args['prompt_template'][:50]}...")
 
         if "model_name" not in args:
-            raise ValueError(f"No model name provided for agent. Provide it in the model parameter or in the default model setup.")
+            raise ValueError(
+                f"No model name provided for agent. Provide it in the model parameter or in the default model setup."
+            )
 
         return args
 

--- a/mindsdb/interfaces/agents/langchain_agent.py
+++ b/mindsdb/interfaces/agents/langchain_agent.py
@@ -300,7 +300,7 @@ class LangchainAgent:
 
         if "model_name" not in args:
             raise ValueError(
-                f"No model name provided for agent. Provide it in the model parameter or in the default model setup."
+                "No model name provided for agent. Provide it in the model parameter or in the default model setup."
             )
 
         return args

--- a/mindsdb/interfaces/agents/langchain_agent.py
+++ b/mindsdb/interfaces/agents/langchain_agent.py
@@ -298,6 +298,9 @@ class LangchainAgent:
         if "prompt_template" in args:
             logger.info(f"Using prompt template: {args['prompt_template'][:50]}...")
 
+        if "model_name" not in args:
+            raise ValueError(f"No model name provided for agent. Provide it in the model parameter or in the default model setup.")
+
         return args
 
     def get_metadata(self) -> Dict:

--- a/mindsdb/interfaces/skills/custom/text2sql/mindsdb_sql_toolkit.py
+++ b/mindsdb/interfaces/skills/custom/text2sql/mindsdb_sql_toolkit.py
@@ -15,6 +15,7 @@ from mindsdb.interfaces.skills.custom.text2sql.mindsdb_kb_tools import (
 
 
 class MindsDBSQLToolkit(SQLDatabaseToolkit):
+    include_tables_tools: bool = True
     include_knowledge_base_tools: bool = True
 
     def get_tools(self, prefix="") -> List[BaseTool]:
@@ -212,8 +213,13 @@ class MindsDBSQLToolkit(SQLDatabaseToolkit):
         )
 
         # Return standard SQL tools and knowledge base tools
-        return sql_tools + [
+        kb_tools = [
             kb_list_tool,
             kb_info_tool,
             kb_query_tool,
         ]
+
+        if not self.include_tables_tools:
+            return kb_tools
+        else:
+            return sql_tools + kb_tools

--- a/mindsdb/interfaces/skills/skill_tool.py
+++ b/mindsdb/interfaces/skills/skill_tool.py
@@ -347,7 +347,13 @@ class SkillToolController:
         )
         db = MindsDBSQL.custom_init(sql_agent=sql_agent)
         should_include_kb_tools = include_knowledge_bases is not None and len(include_knowledge_bases) > 0
-        toolkit = MindsDBSQLToolkit(db=db, llm=llm, include_knowledge_base_tools=should_include_kb_tools)
+        should_include_tables_tools = len(databases_struct) > 0 or len(tables_list) > 0
+        toolkit = MindsDBSQLToolkit(
+            db=db,
+            llm=llm,
+            include_tables_tools=should_include_tables_tools,
+            include_knowledge_base_tools=should_include_kb_tools,
+        )
         return toolkit.get_tools()
 
     def _make_retrieval_tools(self, skill: db.Skills, llm, embedding_model):

--- a/mindsdb/interfaces/skills/sql_agent.py
+++ b/mindsdb/interfaces/skills/sql_agent.py
@@ -405,6 +405,7 @@ class SQLAgent:
             tables_idx[tuple(table.parts)] = table
 
         tables = []
+        not_found = []
         for table_name in table_names:
             if not table_name.strip():
                 continue
@@ -419,9 +420,12 @@ class SQLAgent:
             table_identifier = tables_idx.get(tuple(table_parts))
 
             if table_identifier is None:
-                raise ValueError(f"Table {table_name} not found in the database")
-            tables.append(table_identifier)
+                not_found.append(table_name)
+            else:
+                tables.append(table_identifier)
 
+        if not_found:
+            raise ValueError(f"Tables: {', '.join(not_found)} not found in the database")
         return tables
 
     def get_knowledge_base_info(self, kb_names: Optional[List[str]] = None) -> str:


### PR DESCRIPTION
## Description

Fixes:
- don't include sql tools if no tables available for agent. otherwise LLM tries to use tables tools even if only a single KB is available
- Show error message if model is not defined for agent (not in 'create agent' or default config)
  - WAS: "KeyError: 'model_name'" error
- Check all tables in "sql_db_schema" tool and return messages with all not found tables together. it reduces number of iteration of llm calls

Fixes https://linear.app/mindsdb/issue/CONN-1360/bug-agents-do-not-query-data-from-kbs

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



