### PR TITLE
11431 delete files api fix

### DIFF
--- a/mindsdb/api/http/namespaces/file.py
+++ b/mindsdb/api/http/namespaces/file.py
@@ -208,6 +208,6 @@ class File(Resource):
             return http_error(
                 400,
                 "Error deleting file",
-                f"There was an error while tring to delete file with name '{name}'",
+                f"There was an error while trying to delete file with name '{name}'",
             )
         return "", 200

--- a/mindsdb/interfaces/file/file_controller.py
+++ b/mindsdb/interfaces/file/file_controller.py
@@ -151,7 +151,7 @@ class FileController:
     def delete_file(self, name):
         file_record = db.session.query(db.File).filter_by(company_id=ctx.company_id, name=name).first()
         if file_record is None:
-            return None
+            raise Exception(f"File '{name}' does not exists")
         file_id = file_record.id
         db.session.delete(file_record)
         db.session.commit()

--- a/tests/unit/api/http/files_test.py
+++ b/tests/unit/api/http/files_test.py
@@ -1,0 +1,83 @@
+from http import HTTPStatus
+import tempfile
+
+
+def test_get_files_list(client):
+    """Test getting list of all files"""
+    response = client.get("/api/files/", follow_redirects=True)
+    assert response.status_code == HTTPStatus.OK
+    files_list = response.get_json()
+    assert isinstance(files_list, list)
+
+
+def test_put_file(client):
+    """Test uploading a file"""
+    file_content = b"Hello, World!"
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        temp_file.write(file_content)
+        temp_file.flush()
+        temp_file.seek(0)
+        temp_file.seek(0)
+        data = {"file": (temp_file, "test.txt")}
+        response = client.put(
+            "/api/files/test.txt",
+            data=data,
+            content_type="multipart/form-data",
+            follow_redirects=True,
+        )
+    assert response.status_code == HTTPStatus.OK
+
+
+def test_delete_file(client):
+    """Test deleting a file"""
+    response = client.delete("/api/files/test.txt", follow_redirects=True)
+    assert response.status_code == HTTPStatus.OK
+
+
+def test_delete_nonexistent_file(client):
+    """Test deleting a nonexistent file"""
+    response = client.delete("/api/files/nonexistent.txt", follow_redirects=True)
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    data = response.get_json()
+    assert "Error deleting file" in data["title"]
+    assert (
+        "There was an error while trying to delete file with name 'nonexistent.txt'"
+        in data["detail"]
+    )
+
+
+def test_put_file_invalid_url(client):
+    """Test uploading with an invalid URL"""
+    data = {"source_type": "url", "source": "not_a_url", "file": "bad.txt"}
+    response = client.put(
+        "/api/files/bad.txt",
+        json=data,
+        content_type="application/json",
+        follow_redirects=True,
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "Invalid URL" in data["title"]
+
+
+def test_put_file_url_upload_disabled(client, monkeypatch):
+    """Test uploading from URL when URL upload is disabled"""
+    # Patch config to disable URL upload
+    monkeypatch.setattr(
+        "mindsdb.api.http.namespaces.file.config",
+        {"url_file_upload": {"enabled": False}},
+    )
+    data = {
+        "source_type": "url",
+        "source": "http://example.com/file.txt",
+        "file": "remote.txt",
+    }
+    response = client.put(
+        "/api/files/remote.txt",
+        json=data,
+        content_type="application/json",
+        follow_redirects=True,
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "URL file upload is disabled" in data["detail"]


### PR DESCRIPTION
## Description
When deleting a file via ` DELETE /api/files/{name} ` we always get a status `200 OK` even if the file is not existing 
Please include a summary of the change and the issue it solves. 

Fixes #11431 

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [x]   Test Location: `tests/unit/api/http/files_test.py`
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



