### PR TITLE
Fix SQL renderer for `INTERVAL` statement

### DIFF
--- a/mindsdb/utilities/render/sqlalchemy_render.py
+++ b/mindsdb/utilities/render/sqlalchemy_render.py
@@ -47,7 +47,7 @@ def _compile_interval(element, compiler, **kw):
         if items[1].upper().endswith("S"):
             items[1] = items[1][:-1]
 
-    if compiler.dialect.driver in ["snowflake"] or compiler.dialect.name in ["postgresql"]:
+    if getattr(compiler.dialect, "driver", None) == "snowflake" or compiler.dialect.name == "postgresql":
         # quote all
         args = " ".join(map(str, items))
         args = f"'{args}'"

--- a/tests/unit/handlers/test_clickhouse.py
+++ b/tests/unit/handlers/test_clickhouse.py
@@ -4,6 +4,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from sqlalchemy.exc import SQLAlchemyError
+from mindsdb_sql_parser import parse_sql
 
 from base_handler_test import BaseDatabaseHandlerTest
 
@@ -53,6 +54,11 @@ class TestClickHouseHandler(BaseDatabaseHandlerTest, unittest.TestCase):
         self.assertEqual(self.handler.dialect, "clickhouse")
         self.assertFalse(self.handler.is_connected)
         self.assertEqual(self.handler.protocol, "native")
+
+    def test_renderer(self):
+        sql = "SELECT * FROM ch.table WHERE created_at = (now() - INTERVAL '5' MINUTE);"
+        rendered_sql = self.handler.renderer.get_string(parse_sql(sql), with_failback=True)
+        assert rendered_sql == 'SELECT * \nFROM ch."table" \nWHERE created_at = now() - INTERVAL \'5\' MINUTE'
 
     def test_connect_success(self):
         self.mock_connect.return_value = MagicMock()

--- a/tests/unit/handlers/test_clickhouse.py
+++ b/tests/unit/handlers/test_clickhouse.py
@@ -58,7 +58,7 @@ class TestClickHouseHandler(BaseDatabaseHandlerTest, unittest.TestCase):
     def test_renderer(self):
         sql = "SELECT * FROM ch.table WHERE created_at = (now() - INTERVAL '5' MINUTE);"
         rendered_sql = self.handler.renderer.get_string(parse_sql(sql), with_failback=True)
-        assert rendered_sql == 'SELECT * \nFROM ch."table" \nWHERE created_at = now() - INTERVAL \'5\' MINUTE'
+        assert rendered_sql == "SELECT * \nFROM ch.\"table\" \nWHERE created_at = now() - INTERVAL '5' MINUTE"
 
     def test_connect_success(self):
         self.mock_connect.return_value = MagicMock()


### PR DESCRIPTION
## Description

There was an error with the SQL renderer for the `INTERVAL` statement. This error occurred for dialects that do not have the 'driver' attribute.

Fixes #11422, CONN-1391

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



