### PR TITLE
Fix agent access to sql  fixes  sql fix

### DIFF
--- a/mindsdb/interfaces/agents/constants.py
+++ b/mindsdb/interfaces/agents/constants.py
@@ -260,8 +260,6 @@ MINDSDB_PREFIX = """You are an AI assistant powered by MindsDB. You have access 
 
 For factual questions, ALWAYS use the available tools to look up information rather than relying on your internal knowledge.
 
-Here is the user's question: {{question}}   
-
 TOOLS:
 ------
 

--- a/mindsdb/interfaces/skills/custom/text2sql/mindsdb_sql_toolkit.py
+++ b/mindsdb/interfaces/skills/custom/text2sql/mindsdb_sql_toolkit.py
@@ -55,7 +55,7 @@ class MindsDBSQLToolkit(SQLDatabaseToolkit):
             f"""\
             Input: A detailed and well-structured SQL query. The query must be enclosed between the symbols $START$ and $STOP$.
             Output: Database result or error message. For errors, rewrite and retry the query. For 'Unknown column' errors, use '{info_sql_database_tool.name}' to check table fields.
-            This system is a highly intelligent and reliable PostgreSQL SQL skill designed to work with databases.
+            This system is a highly intelligent and reliable SQL skill designed to work with databases.
             Follow these instructions with utmost precision:
             1. Final Response Format:
                - Assume the frontend fully supports Markdown unless the user specifies otherwise.
@@ -73,7 +73,7 @@ class MindsDBSQLToolkit(SQLDatabaseToolkit):
                - Let the user know they can request additional results and/or specify how they would like the results ordered or grouped.
             5. Date Handling:
                - **System current date and time: {current_date_time} (UTC or local timezone based on server settings).**
-               - **Always** use PostgreSQL-compatible `CURRENT_DATE` or `NOW()` functions when working with dates—never assume or guess the current date.
+               - **Always** use `CURRENT_DATE` or `NOW()` functions when working with dates—never assume or guess the current date.
                - For any date-related comparisons in the query, *always* ensure that your query casts the column being compared using `column_name::DATE [operator] ..`
                - Do not compare date values without casting columns to date.
                - For date interval operations, use Interval units as keywords. You can use keywords to specify units like days, hours, months, years, etc., directly without quotes. Examples:
@@ -95,6 +95,8 @@ class MindsDBSQLToolkit(SQLDatabaseToolkit):
             8. Identity and Purpose:
                - When asked about yourself or your maker, state that you are a Data-Mind, created by MindsDB to help answer data questions.
                - When asked about your purpose or how you can help, explore the available data sources and then explain that you can answer questions based on the connected data. Provide a few relevant example questions that you could answer for the user about their data.
+            9. Important: you can use only mysql quoting rules to compose queries: backticks (`) for identifiers, and single quotes (') for constants
+
             Adhere to these guidelines for all queries and responses. Ask for clarification if needed.
         """
         )

--- a/mindsdb/interfaces/skills/custom/text2sql/mindsdb_sql_toolkit.py
+++ b/mindsdb/interfaces/skills/custom/text2sql/mindsdb_sql_toolkit.py
@@ -120,7 +120,7 @@ class MindsDBSQLToolkit(SQLDatabaseToolkit):
             query_sql_database_tool,
             info_sql_database_tool,
             list_sql_database_tool,
-            mindsdb_sql_parser_tool,
+            # mindsdb_sql_parser_tool,
         ]
         if not self.include_knowledge_base_tools:
             return sql_tools

--- a/mindsdb/interfaces/skills/sql_agent.py
+++ b/mindsdb/interfaces/skills/sql_agent.py
@@ -585,7 +585,7 @@ class SQLAgent:
 
     def _get_sample_rows(self, table: str, fields: List[str]) -> str:
         logger.info(f"_get_sample_rows: table={table} fields={fields}")
-        command = f"select {', '.join(fields)} from {table} limit {self._sample_rows_in_table_info};"
+        command = f"select * from {table} limit {self._sample_rows_in_table_info};"
         try:
             ret = self._call_engine(command)
             sample_rows = ret.data.to_lists()


### PR DESCRIPTION
## Description

Updates:
- Update instructions to force llm to use mysql quiting style (backticks for identifiers)
  - also removed mentioning postgres database in main prompt for it
- disabled sql_parser_tool. @dusvyat, do we have some benchmarks that we might use to check that this change doesn't degrade quality?
  - it adds extra step for llm before executing query (increases response time).
  - also its payload is not clear: it just parses the query and render it again. db_query also shows error in case of parsing error
- Fix error if with postgresql when column names are in mixed case ([commit](https://github.com/mindsdb/mindsdb/commit/1222ad1366e32ea7a906127ec59fbec390910089))
- removed unused line in prompt in main template (`Here is the user's question:`)

Tested with queries from issues below:
```sql
select * from financial_agent where question = "What stocks are in the portfolio?";
select * from financial_agent where question = "What's the percentage breakdown of investments by category in the portfolio";
select * from financial_agent where question = "What category has the most exposure?";
select * from financial_agent where question = "Leadership has mandated that we limit our exposure to crypto to 10%. Is the portfolio compliant and if not, what must I do to make it compliant?";
---
select * from supplychain_agent where question ="What is the current stock level of a specific product: Radiance Ritual?";
select * from supplychain_agent where question ="Which products are low in stock and need reordering?";
select * from supplychain_agent where question ="What are the recent shipment details for a SKU2?";
select * from supplychain_agent where question ="How long does it typically take for a SKU2 to be delivered?";
select * from supplychain_agent where question ="What are the details of SKU5, such as its price and description?";
select * from supplychain_agent where question ="Can you list all the products from a cosmetics category?";
select * from supplychain_agent where question ="Who are the suppliers for SKU5?";
select * from supplychain_agent where question ="What are the contact details of supplier of SKU5?";
select * from supplychain_agent where question ="Can you provide a summary of the inventory status?";
select * from supplychain_agent where question ="What are the top-selling products?";
```

Fixes https://linear.app/mindsdb/issue/CONN-1442/bug-agentsintermittent-issues-in-executing-sql-query
Fixes https://linear.app/mindsdb/issue/CONN-1445/bug-agents-unable-to-retrieve-data-from-tables


## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



