### PR TITLE
Fix snowflake:  use PUBLIC schema if is not set

### DIFF
--- a/mindsdb/integrations/handlers/snowflake_handler/snowflake_handler.py
+++ b/mindsdb/integrations/handlers/snowflake_handler/snowflake_handler.py
@@ -204,10 +204,11 @@ class SnowflakeHandler(MetaDatabaseHandler):
             "user": self.connection_data.get("user"),
             "password": self.connection_data.get("password"),
             "database": self.connection_data.get("database"),
+            "schema": self.connection_data.get("schema", "PUBLIC"),
         }
 
         # Optional connection parameters
-        optional_params = ["schema", "warehouse", "role"]
+        optional_params = ["warehouse", "role"]
         for param in optional_params:
             if param in self.connection_data:
                 config[param] = self.connection_data[param]


### PR DESCRIPTION
## Description

If schema is not set - use PUBLIC. It will show tables from PUBLIC schema

Example: `snowflake_datasource` connection was created with schema, `snowflake_sales_data` - without:
<img width="198" height="153" alt="image" src="https://github.com/user-attachments/assets/a0813122-0f25-4977-9177-283e44243977" />

Fixes https://linear.app/mindsdb/issue/FQE-1486/snowflake-handler-fails-to-discover-tables-on-connection

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



