### PR TITLE
Env var to disable GUI autoupdate

### DIFF
--- a/mindsdb/api/http/initialize.py
+++ b/mindsdb/api/http/initialize.py
@@ -95,7 +95,7 @@ def custom_output_json(data, code, headers=None):
 
 
 def get_last_compatible_gui_version() -> Version | bool:
-    logger.debug("Getting last compatible frontend..")
+    logger.debug("Getting last compatible frontend...")
     try:
         res = requests.get(
             "https://mindsdb-web-builds.s3.amazonaws.com/compatible-config.json",
@@ -178,7 +178,6 @@ def get_current_gui_version() -> Version:
 
 
 def initialize_static():
-    logger.debug("Initializing static..")
     last_gui_version_lv = get_last_compatible_gui_version()
     current_gui_version_lv = get_current_gui_version()
     required_gui_version = config["gui"].get("version")
@@ -214,8 +213,11 @@ def initialize_app():
     init_static_thread = None
 
     if config["gui"]["autoupdate"] is True or (config["gui"]["open_on_start"] is True and gui_exists is False):
+        logger.debug("Initializing static...")
         init_static_thread = threading.Thread(target=initialize_static, name="initialize_static")
         init_static_thread.start()
+    else:
+        logger.debug(f"Skip initializing static: config['gui']={config['gui']}, gui_exists={gui_exists}")
 
     # Wait for static initialization.
     if config["gui"]["open_on_start"] is True and init_static_thread is not None:
@@ -309,7 +311,6 @@ def initialize_app():
 
     @app.before_request
     def before_request():
-        logger.debug(f"HTTP {request.method}: {request.path}")
         ctx.set_default()
 
         h = request.headers.get("Authorization")
@@ -371,7 +372,7 @@ def initialize_app():
 
 
 def initialize_flask(config, init_static_thread):
-    logger.debug("Initializing flask..")
+    logger.debug("Initializing flask...")
     # region required for windows https://github.com/mindsdb/mindsdb/issues/2526
     mimetypes.add_type("text/css", ".css")
     mimetypes.add_type("text/javascript", ".js")

--- a/mindsdb/integrations/handlers/byom_handler/byom_handler.py
+++ b/mindsdb/integrations/handlers/byom_handler/byom_handler.py
@@ -1,10 +1,9 @@
 """BYOM: Bring Your Own Model
 
 env vars to contloll BYOM:
- - MINDSDB_BYOM_ENABLED - can BYOM be uysed or not. Locally enabled by default.
+ - MINDSDB_BYOM_ENABLED - can BYOM be used or not. Locally enabled by default.
  - MINDSDB_BYOM_INHOUSE_ENABLED - enable or disable 'inhouse' BYOM usage. Locally enabled by default.
  - MINDSDB_BYOM_DEFAULT_TYPE - [inhouse|venv] default byom type. Locally it is 'venv' by default.
- - MINDSDB_BYOM_TYPE - [safe|unsafe] - obsolete, same as above.
 """
 
 import os
@@ -73,15 +72,8 @@ class BYOMHandler(BaseMLEngine):
             self._default_byom_type = BYOM_TYPE.VENV
             if os.environ.get("MINDSDB_BYOM_DEFAULT_TYPE") is not None:
                 self._default_byom_type = BYOM_TYPE[os.environ.get("MINDSDB_BYOM_DEFAULT_TYPE").upper()]
-            else:
-                env_var = os.environ.get("MINDSDB_BYOM_DEFAULT_TYPE")
-                if env_var == "SAVE":
-                    self._default_byom_type = BYOM_TYPE["VENV"]
-                elif env_var == "UNSAVE":
-                    self._default_byom_type = BYOM_TYPE["INHOUSE"]
-                else:
-                    raise KeyError
         except KeyError:
+            logger.warning(f"Wrong value of env var MINDSDB_BYOM_DEFAULT_TYPE, {BYOM_TYPE.VENV} will be used")
             self._default_byom_type = BYOM_TYPE.VENV
         # endregion
 

--- a/mindsdb/interfaces/jobs/scheduler.py
+++ b/mindsdb/interfaces/jobs/scheduler.py
@@ -128,7 +128,6 @@ class Scheduler:
 
 
 def start(verbose=False):
-    logger.info("Jobs API is starting..")
     scheduler = Scheduler()
 
     scheduler.start()

--- a/mindsdb/utilities/config.py
+++ b/mindsdb/utilities/config.py
@@ -356,6 +356,15 @@ class Config:
             self._env_config["gui"]["open_on_start"] = False
             self._env_config["gui"]["autoupdate"] = False
 
+        mindsdb_gui_autoupdate = os.environ.get("MINDSDB_GUI_AUTOUPDATE", "").lower()
+        if mindsdb_gui_autoupdate in ("0", "false"):
+            self._env_config["gui"]["autoupdate"] = False
+        elif mindsdb_gui_autoupdate in ("1", "true"):
+            self._env_config["gui"]["autoupdate"] = True
+        elif mindsdb_gui_autoupdate != "":
+            raise ValueError(f"Wrong value of env var MINDSDB_GUI_AUTOUPDATE={mindsdb_gui_autoupdate}")
+
+
     def fetch_auto_config(self) -> bool:
         """Load dict readed from config.auto.json to `auto_config`.
         Do it only if `auto_config` was not loaded before or config.auto.json been changed.


### PR DESCRIPTION
## Description

Added new env var to control GUI autoupdate:
 - if MINDSDB_GUI_AUTOUPDATE = false or 0 - disable GUI autoupdate
 - if MINDSDB_GUI_AUTOUPDATE = true or 1 - enable GUI autoupdate (default)

Fixes #11409

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



