### PR TITLE
docs: Update authentication credentials for Astra DB connections

### DIFF
--- a/docs/integrations/data-integrations/datastax.mdx
+++ b/docs/integrations/data-integrations/datastax.mdx
@@ -5,7 +5,7 @@ sidebarTitle: DataStax
 
 This is the implementation of the DataStax data handler for MindsDB.
 
-[DataStax](https://www.datastax.com/) Astra DB is a cloud database-as-a-service based on Apache Cassandra. DataStax also offers DataStax Enterprise (DSE), an on-premises database built on Apache Cassandra, and Astra Streaming, a messaging and event streaming cloud service based on Apache Pulsar.
+https://docs.datastax.com/en/astra-db-serverless/index.html[DataStax Astra DB] is a cloud database-as-a-service based on Apache Cassandra. DataStax also offers on-premises solutions, DataStax Enterprise (DSE) and Hyper-Converged Database (HCD), as well as Astra Streaming, a messaging and event streaming cloud service based on Apache Pulsar.
 
 ## Prerequisites
 
@@ -13,7 +13,7 @@ Before proceeding, ensure the following prerequisites are met:
 
 1. Install MindsDB locally via [Docker](/setup/self-hosted/docker) or [Docker Desktop](/setup/self-hosted/docker-desktop).
 2. To connect DataStax to MindsDB, install the required dependencies following [this instruction](/setup/self-hosted/docker#install-dependencies).
-3. Install or ensure access to DataStax.
+3. Create an [Astra DB database](https://docs.datastax.com/en/astra-db-serverless/databases/create-database.html).
 
 ## Implementation
 
@@ -21,9 +21,9 @@ DataStax Astra DB is API-compatible with Apache Cassandra and ScyllaDB. Therefor
 
 The required arguments to establish a connection are as follows:
 
-* `user` is the user to authenticate.
-* `password` is the password to authenticate the user.
-* `secure_connect_bundle` is the path to the `secure_connect_bundle` zip file.
+* `user`: The literal string `token`
+* `password`: An [Astra application token](https://docs.datastax.com/en/astra-db-serverless/administration/manage-application-tokens.html)
+* `secure_connect_bundle`: The path to your database's [Secure Connect Bundle](https://docs.datastax.com/en/astra-db-serverless/databases/secure-connect-bundle.html) zip file
 
 ## Usage
 
@@ -34,12 +34,11 @@ CREATE DATABASE astra_connection
 WITH
     engine = "astra",
     parameters = {
-        "user": "user",
-        "password": "pass",
+        "user": "token",
+        "password": "application_token",
         "secure_connect_bundle": "/home/Downloads/file.zip"
     };
 ```
-
 
 or, reference the bundle from Datastax s3 as:
 
@@ -47,8 +46,8 @@ or, reference the bundle from Datastax s3 as:
 CREATE DATABASE astra_connection
 WITH ENGINE = "astra",
 PARAMETERS = {
-    "user": "user",
-    "password": "pass",
+    "user": "token",
+    "password": "application_token",
     "secure_connect_bundle": "https://datastax-cluster-config-prod.s3.us-east-2.amazonaws.com/32312-b9eb-4e09-a641-213eaesa12-1/secure-connect-demo.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AK..."
 }  
 ```


### PR DESCRIPTION
## Description

* Update the `user` and `password` for the Astra DB connection. This is based on how the `python-driver` (from which `scylla-driver` is forked) authenticates to Astra.
* Provide links to Astra documentation for the credentials and prerequisites.

As an aside for the maintainer's consideration: scylla-driver doesn't officially support Astra.
[scylla-driver](https://github.com/scylladb/python-driver/) is forked from [datastax/python-driver](https://github.com/datastax/python-driver). This is the [recommended Python driver](https://docs.datastax.com/en/datastax-drivers/compatibility/python-drivers.html) for Astra as well as HCD, DSE, and [OSS Cassandra](https://cassandra.apache.org/doc/latest/cassandra/getting-started/drivers.html#python).

## Type of change

Documentation only.

- [x] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [x]  Verification Steps: There should be no dramatic change, but check the docs build to make sure it looks correct.

## Checklist:

- [n/a] My code follows the style guidelines(PEP 8) of MindsDB.
- [n/a] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [n/a] Relevant unit and integration tests are updated or added.
