### PR TITLE
Fix `EVALUATE KNOWLEDGE_BASE` with azure-openai

### DIFF
--- a/mindsdb/interfaces/knowledge_base/evaluate.py
+++ b/mindsdb/interfaces/knowledge_base/evaluate.py
@@ -291,7 +291,9 @@ class EvaluateRerank(EvaluateBase):
     def evaluate(self, test_data: pd.DataFrame) -> pd.DataFrame:
         json_to_log_list = []
         if {"question", "answer"} - set(test_data.columns):
-            raise KeyError(f"Test data must contain \"question\" and \"answer\" columns. Columns in the provided test data: {list(test_data.columns)}")
+            raise KeyError(
+                f'Test data must contain "question" and "answer" columns. Columns in the provided test data: {list(test_data.columns)}'
+            )
         questions = test_data.to_dict("records")
 
         for i, item in enumerate(questions):
@@ -488,7 +490,9 @@ class EvaluateDocID(EvaluateBase):
     def evaluate(self, test_data: pd.DataFrame) -> pd.DataFrame:
         stats = []
         if {"question", "doc_id"} - set(test_data.columns):
-            raise KeyError(f"Test data must contain \"question\" and \"doc_id\" columns. Columns in the provided test data: {list(test_data.columns)}")
+            raise KeyError(
+                f'Test data must contain "question" and "doc_id" columns. Columns in the provided test data: {list(test_data.columns)}'
+            )
         questions = test_data.to_dict("records")
 
         for i, item in enumerate(questions):

--- a/mindsdb/interfaces/knowledge_base/llm_client.py
+++ b/mindsdb/interfaces/knowledge_base/llm_client.py
@@ -31,7 +31,7 @@ class LLMClient:
             azure_api_key = params.get("api_key") or os.getenv("AZURE_OPENAI_API_KEY")
             azure_api_endpoint = params.get("base_url") or os.environ.get("AZURE_OPENAI_ENDPOINT")
             azure_api_version = params.get("api_version") or os.environ.get("AZURE_OPENAI_API_VERSION")
-            self._llm_client = AzureOpenAI(
+            self.client = AzureOpenAI(
                 api_key=azure_api_key, azure_endpoint=azure_api_endpoint, api_version=azure_api_version, max_retries=2
             )
         elif self.provider == "openai":


### PR DESCRIPTION
## Description

Fix for `EVALUATE KNOWLEDGE_BASE` when azure-openai is used.

To replicate, create a KB, upload any test_data and run:
```sql
EVALUATE KNOWLEDGE_BASE my_kb
USING
    test_table = files.kb_test_data,
    generate_data=true,
    llm= {
        "provider": "azure_openai",
        "model_name" : "gpt-4.1",
        "base_url": "https://url.openai.azure.com/",
        "api_key": 'key,
        "api_version": "2023-05-15"
    },
    save_to=files.my_result_test;
```

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



