### PR TITLE
fix KB `GREATER THAN` filter

### DIFF
--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -384,7 +384,7 @@ class KnowledgeBaseTable:
         # if relevance filtering method is strictly GREATER THAN we filter the df
         if gt_filtering:
             relevance_scores = TableField.RELEVANCE.value
-            df = df[relevance_scores > relevance_threshold]
+            df = df[df[relevance_scores] > relevance_threshold]
 
         return df
 

--- a/tests/unit/executor/test_knowledge_base.py
+++ b/tests/unit/executor/test_knowledge_base.py
@@ -670,3 +670,29 @@ class TestKB(BaseExecutorDummyML):
 
         # default model was saved
         assert "dummy_model" in ret["EMBEDDING_MODEL"][0]
+
+    @patch("mindsdb.integrations.handlers.litellm_handler.litellm_handler.embedding")
+    def test_relevance_filtering_gt_operator(self, mock_litellm_embedding):
+        """Test relevance filtering with GREATER_THAN operator"""
+        set_litellm_embedding(mock_litellm_embedding)
+
+        test_data = [
+            {"id": "1", "content": "This is about machine learning and AI"},
+            {"id": "2", "content": "This is about cooking recipes"},
+            {"id": "3", "content": "This is about artificial intelligence and neural networks"},
+            {"id": "4", "content": "This is about gardening tips"},
+        ]
+        df = pd.DataFrame(test_data)
+        self.save_file("test_docs", df)
+        self._create_kb("kb_relevance_test")
+        self.run_sql("""
+            insert into kb_relevance_test
+            select id, content from files.test_docs
+        """)
+
+        ret = self.run_sql("""
+            select * from kb_relevance_test
+            where content = 'machine learning'
+            and relevance > 0.5
+        """)
+        assert isinstance(ret, pd.DataFrame)


### PR DESCRIPTION
## Description

If create KB and try to filter:
```sql
CREATE KNOWLEDGE_BASE my_kb
USING
    embedding_model = {
        "provider": "openai",
        "model_name" : "text-embedding-3-large",
        "api_key": "sk-abc123"
    },
    reranking_model = {
        "provider": "openai",
        "model_name": "gpt-4o",
        "api_key": "sk-abc123"
    },
    metadata_columns = ['product'],
    content_columns = ['notes'],
    id_column = 'order_id';

INSERT INTO my_kb
SELECT order_id, product, notes
FROM sample_data.orders;

SELECT chunk_content, distance, relevance
FROM my_kb
WHERE product = 'Bluetooth Speaker'
AND content = 'portable'
AND relevance > 0.01;
```
then the query fail with
```
'>' not supported between instances of 'str' and 'float'
```

Fixes #FQE-1623

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



