### PR TITLE
KB: metadata as columns

### DIFF
--- a/tests/unit/executor/test_knowledge_base.py
+++ b/tests/unit/executor/test_knowledge_base.py
@@ -211,9 +211,9 @@ class TestKB(BaseExecutorDummyML):
             select * from files.reviews
         """)
 
+        # metadata as columns
         ret = self.run_sql("""
-                select chunk_content,
-                 metadata->>'specs' as specs, metadata->>'product' as product, metadata->>'url' as url
+                select chunk_content, specs, product, url
                 from kb_review 
                 where _original_doc_id = 123 -- id is id
         """)


### PR DESCRIPTION
## Description

Show metadata as separated columns. It allows to use them as select targed
Example:
<img width="697" height="287" alt="image" src="https://github.com/user-attachments/assets/10d47230-0f56-4571-b9b5-ef8891e53f14" />


Fixes https://linear.app/mindsdb/issue/FQE-1577/make-metadata-columns-available-in-sql-query-result-in-kb

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



