### PR TITLE
Fix recursion with logprobs if model is not found

### DIFF
--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -1348,7 +1348,7 @@ class KnowledgeBaseController:
             reranker = get_reranking_model_from_params(params)
             reranker.get_scores("test", ["test"])
         except (ValueError, RuntimeError) as e:
-            if params["provider"] in ("azure_openai", "openai"):
+            if params["provider"] in ("azure_openai", "openai") and params.get("method") != "no-logprobs":
                 # check with no-logprobs
                 params["method"] = "no-logprobs"
                 self._test_reranking(params)


### PR DESCRIPTION
## Description

If model doesn't not exists it goes into recursion to call _test_reranking once again

Fixes https://linear.app/mindsdb/issue/FQE-1688/fix-testing-logprob-bug

## Type of change


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



