### PR TITLE
docs -- query kb's chunk_content column

### DIFF
--- a/docs/mindsdb_sql/knowledge_bases/query.mdx
+++ b/docs/mindsdb_sql/knowledge_bases/query.mdx
@@ -133,7 +133,7 @@ Alternatively, users can filter by the `chunk_content` column of the knowledge b
 ```sql
 SELECT *
 FROM my_kb
-WHERE chunk_content = '%color%'
+WHERE chunk_content LIKE '%color%'
 ```
 
 Here is the output:


### PR DESCRIPTION
## Description

docs -- query kb's chunk_content column

related ticket: https://linear.app/mindsdb/issue/FQE-1574/add-chunk-content-as-a-possible-filter-in-kb-queries

Fixes #issue_number

## Type of change

- [ ] 📄 This change is a documentation update
