### PR TITLE
Fix: minor grammar and formatting issues in Slack integration doc

### DIFF
--- a/docs/integrations/app-integrations/slack.mdx
+++ b/docs/integrations/app-integrations/slack.mdx
@@ -49,7 +49,7 @@ Here is how to set up a Slack app and generate both a Slack bot token and a Slac
 
   1. Follow [this link](https://api.slack.com/apps) and sign in with your Slack account.
   2. Create a new app `From scratch` or select an existing app.
-      - Please note that the following instructions support apps created `From scratch`.
+      - Please note that the following instructions support apps created *From scratch*.
       - For apps created `From an app manifest`, please follow the [Slack docs here](https://api.slack.com/reference/manifests).
   3. Go to *Basic Information* under *Settings*.
       - Under *App-Level Tokens*, click on *Generate Token and Scopes*.
@@ -125,7 +125,7 @@ Here is how to set up a Slack app and generate a Slack bot token:
       - mpim:read
       - users:read
   5. Install the bot in your workspace.
-  6. Under the *OAuth Tokens for Your Workspace* section, copy the the *Bot User OAuth Token* value.
+  6. Under the *OAuth Tokens for Your Workspace* section, copy the *Bot User OAuth Token* value.
   7. Open your Slack application and add the App/Bot to one of the channels:
       - Go to the channel where you want to use the bot.
       - Right-click on the channel and select *View Channel Details*.
@@ -150,7 +150,7 @@ WITH
 <Warning>
 The following usage applies when **Connection Method 2** was used to connect Slack.
 
-See the usage for **Connection Method 1** [via the `CREATE CHATBOT` syntax](/sql/tutorials/create-chatbot).
+See the usage for **Connection Method 1** — [via the `CREATE CHATBOT` syntax](/sql/tutorials/create-chatbot).
 </Warning>
 
 Retrieve data from a specified table by providing the integration and table names:


### PR DESCRIPTION
Fixed small grammar mistake ('copy the the'), improved markdown formatting, and added spacing before link in Usage section.

## Description

Please include a summary of the change and the issue it solves. 

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



