### PR TITLE
Add schema to mssql

### DIFF
--- a/mindsdb/integrations/handlers/mssql_handler/README.md
+++ b/mindsdb/integrations/handlers/mssql_handler/README.md
@@ -85,6 +85,7 @@ Optional connection parameters include the following:
 
 * `port`: The port number for connecting to the Microsoft SQL Server. Default is 1433.
 * `server`: The server name to connect to. Typically only used with named instances or Azure SQL Database.
+* `schema`: The schema in which objects are searched first. If specified, all table references without an explicit schema will be automatically qualified with this schema.
 
 ### ODBC Connection
 

--- a/mindsdb/integrations/handlers/mssql_handler/__about__.py
+++ b/mindsdb/integrations/handlers/mssql_handler/__about__.py
@@ -1,9 +1,9 @@
-__title__ = 'MindsDB Microsoft SQL Server handler'
-__package_name__ = 'mindsdb_mssql_handler'
-__version__ = '0.0.1'
+__title__ = "MindsDB Microsoft SQL Server handler"
+__package_name__ = "mindsdb_mssql_handler"
+__version__ = "0.0.1"
 __description__ = "MindsDB handler for Microsoft SQL Server"
-__author__ = 'MindsDB Inc'
-__github__ = 'https://github.com/mindsdb/mindsdb'
-__pypi__ = 'https://pypi.org/project/mindsdb/'
-__license__ = 'MIT'
-__copyright__ = 'Copyright 2022- mindsdb'
+__author__ = "MindsDB Inc"
+__github__ = "https://github.com/mindsdb/mindsdb"
+__pypi__ = "https://pypi.org/project/mindsdb/"
+__license__ = "MIT"
+__copyright__ = "Copyright 2022- mindsdb"

--- a/mindsdb/integrations/handlers/mssql_handler/__init__.py
+++ b/mindsdb/integrations/handlers/mssql_handler/__init__.py
@@ -2,20 +2,30 @@ from mindsdb.integrations.libs.const import HANDLER_TYPE
 
 from .__about__ import __version__ as version, __description__ as description
 from .connection_args import connection_args, connection_args_example
+
 try:
     from .mssql_handler import SqlServerHandler as Handler
+
     import_error = None
 except Exception as e:
     Handler = None
     import_error = e
 
 
-title = 'Microsoft SQL Server'
-name = 'mssql'
+title = "Microsoft SQL Server"
+name = "mssql"
 type = HANDLER_TYPE.DATA
-icon_path = 'icon.svg'
+icon_path = "icon.svg"
 
 __all__ = [
-    'Handler', 'version', 'name', 'type', 'title', 'description',
-    'connection_args_example', 'connection_args', 'import_error', 'icon_path'
+    "Handler",
+    "version",
+    "name",
+    "type",
+    "title",
+    "description",
+    "connection_args_example",
+    "connection_args",
+    "import_error",
+    "icon_path",
 ]

--- a/mindsdb/integrations/handlers/mssql_handler/connection_args.py
+++ b/mindsdb/integrations/handlers/mssql_handler/connection_args.py
@@ -5,48 +5,50 @@ from mindsdb.integrations.libs.const import HANDLER_CONNECTION_ARG_TYPE as ARG_T
 
 connection_args = OrderedDict(
     user={
-        'type': ARG_TYPE.STR,
-        'description': 'The user name used to authenticate with the Microsoft SQL Server.',
-        'required': True,
-        'label': 'User'
+        "type": ARG_TYPE.STR,
+        "description": "The user name used to authenticate with the Microsoft SQL Server.",
+        "required": True,
+        "label": "User",
     },
     password={
-        'type': ARG_TYPE.PWD,
-        'description': 'The password to authenticate the user with the Microsoft SQL Server.',
-        'required': True,
-        'label': 'Password',
-        'secret': True
+        "type": ARG_TYPE.PWD,
+        "description": "The password to authenticate the user with the Microsoft SQL Server.",
+        "required": True,
+        "label": "Password",
+        "secret": True,
     },
     database={
-        'type': ARG_TYPE.STR,
-        'description': 'The database name to use when connecting with the Microsoft SQL Server.',
-        'required': True,
-        'label': 'Database'
+        "type": ARG_TYPE.STR,
+        "description": "The database name to use when connecting with the Microsoft SQL Server.",
+        "required": True,
+        "label": "Database",
     },
     host={
-        'type': ARG_TYPE.STR,
-        'description': 'The host name or IP address of the Microsoft SQL Server.',
-        'required': True,
-        'label': 'Host'
+        "type": ARG_TYPE.STR,
+        "description": "The host name or IP address of the Microsoft SQL Server.",
+        "required": True,
+        "label": "Host",
     },
     port={
-        'type': ARG_TYPE.INT,
-        'description': 'The TCP/IP port of the Microsoft SQL Server. Must be an integer.',
-        'required': False,
-        'label': 'Port'
+        "type": ARG_TYPE.INT,
+        "description": "The TCP/IP port of the Microsoft SQL Server. Must be an integer.",
+        "required": False,
+        "label": "Port",
     },
     server={
-        'type': ARG_TYPE.STR,
-        'description': 'The server name of the Microsoft SQL Server. Typically only used with named instances or Azure SQL Database.',
-        'required': False,
-        'label': 'Server'
-    }
+        "type": ARG_TYPE.STR,
+        "description": "The server name of the Microsoft SQL Server. Typically only used with named instances or Azure SQL Database.",
+        "required": False,
+        "label": "Server",
+    },
+    schema={
+        "type": ARG_TYPE.STR,
+        "description": "The schema in which objects are searched first. If not provided, all schemas will be queried.",
+        "required": False,
+        "label": "Schema",
+    },
 )
 
 connection_args_example = OrderedDict(
-    host='127.0.0.1',
-    port=1433,
-    user='sa',
-    password='password',
-    database='master'
+    host="127.0.0.1", port=1433, user="sa", password="password", database="master", schema="dbo"
 )


### PR DESCRIPTION
## Description

Fixes the issue where AI agents generate SQL queries without schema qualifiers, causing queries to fail when user data is in a specific schema. Now, we check if schema exist and use that schema without the need to ALTER users table for MS SQL

## Type of change

(Please delete options that are not relevant)

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update


## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [X] Necessary documentation updates are either made or tracked in issues.
- [X] Relevant unit and integration tests are updated or added.



