### PR TITLE
Fixed MSSQL Query Execution Result Conversion

### DIFF
--- a/mindsdb/integrations/handlers/mssql_handler/mssql_handler.py
+++ b/mindsdb/integrations/handlers/mssql_handler/mssql_handler.py
@@ -78,15 +78,11 @@ def _make_table_response(
     if not result:
         data_frame = pd.DataFrame(columns=columns)
     elif use_odbc:
-        # For pyodbc with large datasets, convert Row objects efficiently
-        # Using iterator with pd.DataFrame avoids intermediate list creation
-        try:
-            data_frame = pd.DataFrame(result, columns=columns)
-        except (ValueError, TypeError):
-            # Fallback: convert Row objects to tuples
-            data_frame = pd.DataFrame.from_records((tuple(row) for row in result), columns=columns)
+        # from_records() understands tuple-like records (including pyodbc.Row)
+        data_frame = pd.DataFrame.from_records(result, columns=columns)
     else:
-        data_frame = pd.DataFrame(result, columns=columns)
+        # pymssql with as_dict=True returns list of dicts
+        data_frame = pd.DataFrame(result)
 
     for column in description:
         column_name = column[0]


### PR DESCRIPTION
## Description

This PR fixes the query execution result to DataFrame conversion when the ODBC connection type is used. Previously, this was returning a tuple when executing `SELECT COUNT(*) ...` queries.

Fixes https://linear.app/mindsdb/issue/STRC-333/mssql-data-preview-and-row-counts-fail-when-using-odbc

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

<img width="1189" height="376" alt="image" src="https://github.com/user-attachments/assets/6e130b60-36a5-4060-ae0d-2d4483f9a32b" />

<img width="1188" height="338" alt="image" src="https://github.com/user-attachments/assets/45137b34-18b7-431b-b844-d1f74e5e7828" />

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added.