### PR TITLE
Fix SQLite Threading error

### DIFF
--- a/mindsdb/integrations/handlers/sqlite_handler/sqlite_handler.py
+++ b/mindsdb/integrations/handlers/sqlite_handler/sqlite_handler.py
@@ -42,6 +42,9 @@ class SQLiteHandler(DatabaseHandler):
         self.connection_data = connection_data
         self.kwargs = kwargs
 
+        # SQLite objects created in a thread can only be used in that same thread.
+        self.thread_safe = False
+
         self.connection = None
         self.is_connected = False
 


### PR DESCRIPTION
## Description

This PR fixes an error that appears if queries to the sqlite handler are processed in different threads.

Error was possible to replicate in this 3 steps:
1. run a query to the SQLite handler
2. run a long-running query, for example to postgres db: `select * from my_pg (select pg_sleep(10))`
3. while previous query is executed, run another query to sqlite

Fixes #FQE-61

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



