### PR TITLE
Api hander: not supported conditions as post-filters

### DIFF
--- a/mindsdb/integrations/utilities/sql_utils.py
+++ b/mindsdb/integrations/utilities/sql_utils.py
@@ -97,7 +97,7 @@ def conditions_to_filter(binary_op: ASTNode):
     return filters
 
 
-def extract_comparison_conditions(binary_op: ASTNode, ignore_functions=False):
+def extract_comparison_conditions(binary_op: ASTNode, ignore_functions=False, strict=True):
     """Extracts all simple comparison conditions that must be true from an AST node.
     Does NOT support 'or' conditions.
     """
@@ -119,7 +119,11 @@ def extract_comparison_conditions(binary_op: ASTNode, ignore_functions=False):
 
             if not isinstance(arg1, ast.Identifier):
                 # Only support [identifier] =/</>/>=/<=/etc [constant] comparisons.
-                raise NotImplementedError(f"Not implemented arg1: {arg1}")
+                if strict:
+                    raise NotImplementedError(f"Not implemented arg1: {arg1}")
+                else:
+                    conditions.append(node)
+                    return
 
             if isinstance(arg2, ast.Constant):
                 value = arg2.value
@@ -190,7 +194,7 @@ def project_dataframe(df, targets, table_columns):
     return df
 
 
-def filter_dataframe(df: pd.DataFrame, conditions: list):
+def filter_dataframe(df: pd.DataFrame, conditions: list, raw_conditions=None):
     # convert list of conditions to ast.
     # assumes that list was got from extract_comparison_conditions
     where_query = None
@@ -208,6 +212,13 @@ def filter_dataframe(df: pd.DataFrame, conditions: list):
             where_query = item
         else:
             where_query = ast.BinaryOperation(op="and", args=[where_query, item])
+
+    if raw_conditions:
+        for condition in raw_conditions:
+            if where_query is None:
+                where_query = condition
+            else:
+                where_query = ast.BinaryOperation(op="and", args=[where_query, condition])
 
     query = ast.Select(targets=[ast.Star()], from_table=ast.Identifier("df"), where=where_query)
 


### PR DESCRIPTION
## Description

If condition is not supported - convert to post-filter

For example condition with `cast` will be filtered after getting contatcs
```sql

SELECT
    id,
    ROUND(CAST(id AS DECIMAL), 2) AS rounded_total
FROM
    hubspot_datasource.contacts
WHERE
    CAST(id AS DECIMAL) > 0
LIMIT 5;

```


## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)
## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



