### PR TITLE
ChromaDB: clear storage on KB deletion

### DIFF
--- a/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
+++ b/mindsdb/integrations/handlers/chromadb_handler/chromadb_handler.py
@@ -477,8 +477,10 @@ class ChromaDBHandler(VectorStoreHandler):
                 collection = self._client.get_collection(table_name)
                 segments = self._client._server._sysdb.get_segments(collection.id)
                 for segment in segments:
-                    self._client._server._sysdb.delete_segment(collection=collection.id, id=segment['id'])
-                    shutil.rmtree(os.path.join(self._client_config["persist_directory"], str(segment['id'])), ignore_errors=True)
+                    self._client._server._sysdb.delete_segment(collection=collection.id, id=segment["id"])
+                    shutil.rmtree(
+                        os.path.join(self._client_config["persist_directory"], str(segment["id"])), ignore_errors=True
+                    )
 
             self._client.delete_collection(table_name)
             self._sync()


### PR DESCRIPTION
## Description

There was a bug: if create/delete KB, then data keep exists on the disk. The fix is - delete persistent storage on 'table' deletion

Fixes #FQE-1786

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



