### PR TITLE
Fix `HubSpot` handler: validate columns names in statistic

### DIFF
--- a/mindsdb/integrations/handlers/hubspot_handler/hubspot_handler.py
+++ b/mindsdb/integrations/handlers/hubspot_handler/hubspot_handler.py
@@ -152,9 +152,6 @@ class HubspotHandler(MetaAPIHandler):
         deals_data = DealsTable(self)
         self._register_table("deals", deals_data)
 
-        self.connect()
-        self.connection.crm.properties.core_api.get_all(object_type="contacts")
-
     def connect(self) -> HubSpot:
         """Creates a new Hubspot API client if needed and sets it as the client to use for requests.
 


### PR DESCRIPTION
## Description

Due to the way the hubspot api works, it may return different set of fields for different records. Added filter for default fields when calculating columns statistic.

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



