### PR TITLE
Fix hybrid search

### DIFF
--- a/mindsdb/integrations/libs/vectordatabase_handler.py
+++ b/mindsdb/integrations/libs/vectordatabase_handler.py
@@ -1,4 +1,5 @@
 import ast
+import copy
 import hashlib
 from enum import Enum
 from typing import Dict, List, Optional
@@ -409,6 +410,9 @@ class VectorStoreHandler(BaseHandler):
         if conditions is None:
             where_statement = query.where
             conditions = self.extract_conditions(where_statement)
+        else:
+            # it is mutated
+            conditions = copy.deepcopy(conditions)
         self._convert_metadata_filters(conditions, allowed_metadata_columns=allowed_metadata_columns)
 
         # 4. Get offset and limit


### PR DESCRIPTION
## Description

When hybrid search is enabled `conditions` list is used twice and but it is mutated after first usage in vector db


Fixes https://linear.app/mindsdb/issue/FQE-1804/hybrid-search-doesnt-work

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



