### PR TITLE
Use pgvector as the default kb store in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
     image: mindsdb/mindsdb:devel
 
     depends_on:
-      postgres:
-        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
 #     Uncomment the following lines if you want to use the local version of otel-collector and langfuse
 #      otel-collector:
 #        condition: service_started
@@ -35,6 +35,7 @@ services:
       - '47335:47335'
     environment:
       MINDSDB_DB_CON: "postgresql://postgres:postgres@postgres/mindsdb"
+      KB_PGVECTOR_URL: "postgresql://postgres:postgres@postgres/kb"  # Use pgvector as the default store for knowledge bases
       MINDSDB_DOCKER_ENV: "True"
       MINDSDB_STORAGE_DIR: "/mindsdb/var"
       FLASK_DEBUG: 1  # This will make sure http requests are logged regardless of log level
@@ -101,8 +102,8 @@ services:
     image: langfuse/langfuse:2.87.0
     restart: always
     depends_on:
-      postgres:
-        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     ports:
       - "3000:3000"
     healthcheck:
@@ -128,7 +129,7 @@ services:
 
   postgres:
     <<: *autoRestartOnFailure
-    image: postgres:16.4
+    image: pgvector/pgvector:pg17
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
@@ -142,9 +143,39 @@ services:
     ports:
       - "15432:5432" # Expose the port to the host. Use 15432 to avoid conflicts with local postgres installations
     volumes:
-      - db_data:/var/lib/postgresql/data
-      - ./scripts/init-dbs.sh:/docker-entrypoint-initdb.d/init-dbs.sh
+      - data_pg17:/var/lib/postgresql/data
+
+  # Uncomment if you need to upgrade from Postgres 16 to 17
+  # Follow the upgrade proceedure in the MindsDB 25.11.1 release notes
+  # 
+  # postgres16:
+  #   <<: *autoRestartOnFailure
+  #   image: pgvector/pgvector:pg16
+  #   restart: always
+  #   environment:
+  #     - POSTGRES_USER=postgres
+  #     - POSTGRES_PASSWORD=postgres
+  #     - POSTGRES_DB=postgres
+  #   volumes:
+  #     - db_data:/var/lib/postgresql/data
+
+  # Ensures the required databases and extensions are created before other services start
+  migrate:
+    image: pgvector/pgvector:pg17
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=postgres
+    volumes:
+      - ./scripts/init-dbs.sh:/init-dbs.sh:ro
+    entrypoint: ["/bin/bash", "/init-dbs.sh"]
 
 volumes:
   db_data:
+    driver: local
+  data_pg17:
     driver: local

--- a/scripts/init-dbs.sh
+++ b/scripts/init-dbs.sh
@@ -1,8 +1,29 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Create additional databases
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
-  CREATE DATABASE mindsdb;
-  CREATE DATABASE langfuse;
-EOSQL
+# List the databases you want to ensure exist
+DBS=(
+  "mindsdb"
+  "kb"
+  "langfuse"
+)
+
+POSTGRES_USER="${POSTGRES_USER:-postgres}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-postgres}"
+POSTGRES_HOST="${POSTGRES_HOST:-postgres}"
+POSTGRES_DB="${POSTGRES_DB:-postgres}"
+
+for db in "${DBS[@]}"; do
+  echo "Ensuring database '${db}' exists..."
+  PGPASSWORD=$POSTGRES_PASSWORD psql -v ON_ERROR_STOP=1 \
+       -U "${POSTGRES_USER}" \
+       -h "${POSTGRES_HOST}" \
+       -d "${POSTGRES_DB}" <<SQL
+SELECT 'CREATE DATABASE "${db}"'
+WHERE NOT EXISTS (
+  SELECT FROM pg_database WHERE datname = '${db}'
+) \gexec
+SQL
+done
+
+echo "Done."


### PR DESCRIPTION
## Description

Switches the postgres image used in our docker-compose to one with pgvector and sets this DB as the default KB store.

Also upgrades the postgres version in our docker-compose stack from 16 to 17. This brings it on par with the docker extension and AMIs so that the data in each is interchangeable.

**The following needs to be added to the release notes as the upgrade procedure for anyone who has existing data in their docker-compose stack and wants to keep it:**

### Upgrading docker-compose stack from postgres 16 to 17:

1. Run `git pull` to update your MindsDB repo and get the latest `docker-compose.yml`
1. Uncomment the "postgres16" service in the MindsDB `docker-compose.yml`
1. Run `docker compose up -d postgres16` to start the postgres 16 DB.
1. `docker compose exec -T postgres16 pg_dumpall -U postgres > pg16_backup.sql` to dump the postgres 16 DB to a local file on your machine.
1. `docker compose down` to stop the postgres 16 DB.
1. Re-comment out the "postgres16" service in the MindsDB `docker-compose.yml`
1. `docker compose up -d postgres` to start the postgres 17 DB.
1. `cat pg16_backup.sql | docker compose exec -T postgres psql -U postgres` to restore your backup to the postgres 17 DB.
1. Check data is in the new DB: `docker compose exec -it postgres psql -U postgres -d mindsdb -c '\dt'`. You should see a list of tables in the mindsdb database. If there are no tables or you get an error, the data backup or restore was not successful.
1. `docker compose up` to start MindsDB and all the other services.
1. Optionally clean up the old DB volume and DB file: `docker volume rm db_data; rm pg16_backup.sql`

## Type of change

- [x] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)


## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Follow the instructions above for migration, then test locally
 - [ ]   Verification Steps: Follow the instructions above for migration, then test locally


## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



