### PR TITLE
Snowflake key file auth

### DIFF
--- a/docs/integrations/data-integrations/snowflake.mdx
+++ b/docs/integrations/data-integrations/snowflake.mdx
@@ -65,7 +65,8 @@ WITH
         "account": "tvuibdy-vm85921",
         "user": "your_username",
         "password": "your_password",
-        "database": "test_db"
+        "database": "test_db",
+        "auth_type": "password"
     };
 ```
 
@@ -82,7 +83,7 @@ WITH
         "user": "your_username",
         "private_key_path": "/path/to/your/private_key.pem",
         "database": "test_db",
-        "credential_type": "key_pair"
+        "auth_type": "key_pair"
     };
 ```
 
@@ -98,7 +99,7 @@ WITH
         "private_key_path": "/path/to/your/private_key.pem",
         "private_key_passphrase": "your_passphrase",
         "database": "test_db",
-        "credential_type": "key_pair"
+        "auth_type": "key_pair"
     };
 ```
 
@@ -109,6 +110,7 @@ Required parameters:
 * `account`: The Snowflake account identifier. This [guide](https://docs.snowflake.com/en/user-guide/admin-account-identifier) will help you find your account identifier.
 * `user`: The username for the Snowflake account.
 * `database`: The name of the Snowflake database to connect to.
+* `auth_type`: The authentication type to use. Options: `"password"` or `"key_pair"`.
 
 Authentication parameters (one method required):
 
@@ -121,7 +123,6 @@ Optional parameters:
 * `warehouse`: The Snowflake warehouse to use for running queries.
 * `schema`: The database schema to use within the Snowflake database. Default is `PUBLIC`.
 * `role`: The Snowflake role to use.
-* `credential_type`: The authentication type to use. Options: "key_pair" or leave empty for password auth.
 
 <Note>
 For detailed instructions on setting up key pair authentication, please refer to [AUTHENTICATION.md](AUTHENTICATION.md) or the [Snowflake Key Pair Authentication documentation](https://docs.snowflake.com/en/user-guide/key-pair-auth.html).

--- a/mindsdb/integrations/handlers/snowflake_handler/README.md
+++ b/mindsdb/integrations/handlers/snowflake_handler/README.md
@@ -65,7 +65,8 @@ WITH
         "account": "tvuibdy-vm85921",
         "user": "your_username",
         "password": "your_password",
-        "database": "test_db"
+        "database": "test_db",
+        "auth_type": "password"
     };
 ```
 
@@ -82,7 +83,7 @@ WITH
         "user": "your_username",
         "private_key_path": "/path/to/your/private_key.pem",
         "database": "test_db",
-        "credential_type": "key_pair"
+        "auth_type": "key_pair"
     };
 ```
 
@@ -98,7 +99,7 @@ WITH
         "private_key_path": "/path/to/your/private_key.pem",
         "private_key_passphrase": "your_passphrase",
         "database": "test_db",
-        "credential_type": "key_pair"
+        "auth_type": "key_pair"
     };
 ```
 
@@ -109,6 +110,7 @@ Required parameters:
 * `account`: The Snowflake account identifier. This [guide](https://docs.snowflake.com/en/user-guide/admin-account-identifier) will help you find your account identifier.
 * `user`: The username for the Snowflake account.
 * `database`: The name of the Snowflake database to connect to.
+* `auth_type`: The authentication type to use. Options: `"password"` or `"key_pair"`.
 
 Authentication parameters (one method required):
 
@@ -121,7 +123,6 @@ Optional parameters:
 * `warehouse`: The Snowflake warehouse to use for running queries.
 * `schema`: The database schema to use within the Snowflake database. Default is `PUBLIC`.
 * `role`: The Snowflake role to use.
-* `credential_type`: The authentication type to use. Options: "key_pair" or leave empty for password auth.
 
 <Note>
 For detailed instructions on setting up key pair authentication, please refer to [AUTHENTICATION.md](AUTHENTICATION.md) or the [Snowflake Key Pair Authentication documentation](https://docs.snowflake.com/en/user-guide/key-pair-auth.html).

--- a/mindsdb/integrations/handlers/snowflake_handler/auth_types.py
+++ b/mindsdb/integrations/handlers/snowflake_handler/auth_types.py
@@ -16,8 +16,7 @@ class PasswordAuthType(SnowflakeAuthType):
             raise ValueError("Required parameters (account, user, database) must be provided.")
 
         if not kwargs.get("password"):
-            raise ValueError("Either password or private_key_path must be provided for authentication.")
-
+            raise ValueError("Password must be provided when auth_type is 'password'.")
         return {
             "account": kwargs.get("account"),
             "user": kwargs.get("user"),
@@ -26,13 +25,14 @@ class PasswordAuthType(SnowflakeAuthType):
             "schema": kwargs.get("schema"),
             "role": kwargs.get("role"),
             "warehouse": kwargs.get("warehouse"),
+            "auth_type": "password",
         }
 
 
 class KeyPairAuthType(SnowflakeAuthType):
     def get_config(self, **kwargs) -> Dict[str, Any]:
         if not kwargs.get("private_key_path"):
-            raise ValueError("Either password or private_key_path must be provided for authentication.")
+            raise ValueError("private_key_path must be provided when auth_type is 'key_pair'.")
 
         if not all(kwargs.get(key) for key in ["account", "user", "database"]):
             raise ValueError("Required parameters (account, user, database) must be provided.")
@@ -50,6 +50,7 @@ class KeyPairAuthType(SnowflakeAuthType):
             "role": kwargs.get("role"),
             "warehouse": kwargs.get("warehouse"),
             "authenticator": "SNOWFLAKE_JWT",
+            "auth_type": "key_pair",
         }
         if kwargs.get("private_key_passphrase"):
             config["private_key_file_pwd"] = kwargs.get("private_key_passphrase")

--- a/mindsdb/integrations/handlers/snowflake_handler/connection_args.py
+++ b/mindsdb/integrations/handlers/snowflake_handler/connection_args.py
@@ -60,12 +60,14 @@ connection_args = OrderedDict(
         "required": False,
         "label": "Role",
     },
-    credential_type={
+    auth_type={
         "type": ARG_TYPE.STR,
-        "description": 'The authentication type to use. Options: "key_pair" or leave empty for password auth.',
-        "required": False,
-        "label": "Credential Type",
+        "description": 'Required authentication type. Options: "password" or "key_pair".',
+        "required": True,
+        "label": "Auth Type",
     },
 )
 
-connection_args_example = OrderedDict(account="abcxyz-1234567", user="user", password="password", database="test")
+connection_args_example = OrderedDict(
+    account="abcxyz-1234567", user="user", password="password", database="test", auth_type="password"
+)


### PR DESCRIPTION
## Description

This PR adds key file authentication to Snowflake alongside existing user/pass auth.

Fixes https://linear.app/mindsdb/issue/FQE-1794/expand-snowflake-authentication-options

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update


## Additional Media:
<img width="1941" height="578" alt="Screenshot from 2025-12-03 12-14-14" src="https://github.com/user-attachments/assets/f1827569-1abe-468b-9be0-db42b0510180" />




## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [X] Necessary documentation updates are either made or tracked in issues.
- [X] Relevant unit and integration tests are updated or added.



