### PR TITLE
fix: Optimize get_integration by fetching directly from DB

### DIFF
--- a/mindsdb/interfaces/database/database.py
+++ b/mindsdb/interfaces/database/database.py
@@ -101,11 +101,15 @@ class DatabaseController:
 
     def get_integration(self, integration_id):
         # get integration by id
-
-        # TODO get directly from db?
-        for rec in self.get_list():
-            if rec["id"] == integration_id and rec["type"] == "data":
-                return {"name": rec["name"], "type": rec["type"], "engine": rec["engine"], "id": rec["id"]}
+        integration = self.integration_controller.get_by_id(integration_id)
+        if integration and integration.get("type", "data") == "data":
+            return {
+                "name": integration["name"],
+                "type": integration["type"],
+                "engine": integration["engine"],
+                "id": integration["id"],
+            }
+        return None
 
     def exists(self, db_name: str) -> bool:
         return db_name.lower() in self.get_dict()


### PR DESCRIPTION
The previous implementation of 'get_integration' loaded all databases into memory and iterated through them to find the matching integration. This was inefficient and could lead to performance issues on systems with a large number of databases.

This commit refactors 'get_integration' to use the 'integration_controller.get_by_id' method, which directly queries the database for the integration. This significantly improves performance by avoiding unnecessary data loading and iteration.

