### PR TITLE
Do not show warning for extra with no requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,6 @@ def define_deps():
     extra_requirements = {}
     full_requirements = []
     for fn in os.listdir(os.path.normpath("./requirements")):
-        extra = []
         if fn.startswith("requirements-") and fn.endswith(".txt"):
             extra_name = fn.replace("requirements-", "").replace(".txt", "")
             with open(os.path.normpath(f"./requirements/{fn}")) as fp:
@@ -100,7 +99,6 @@ def define_deps():
     handlers_dir_path = os.path.normpath("./mindsdb/integrations/handlers")
     for fn in os.listdir(handlers_dir_path):
         if os.path.isdir(os.path.join(handlers_dir_path, fn)) and fn.endswith("_handler"):
-            extra = []
             base_extra_name = fn.replace("_handler", "")
             extra_requirements[base_extra_name] = []
             for req_file_path in glob.glob(os.path.join(handlers_dir_path, fn, "requirements*.txt")):


### PR DESCRIPTION
## Description

If try to install extra with no requirements
```
pip3 install -e .[postgres]
```
then warning appear
```
WARNING: mindsdb 25.11.1 does not provide the extra 'postgres'
```
This PR add changes to not show a warning if extra is any handler name, regardless of requirements existence.

Fixes #FQE-1808

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



