### PR TITLE
fix(sheets): handle column names with spaces

### DIFF
--- a/mindsdb/integrations/handlers/sheets_handler/sheets_handler.py
+++ b/mindsdb/integrations/handlers/sheets_handler/sheets_handler.py
@@ -4,9 +4,9 @@ import pandas as pd
 import duckdb
 
 from mindsdb_sql_parser import parse_sql
-from mindsdb.integrations.libs.base import DatabaseHandler
-
 from mindsdb_sql_parser.ast.base import ASTNode
+from mindsdb.integrations.libs.base import DatabaseHandler
+from mindsdb.utilities.render.sqlalchemy_render import SqlalchemyRender
 
 from mindsdb.utilities import log
 from mindsdb.integrations.libs.response import (
@@ -39,6 +39,7 @@ class SheetsHandler(DatabaseHandler):
         self.dialect = 'sheets'
         self.connection_data = connection_data
         self.kwargs = kwargs
+        self.renderer = SqlalchemyRender('duckdb')
 
         self.connection = None
         self.is_connected = False
@@ -137,7 +138,8 @@ class SheetsHandler(DatabaseHandler):
         Returns:
             HandlerResponse
         """
-        return self.native_query(query.to_string())
+        query_str = self.renderer.get_string(query, with_failback=True)
+        return self.native_query(query_str)
 
     def get_tables(self) -> StatusResponse:
         """


### PR DESCRIPTION
## Summary
Fix for Google Sheets handler not properly handling column names with spaces when using backticks.

## Problem
When selecting columns with spaces using backticks (e.g., `\`Column Name\``), the query would fail because:
- MindsDB parser accepts backticks (MySQL-style)
- But the handler uses DuckDB which expects double quotes for identifiers

## Solution
Use `SqlalchemyRender` with DuckDB dialect to properly render SQL queries with correct identifier quoting, following the same pattern used by the DuckDB handler.

## Changes
- Import `SqlalchemyRender` from mindsdb utilities
- Add renderer with 'duckdb' dialect in handler initialization
- Use `renderer.get_string()` instead of `query.to_string()` for proper dialect-aware rendering

## Testing
Column names with spaces should now work correctly:
```sql
SELECT \`Column Name\` FROM my_sheet
```

Fixes #11838