### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/mindsdb/api/mcp/__init__.py
+++ b/mindsdb/api/mcp/__init__.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
@@ -62,7 +63,14 @@ query_tool_description = dedent("""\
 """)
 
 
-@mcp.tool(name="query", description=query_tool_description)
+@mcp.tool(
+    name="query",
+    description=query_tool_description,
+    annotations=ToolAnnotations(
+        title="Execute SQL Query",
+        destructiveHint=True,
+    ),
+)
 def query(query: str, context: dict | None = None) -> dict[str, Any]:
     """Execute a SQL query against MindsDB
 
@@ -109,7 +117,14 @@ list_databases_tool_description = (
 )
 
 
-@mcp.tool(name="list_databases", description=list_databases_tool_description)
+@mcp.tool(
+    name="list_databases",
+    description=list_databases_tool_description,
+    annotations=ToolAnnotations(
+        title="List Databases",
+        readOnlyHint=True,
+    ),
+)
 def list_databases() -> list[str]:
     """
     List all databases in MindsDB


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`, `title`) to the MCP server tools to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Changes

- Added `ToolAnnotations` import from `mcp.types`
- Added `destructiveHint: true` to `query` tool (can execute any SQL including INSERT, UPDATE, DELETE)
- Added `readOnlyHint: true` to `list_databases` tool (only reads database list)
- Added `title` annotations for human-readable display

## Why This Matters

Tool annotations provide semantic metadata that helps LLMs:
- Distinguish between read-only operations and potentially destructive ones
- Make better decisions about when to use tools and in what order
- Provide safer tool execution by flagging operations that modify data

The `query` tool is marked as `destructiveHint: true` because it can execute any SQL statement, including those that create, update, or delete data. The `list_databases` tool is marked as `readOnlyHint: true` because it only reads the list of available databases without any side effects.

## Testing

- [x] Python syntax validation passes
- [x] Ruff linting passes (no errors)
- [x] Import path verified against MCP SDK 1.10.1

## Before/After

**Before:**
```python
@mcp.tool(name="list_databases", description=list_databases_tool_description)
def list_databases() -> list[str]:
    # No annotations - LLM doesn't know if this modifies data
```

**After:**
```python
@mcp.tool(
    name="list_databases",
    description=list_databases_tool_description,
    annotations=ToolAnnotations(
        title="List Databases",
        readOnlyHint=True,
    ),
)
def list_databases() -> list[str]:
    # LLM now knows this is safe to call without side effects
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)