### PR TITLE
Fix typo in integrations directory path in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@
 1. MindsDB Core: The MindsDB Core component specifically uses the Elastic License 2.0. This is a distinct license that applies to this particular part of the project.
 
 2. License File in Work's Directory: If there is a LICENSE file located in the same directory as the work, that license will apply to the work:
- *  `/mindsdb/integraions` directory that contains all integrations is Licensed under MIT License.
+ *  `/mindsdb/integrations` directory that contains all integrations is Licensed under MIT License.
 
 3. Default to Elastic License 2.0: If no specific LICENSE file is found following the above rules, the work defaults to being licensed under the Elastic License 2.0.
 


### PR DESCRIPTION
## Description

This commit fixes typo in integrations directory path in LICENSE

## Type of change

(Please delete options that are not relevant)

- [ X ] 🐛 Bug fix (non-breaking change which fixes an issue)
