### PR TITLE
fix(openai): add gpt-5/o-series models to chat prefixes to enable conversational context

### DIFF
--- a/mindsdb/integrations/handlers/openai_handler/constants.py
+++ b/mindsdb/integrations/handlers/openai_handler/constants.py
@@ -1,6 +1,14 @@
 OPENAI_API_BASE = "https://api.openai.com/v1"
 
-CHAT_MODELS_PREFIXES = ("gpt-3.5", "gpt-3.5", "gpt-3.5", "gpt-4", "o3-mini", "o1-mini")
+# Updated Jan 2026: streamlined support for GPT-5, GPT-4, and O-series families
+CHAT_MODELS_PREFIXES = (
+    "gpt-5",    # Covers all GPT-5 variants
+    "gpt-4",    # Covers GPT-4, GPT-4o, GPT-4o-mini
+    "o1",       # Covers o1, o1-mini, o1-pro
+    "o3",       # Covers o3, o3-mini
+    "o4",       # Covers o4, o4-mini
+    "gpt-3.5",  # Legacy
+)
 COMPLETION_MODELS = ("babbage-002", "davinci-002")
 FINETUNING_MODELS = ("gpt-3.5-turbo", "babbage-002", "davinci-002", "gpt-4")
 COMPLETION_LEGACY_BASE_MODELS = ("davinci", "curie", "babbage", "ada")


### PR DESCRIPTION
## Description

**The Issue:**
gpt-5 and o-series are currently missing from the CHAT_MODELS_PREFIXES list in constants.py.
Because of this, the system doesn't recognize them as chat models and defaults to one-shot mode. This breaks conversation history (context loss) since it treats every message as a new interaction.

**The Fix:**
I have updated `CHAT_MODELS_PREFIXES` to include `gpt-5`, and `o1/o3/o4` families. This ensures correct routing to `Mode.conversational` and preserves context window behavior.

Fixes #(No specific issue number, maintenance fix)

## Type of change
- 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.