### PR TITLE
Handling `ImportError` when use the `--load-tokenizer` option

### DIFF
--- a/mindsdb/__main__.py
+++ b/mindsdb/__main__.py
@@ -354,6 +354,8 @@ if __name__ == "__main__":
 
                 get_tokenizer()
                 logger.info("Tokenizer successfully loaded")
+            except ImportError:
+                logger.info("Failed to load tokenizer due to an import error")
             except Exception:
                 logger.info("Failed to load tokenizer: ", exc_info=True)
 


### PR DESCRIPTION
## Description

When building the Docker image, the mindsdb --load-tokenizer command is executed. It may fail if `lanchain` is not installed, but this is expected. In this case, a traceback should not be shown.

Fixes #FQE-1964

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



