### PR TITLE
Fix if nan is inserted in knowledge base

### DIFF
--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -743,6 +743,8 @@ class KnowledgeBaseTable:
         except AttributeError:
             ...
 
+        df.replace({np.nan: None}, inplace=True)
+
         # First adapt column names to identify content and metadata columns
         adapted_df, normalized_columns = self._adapt_column_names(df)
         content_columns = normalized_columns["content_columns"]


### PR DESCRIPTION
## Description

There was seen on the query like this. When dataset is selected from database and integer column contain nulls - the ResultSet.to_df can return NANs in dataframe

```sql
insert into kb_stack_vector
select * from pg_sample.stackoverflow_2m 
USING batch_size=1000, track_column=id
```


Fixes https://linear.app/mindsdb/issue/FQE-1975/nan-is-inserted-into-knowledge-base

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



