### PR TITLE
feat(ollama): add support for temperature parameter 

### DIFF
--- a/mindsdb/integrations/handlers/ollama_handler/__about__.py
+++ b/mindsdb/integrations/handlers/ollama_handler/__about__.py
@@ -1,9 +1,9 @@
-__title__ = 'MindsDB Ollama handler'
-__package_name__ = 'mindsdb_ollama_handler'
-__version__ = '0.0.1'
+__title__ = "MindsDB Ollama handler"
+__package_name__ = "mindsdb_ollama_handler"
+__version__ = "0.0.1"
 __description__ = "MindsDB handler for Ollama"
-__author__ = 'MindsDB Inc'
-__github__ = 'https://github.com/mindsdb/mindsdb'
-__pypi__ = 'https://pypi.org/project/mindsdb/'
-__license__ = 'MIT'
-__copyright__ = 'Copyright 2023- mindsdb'
+__author__ = "MindsDB Inc"
+__github__ = "https://github.com/mindsdb/mindsdb"
+__pypi__ = "https://pypi.org/project/mindsdb/"
+__license__ = "MIT"
+__copyright__ = "Copyright 2023- mindsdb"

--- a/mindsdb/integrations/handlers/ollama_handler/__init__.py
+++ b/mindsdb/integrations/handlers/ollama_handler/__init__.py
@@ -1,19 +1,19 @@
 from mindsdb.integrations.libs.const import HANDLER_TYPE
 
 from .__about__ import __version__ as version, __description__ as description
+
 try:
     from .ollama_handler import OllamaHandler as Handler
+
     import_error = None
 except Exception as e:
     Handler = None
     import_error = e
 
-title = 'Ollama'
-name = 'ollama'
+title = "Ollama"
+name = "ollama"
 type = HANDLER_TYPE.ML
-icon_path = 'icon.png'
+icon_path = "icon.png"
 permanent = False
 
-__all__ = [
-    'Handler', 'version', 'name', 'type', 'title', 'description', 'import_error', 'icon_path'
-]
+__all__ = ["Handler", "version", "name", "type", "title", "description", "import_error", "icon_path"]

--- a/mindsdb/integrations/handlers/ollama_handler/ollama_handler.py
+++ b/mindsdb/integrations/handlers/ollama_handler/ollama_handler.py
@@ -14,38 +14,40 @@ class OllamaHandler(BaseMLEngine):
 
     @staticmethod
     def create_validation(target, args=None, **kwargs):
-        if 'using' not in args:
+        if "using" not in args:
             raise Exception("Ollama engine requires a USING clause! Refer to its documentation for more details.")
         else:
-            args = args['using']
+            args = args["using"]
 
-        if 'model_name' not in args:
-            raise Exception('`model_name` must be provided in the USING clause.')
+        if "model_name" not in args:
+            raise Exception("`model_name` must be provided in the USING clause.")
 
         # check ollama service health
-        connection = args.get('ollama_serve_url', OllamaHandler.DEFAULT_SERVE_URL)
-        status = requests.get(connection + '/api/tags').status_code
+        connection = args.get("ollama_serve_url", OllamaHandler.DEFAULT_SERVE_URL)
+        status = requests.get(connection + "/api/tags").status_code
         if status != 200:
-            raise Exception(f"Ollama service is not working (status `{status}`). Please double check it is running and try again.")  # noqa
+            raise Exception(
+                f"Ollama service is not working (status `{status}`). Please double check it is running and try again."
+            )  # noqa
 
     def create(self, target: str, df: Optional[pd.DataFrame] = None, args: Optional[Dict] = None) -> None:
-        """ Pull LLM artifacts with Ollama API. """
+        """Pull LLM artifacts with Ollama API."""
         # arg setter
-        args = args['using']
-        args['target'] = target
-        connection = args.get('ollama_serve_url', OllamaHandler.DEFAULT_SERVE_URL)
+        args = args["using"]
+        args["target"] = target
+        connection = args.get("ollama_serve_url", OllamaHandler.DEFAULT_SERVE_URL)
 
         def _model_check():
-            """ Checks model has been pulled and that it works correctly. """
+            """Checks model has been pulled and that it works correctly."""
             responses = {}
-            for endpoint in ['generate', 'embeddings']:
+            for endpoint in ["generate", "embeddings"]:
                 try:
                     code = requests.post(
-                        connection + f'/api/{endpoint}',
+                        connection + f"/api/{endpoint}",
                         json={
-                            'model': args['model_name'],
-                            'prompt': 'Hello.',
-                        }
+                            "model": args["model_name"],
+                            "prompt": "Hello.",
+                        },
                     ).status_code
                     responses[endpoint] = code
                 except Exception:
@@ -57,19 +59,21 @@ class OllamaHandler(BaseMLEngine):
         if 200 not in responses.values():
             # pull model (blocking operation) and serve
             # TODO: point to the engine storage folder instead of default location
-            connection = args.get('ollama_serve_url', OllamaHandler.DEFAULT_SERVE_URL)
-            requests.post(connection + '/api/pull', json={'name': args['model_name']})
+            connection = args.get("ollama_serve_url", OllamaHandler.DEFAULT_SERVE_URL)
+            requests.post(connection + "/api/pull", json={"name": args["model_name"]})
             # try one last time
             responses = _model_check()
             if 200 not in responses.values():
-                raise Exception(f"Ollama model `{args['model_name']}` is not working correctly. Please try pulling this model manually, check it works correctly and try again.")  # noqa
+                raise Exception(
+                    f"Ollama model `{args['model_name']}` is not working correctly. Please try pulling this model manually, check it works correctly and try again."
+                )  # noqa
 
         supported_modes = {k: True if v == 200 else False for k, v in responses.items()}
 
         # check if a mode has been provided and if it is valid
         runnable_modes = [mode for mode, supported in supported_modes.items() if supported]
-        if 'mode' in args:
-            if args['mode'] not in runnable_modes:
+        if "mode" in args:
+            if args["mode"] not in runnable_modes:
                 raise Exception(f"Mode `{args['mode']}` is not supported by the model `{args['model_name']}`.")
 
         # if a mode has not been provided, check if the model supports only one mode
@@ -77,11 +81,11 @@ class OllamaHandler(BaseMLEngine):
         # if it supports multiple modes, set the default mode to 'generate'
         else:
             if len(runnable_modes) == 1:
-                args['mode'] = runnable_modes[0]
+                args["mode"] = runnable_modes[0]
             else:
-                args['mode'] = 'generate'
+                args["mode"] = "generate"
 
-        self.model_storage.json_set('args', args)
+        self.model_storage.json_set("args", args)
 
     def predict(self, df: pd.DataFrame, args: Optional[Dict] = None) -> pd.DataFrame:
         """
@@ -93,62 +97,63 @@ class OllamaHandler(BaseMLEngine):
                 pd.DataFrame: The DataFrame containing row-wise text completions.
         """
         # setup
-        pred_args = args.get('predict_params', {})
-        args = self.model_storage.json_get('args')
-        model_name, target_col = args['model_name'], args['target']
-        prompt_template = pred_args.get('prompt_template',
-                                        args.get('prompt_template', 'Answer the following question: {{{{text}}}}'))
+        pred_args = args.get("predict_params", {})
+        args = self.model_storage.json_get("args")
+        model_name, target_col = args["model_name"], args["target"]
+        prompt_template = pred_args.get(
+            "prompt_template", args.get("prompt_template", "Answer the following question: {{{{text}}}}")
+        )
 
         # prepare prompts
         prompts, empty_prompt_ids = get_completed_prompts(prompt_template, df)
-        df['__mdb_prompt'] = prompts
+        df["__mdb_prompt"] = prompts
 
         # setup endpoint
-        endpoint = args.get('mode', 'generate')
+        endpoint = args.get("mode", "generate")
 
         # call llm
         completions = []
         for i, row in df.iterrows():
             if i not in empty_prompt_ids:
-                temperature = pred_args.get('temperature', args.get('temperature'))
-                
+                temperature = pred_args.get("temperature", args.get("temperature"))
+
                 # Options dictionary
                 options = {}
                 if temperature is not None:
                     try:
-                        options['temperature'] = float(temperature)
+                        options["temperature"] = float(temperature)
                     except ValueError:
-                        pass 
+                        pass
 
                 # Calling API with the new options
-                connection = args.get('ollama_serve_url', OllamaHandler.DEFAULT_SERVE_URL)
+                connection = args.get("ollama_serve_url", OllamaHandler.DEFAULT_SERVE_URL)
                 raw_output = requests.post(
-                    connection + f'/api/{endpoint}',
+                    connection + f"/api/{endpoint}",
                     json={
-                        'model': model_name,
-                        'prompt': row['__mdb_prompt'],
-                        'options': options,  # options passed here
-                    }
+                        "model": model_name,
+                        "prompt": row["__mdb_prompt"],
+                        "options": options,  # options passed here
+                    },
                 )
-                lines = raw_output.content.decode().split('\n')  # stream of output tokens
+                lines = raw_output.content.decode().split("\n")  # stream of output tokens
 
                 values = []
                 for line in lines:
-                    if line != '':
+                    if line != "":
                         info = json.loads(line)
-                        if 'response' in info:
-                            token = info['response']
+                        if "response" in info:
+                            token = info["response"]
                             values.append(token)
-                        elif 'embedding' in info:
-                            embedding = info['embedding']
+                        elif "embedding" in info:
+                            embedding = info["embedding"]
                             values.append(embedding)
 
-                if endpoint == 'embeddings':
+                if endpoint == "embeddings":
                     completions.append(values)
                 else:
-                    completions.append(''.join(values))
+                    completions.append("".join(values))
             else:
-                completions.append('')
+                completions.append("")
 
         # consolidate output
         data = pd.DataFrame(completions)
@@ -156,28 +161,32 @@ class OllamaHandler(BaseMLEngine):
         return data
 
     def describe(self, attribute: Optional[str] = None) -> pd.DataFrame:
-        args = self.model_storage.json_get('args')
-        model_name, target_col = args['model_name'], args['target']
-        prompt_template = args.get('prompt_template', 'Answer the following question: {{{{text}}}}')
+        args = self.model_storage.json_get("args")
+        model_name, target_col = args["model_name"], args["target"]
+        prompt_template = args.get("prompt_template", "Answer the following question: {{{{text}}}}")
 
         if attribute == "features":
-            return pd.DataFrame([[target_col, prompt_template]], columns=['target_column', 'mindsdb_prompt_template'])
+            return pd.DataFrame([[target_col, prompt_template]], columns=["target_column", "mindsdb_prompt_template"])
 
         # get model info
         else:
-            connection = args.get('ollama_serve_url', OllamaHandler.DEFAULT_SERVE_URL)
-            model_info = requests.post(connection + '/api/show', json={'name': model_name}).json()
-            return pd.DataFrame([[
-                model_name,
-                model_info.get('license', 'N/A'),
-                model_info.get('modelfile', 'N/A'),
-                model_info.get('parameters', 'N/A'),
-                model_info.get('template', 'N/A'),
-            ]],
+            connection = args.get("ollama_serve_url", OllamaHandler.DEFAULT_SERVE_URL)
+            model_info = requests.post(connection + "/api/show", json={"name": model_name}).json()
+            return pd.DataFrame(
+                [
+                    [
+                        model_name,
+                        model_info.get("license", "N/A"),
+                        model_info.get("modelfile", "N/A"),
+                        model_info.get("parameters", "N/A"),
+                        model_info.get("template", "N/A"),
+                    ]
+                ],
                 columns=[
-                    'model_type',
-                    'license',
-                    'modelfile',
-                    'parameters',
-                    'ollama_base_template',
-            ])
+                    "model_type",
+                    "license",
+                    "modelfile",
+                    "parameters",
+                    "ollama_base_template",
+                ],
+            )

--- a/mindsdb/integrations/handlers/ollama_handler/tests/test_ollama_handler.py
+++ b/mindsdb/integrations/handlers/ollama_handler/tests/test_ollama_handler.py
@@ -3,21 +3,21 @@ from unittest.mock import patch, Mock
 import pandas as pd
 from mindsdb.integrations.handlers.ollama_handler.ollama_handler import OllamaHandler
 
+
 class TestOllamaHandler(unittest.TestCase):
-    
     def setUp(self):
         # Mock the storage to return valid model configuration
         mock_storage = Mock()
         mock_storage.json_get.return_value = {
-            'model_name': 'tinyllama',
-            'target': 'response',
-            'ollama_serve_url': 'http://localhost:11434'
+            "model_name": "tinyllama",
+            "target": "response",
+            "ollama_serve_url": "http://localhost:11434",
         }
 
         # Initialize handler with mocked storage
-        self.handler = OllamaHandler(name='test_ollama', model_storage=mock_storage, engine_storage={})
+        self.handler = OllamaHandler(name="test_ollama", model_storage=mock_storage, engine_storage={})
 
-    @patch('mindsdb.integrations.handlers.ollama_handler.ollama_handler.requests.post')
+    @patch("mindsdb.integrations.handlers.ollama_handler.ollama_handler.requests.post")
     def test_temperature_passing(self, mock_post):
         """
         Test that the temperature parameter is correctly extracted from args
@@ -29,16 +29,17 @@ class TestOllamaHandler(unittest.TestCase):
         mock_post.return_value = mock_response
 
         # Create input dataframe
-        df = pd.DataFrame({'text': ['Hello']})
-        
+        df = pd.DataFrame({"text": ["Hello"]})
+
         # Execute prediction with temperature argument
-        self.handler.predict(df, args={'predict_params': {'temperature': 0.5}})
+        self.handler.predict(df, args={"predict_params": {"temperature": 0.5}})
 
         # Verify API call payload
-        call_args = mock_post.call_args[1]['json']
-        
-        self.assertIn('options', call_args)
-        self.assertEqual(call_args['options']['temperature'], 0.5)
+        call_args = mock_post.call_args[1]["json"]
 
-if __name__ == '__main__':
+        self.assertIn("options", call_args)
+        self.assertEqual(call_args["options"]["temperature"], 0.5)
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description
Previously, the Ollama handler did not support passing the `temperature` parameter, locking all generations to the default model creativity. This PR extracts the `temperature` argument from `pred_args` (or model `args`) and injects it into the Ollama API options.

This allows users to control the determinism vs. creativity of the LLM directly from SQL.

### Changes
- Modified `predict()` in `ollama_handler.py`.
- Added logic to extract `temperature` from `pred_args`.
- Validates that `temperature` is a float before passing it to the `options` dictionary in the API payload.

### Verification
**Environment:** Local MindsDB + Ollama (llama3.2)

**SQL Used:**
```sql
-- 1. Deterministic (Robot)
SELECT response
FROM my_smart_test
WHERE text = 'Write a poem about Python'
USING temperature = 0.0;

-- 2. Creative (Poet)
SELECT response
FROM my_smart_test
WHERE text = 'Write a poem about Python'
USING temperature = 0.9;
```

### Result
- Validated that the request payload to Ollama includes `"options": {"temperature": 0.9}`
- Model generates different outputs based on the parameter.