### PR TITLE
ignore some dependencies when check for DEP002

### DIFF
--- a/tests/scripts/check_requirements.py
+++ b/tests/scripts/check_requirements.py
@@ -26,10 +26,7 @@ def get_requirements_with_DEP002(path):
             if (
                 line
                 and not line.startswith("#")
-                and (
-                    "pinned by Snyk to avoid a vulnerability" in line
-                    or "ignore-DEP002" in line
-                )
+                and ("pinned by Snyk to avoid a vulnerability" in line or "ignore-DEP002" in line)
             ):
                 package_name = re.split(pattern, line)[0]
                 if package_name:
@@ -285,7 +282,7 @@ def get_ignores_str(ignores_dict: dict, dep002_ignore: list[str] = None) -> str:
     for k, v in ignores_dict.items():
         rules.append(f"{k}={'|'.join(v)}")
         if k == "DEP002" and dep002_ignore:
-            rules[-1] += '|' + '|'.join(dep002_ignore)
+            rules[-1] += "|" + "|".join(dep002_ignore)
 
     return ",".join(rules)
 


### PR DESCRIPTION
## Description

This PR allows you to skip DEP002 check for dependencies if comment contains:
 - `ignore-DEP002`
 - `pinned by Snyk to avoid a vulnerability`

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



