### PR TITLE
Do not raise 'duplicates' error for snyk-pinned requirements

### DIFF
--- a/tests/scripts/check_requirements.py
+++ b/tests/scripts/check_requirements.py
@@ -99,7 +99,7 @@ MAIN_RULE_IGNORES = {
         "openpyxl",
         "onnxruntime",
         "litellm",
-        "urllib3"  # pinned by Snyk to avoid a vulnerability
+        "urllib3",  # pinned by Snyk to avoid a vulnerability
     ],
 }
 


### PR DESCRIPTION
## Description

Snyk raises warnings for dependencies in handler requirements.txt regardless of whether the requirement exists in the main requirements.txt. For example, `requests` exists in main requirements for a long time, but snyk pinned version in this handler: https://github.com/mindsdb/mindsdb/blob/releases/26.0.0/mindsdb/integrations/handlers/tdengine_handler/requirements.txt#L2
To avoid 'duplicate' errors from `check_requiremetns` script, these errors for snyk's dependencies are not checked.

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



