### PR TITLE
fix(agent): Fix SQL Agent cache key to correctly include new tables

### DIFF
--- a/mindsdb/interfaces/skills/sql_agent.py
+++ b/mindsdb/interfaces/skills/sql_agent.py
@@ -296,7 +296,7 @@ class SQLAgent:
         Returns:
             Iterable[str]: list with table names
         """
-        cache_key = f"{ctx.company_id}_{','.join(self._databases)}_tables"
+        cache_key = f"{ctx.company_id}_{','.join(sorted(self._tables_to_include.databases))}_tables"
 
         # first check cache and return if found
         if self._cache:


### PR DESCRIPTION
## Description
This PR fixes a bug where the SQL Agent's table cache key was generated incorrectly, causing multiple agents to share the same cache key and preventing agents from discovering newly added tables in `include_tables` until the cache expired.

### The Bug
In [mindsdb/interfaces/skills/skill_tool.py](cci:7://file:///e:/mindsdb/mindsdb/interfaces/skills/skill_tool.py:0:0-0:0), the `all_databases` list is explicitly set to `[]` passed to [SQLAgent](cci:2://file:///e:/mindsdb/mindsdb/interfaces/skills/sql_agent.py:156:0-669:22).
Consequently, in `SQLAgent.get_usable_table_names`, the cache key was generated as:
`cache_key = f"{ctx.company_id}_{','.join(self._databases)}_tables"`
Resulting in a key like `1__tables`, which ignores the actual database configuration of the specific agent.

### The Fix
The cache key generation logic in [mindsdb/interfaces/skills/sql_agent.py](cci:7://file:///e:/mindsdb/mindsdb/interfaces/skills/sql_agent.py:0:0-0:0) has been updated to use `self._tables_to_include.databases`, which contains the actual list of databases relevant to the agent.
It is also sorted to ensure key consistency.

```python
# Before
cache_key = f"{ctx.company_id}_{','.join(self._databases)}_tables"

# After
cache_key = f"{ctx.company_id}_{','.join(sorted(self._tables_to_include.databases))}_tables"