### PR TITLE
[Test]Db session roll

### DIFF
--- a/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
+++ b/mindsdb/api/mysql/mysql_proxy/mysql_proxy.py
@@ -78,6 +78,7 @@ from mindsdb.utilities.otel import increment_otel_query_request_counter
 from mindsdb.utilities.wizards import make_ssl_cert
 from mindsdb.utilities.exception import QueryError
 from mindsdb.utilities.functions import mark_process
+from mindsdb.interfaces.storage import db
 from mindsdb.api.mysql.mysql_proxy.utilities.dump import (
     dump_result_set_to_mysql,
     column_to_mysql_column_dict,
@@ -87,6 +88,18 @@ from mindsdb.api.mysql.mysql_proxy.utilities.dump import (
 from mindsdb.api.executor.exceptions import WrongCharsetError
 
 logger = log.getLogger(__name__)
+
+
+def _rollback_storage_session() -> None:
+    try:
+        db.session.rollback()
+    except Exception:
+        logger.exception("Failed to rollback storage session after query error")
+    finally:
+        try:
+            db.session.remove()
+        except Exception:
+            logger.exception("Failed to remove storage session after query error")
 
 
 def empty_fn():
@@ -501,7 +514,11 @@ class MysqlProxy(SocketServer.BaseRequestHandler):
     def process_query(self, sql: str) -> SQLAnswer:
         log.log_ram_info(logger)
         executor = Executor(session=self.session, sqlserver=self)
-        executor.query_execute(sql)
+        try:
+            executor.query_execute(sql)
+        except Exception:
+            _rollback_storage_session()
+            raise
         executor_answer = executor.executor_answer
 
         if executor_answer.data is None:


### PR DESCRIPTION
## Description

Please include a summary of the change and the issue it solves. 

Fixes https://linear.app/mindsdb/issue/FQE-2028/sqlalchemy-pendingrollbackerror-in-internal-database-connection-pool

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



