### PR TITLE
Allow native query for Shopify handler

### DIFF
--- a/mindsdb/integrations/handlers/shopify_handler/shopify_handler.py
+++ b/mindsdb/integrations/handlers/shopify_handler/shopify_handler.py
@@ -146,10 +146,10 @@ class ShopifyHandler(MetaAPIHandler):
             result = shopify.GraphQL().execute(query)
         except Exception as e:
             raise InvalidNativeQuery(f"An error occurred when executing the query: {e}")
-        
+
         try:
             result = json.loads(result)
-            data = result.get('data')
+            data = result.get("data")
             df = pd.DataFrame(data)
         except Exception as e:
             raise InvalidNativeQuery(f"An error occurred when parsing the query result into a DataFrame: {e}")

--- a/tests/unit/handlers/test_shopify_handler.py
+++ b/tests/unit/handlers/test_shopify_handler.py
@@ -7,7 +7,6 @@ from mindsdb.integrations.libs.response import HandlerStatusResponse as StatusRe
 from mindsdb.integrations.libs.api_handler_exceptions import (
     MissingConnectionParams,
     ConnectionFailed,
-    InvalidNativeQuery,
 )
 
 # Mock shopify and requests modules before importing the handler
@@ -429,16 +428,17 @@ class TestShopifyHandlerIntegration(BaseShopifyHandlerTest):
                 }
             }
         }
-        
+
         mock_graphql = MagicMock()
         mock_graphql.execute.return_value = json.dumps(graphql_result)
         mock_shopify.GraphQL.return_value = mock_graphql
 
         handler = ShopifyHandler(self.TEST_HANDLER_NAME, connection_data=self.connection_data)
-        result = handler.native_query('{ products(first: 5) { edges { node { id title } } } }')
+        result = handler.native_query("{ products(first: 5) { edges { node { id title } } } }")
 
         # Verify result
         from mindsdb.integrations.libs.response import RESPONSE_TYPE
+
         self.assertEqual(result.type, RESPONSE_TYPE.TABLE)
         self.assertIsNotNone(result.data_frame)
 


### PR DESCRIPTION
## Description

Changes in this PR allow to run native queries (graphql) with shopify handler
```sql
select * from shopify_datasource (
    { products(first: 5) { edges { node { id title } } } }
);
```

Fixes #FQE-1999

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.



