### PR TITLE
Fixed Postgres Queries for Data Catalog Retrieval

### DIFF
--- a/mindsdb/integrations/handlers/postgres_handler/postgres_handler.py
+++ b/mindsdb/integrations/handlers/postgres_handler/postgres_handler.py
@@ -591,8 +591,11 @@ class PostgresHandler(MetaDatabaseHandler):
                 obj_description(pgc.oid, 'pg_class') AS table_description,
                 pgc.reltuples AS row_count
             FROM information_schema.tables t
-            JOIN pg_catalog.pg_class pgc ON pgc.relname = t.table_name
-            JOIN pg_catalog.pg_namespace pgn ON pgn.oid = pgc.relnamespace
+            JOIN pg_catalog.pg_namespace pgn
+            ON pgn.nspname = t.table_schema
+            JOIN pg_catalog.pg_class pgc
+            ON pgc.relname = t.table_name
+            AND pgc.relnamespace = pgn.oid
             WHERE t.table_schema = current_schema()
             AND t.table_type in ('BASE TABLE', 'VIEW')
             AND t.table_name NOT LIKE 'pg_%'
@@ -625,13 +628,14 @@ class PostgresHandler(MetaDatabaseHandler):
                 c.column_default,
                 (c.is_nullable = 'YES') AS is_nullable
             FROM information_schema.columns c
-            JOIN pg_catalog.pg_class pgc ON pgc.relname = c.table_name
-            JOIN pg_catalog.pg_namespace pgn ON pgn.oid = pgc.relnamespace
+            JOIN pg_namespace pgn ON pgn.nspname = c.table_schema
+            JOIN pg_class pgc
+            ON pgc.relname = c.table_name
+            AND pgc.relnamespace = pgn.oid
             WHERE c.table_schema = current_schema()
             AND pgc.relkind = 'r'  -- Only consider regular tables (avoids indexes, sequences, etc.)
             AND c.table_name NOT LIKE 'pg_%'
             AND c.table_name NOT LIKE 'sql_%'
-            AND pgn.nspname = c.table_schema
         """
 
         if table_names is not None and len(table_names) > 0:
@@ -731,10 +735,10 @@ class PostgresHandler(MetaDatabaseHandler):
                 tc.constraint_name
             FROM
                 information_schema.table_constraints AS tc
-            JOIN
-                information_schema.key_column_usage AS kcu
-            ON
-                tc.constraint_name = kcu.constraint_name
+            JOIN information_schema.key_column_usage AS kcu
+                ON tc.constraint_name = kcu.constraint_name
+                AND tc.constraint_schema = kcu.constraint_schema
+                AND tc.table_schema = kcu.table_schema
             WHERE
                 tc.constraint_type = 'PRIMARY KEY'
                 AND tc.table_schema = current_schema()
@@ -766,14 +770,13 @@ class PostgresHandler(MetaDatabaseHandler):
                 tc.constraint_name
             FROM
                 information_schema.table_constraints AS tc
-            JOIN
-                information_schema.key_column_usage AS kcu
-            ON
-                tc.constraint_name = kcu.constraint_name
-            JOIN
-                information_schema.constraint_column_usage AS ccu
-            ON
-                ccu.constraint_name = tc.constraint_name
+                JOIN information_schema.key_column_usage AS kcu
+                    ON tc.constraint_name   = kcu.constraint_name
+                    AND tc.constraint_schema = kcu.constraint_schema
+                    AND tc.table_schema      = kcu.table_schema
+                JOIN information_schema.constraint_column_usage AS ccu
+                    ON ccu.constraint_name   = tc.constraint_name
+                    AND ccu.constraint_schema = tc.constraint_schema
             WHERE
                 tc.constraint_type = 'FOREIGN KEY'
                 AND tc.table_schema = current_schema()


### PR DESCRIPTION
## Description

This PR fixes the queries related to data catalog retrieval in Postgres. The existing queries were previously returning duplicates of tables with the same name across schemas. Screenshots to this effect have been posted below.

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [X] I have attached a brief loom video or screenshots showcasing the new functionality or change.

Given below is the result of querying the META_TABLES table with the previous implementation. Notice how certain tables have been duplicated:

<img width="2372" height="1148" alt="image" src="https://github.com/user-attachments/assets/1c88c89d-f490-4553-901b-fc5b94ec8f31" />

And now:

<img width="1180" height="593" alt="image" src="https://github.com/user-attachments/assets/67667fb6-a573-4f6e-aa67-a2f3172dd1a4" />

## Checklist:

- [X] My code follows the style guidelines(PEP 8) of MindsDB.
- [X] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues - N/A
- [ ] Relevant unit and integration tests are updated or added.