### PR TITLE
Agent KB prompt: don't use join after where

### DIFF
--- a/mindsdb/interfaces/agents/modes/prompts.py
+++ b/mindsdb/interfaces/agents/modes/prompts.py
@@ -154,7 +154,8 @@ GROUP BY release_year;
 
 - AVOID direct joins between tables and knowledge bases. Instead, use `WHERE <IDCOLUMN> IN (SELECT DISTINCT id FROM knowledge_base) ...`
 OR use the knowledge base as a subquery and join on that, for example:
-`SELECT * FROM <TABLE> JOIN (SELECT id, LIST(chunk_content) FROM knowledge_base WHERE content LIKE 'your semantic search query' AND metadata_col=something ... GROUP BY id LIMIT 10000 ) AS kb ON <TABLE>.<IDCOLUMN> = kb.id ...`
+`SELECT * FROM <TABLE> t JOIN (SELECT id, LIST(chunk_content) FROM knowledge_base WHERE content LIKE 'your semantic search query' AND metadata_col=something ... GROUP BY id LIMIT 10000 ) AS kb ON t.<IDCOLUMN> = kb.id WHERE <CONDITIONS FOR TABLE> ... `
+The WHERE clause for the tables conditions must come AFTER all JOINs are completed
 
 - ALWAYS: It is important to set an appropriate LIMIT on knowledge base queries to avoid missing results; the default limit is 10, so if you need more than 10, set it accordingly. When unsure LIMIT 10000 is recommended.
 

--- a/mindsdb/interfaces/agents/pydantic_ai_agent.py
+++ b/mindsdb/interfaces/agents/pydantic_ai_agent.py
@@ -551,6 +551,9 @@ class PydanticAIAgent:
                     retry_count += 1
                     if retry_count >= MAX_RETRIES:
                         error_context = "\n\nPrevious query errors:\n" + "\n---\n".join(accumulated_errors[-3:])
+                        DEBUG_LOGGER(
+                            f"PydanticAIAgent._get_completion_stream: retry ({retry_count}/{MAX_RETRIES}) after error: {query_error}"
+                        )
                         if output.type == ResponseType.FINAL_QUERY:
                             raise RuntimeError(f"Problem with final query: {query_error}")
                     else:


### PR DESCRIPTION
## Description

update prompt to prevent using join after WHERE
```sql
SELECT * 
from table1
join table2 ..
WHERE ...
LEFT JOIN (
  SELECT *   FROM kb
) AS kb
...
```

Add sql error in debug log


Fixes https://linear.app/mindsdb/issue/FQE-2074/agents-agent-streaming-failed-problem-with-final-query-syntax-error

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



