### PR TITLE
fix: correct typos 'seperate' and 'occured'

### DIFF
--- a/mindsdb/integrations/handlers/dspy_handler/dspy_handler.py
+++ b/mindsdb/integrations/handlers/dspy_handler/dspy_handler.py
@@ -21,7 +21,7 @@ from mindsdb.interfaces.storage.model_fs import HandlerStorage, ModelStorage
 from mindsdb.utilities import log
 
 
-_PARSING_ERROR_PREFIX = 'An output parsing error occured'
+_PARSING_ERROR_PREFIX = 'An output parsing error occurred'
 
 logger = log.getLogger(__name__)
 

--- a/mindsdb/integrations/handlers/huggingface_handler/huggingface_handler.py
+++ b/mindsdb/integrations/handlers/huggingface_handler/huggingface_handler.py
@@ -154,7 +154,7 @@ class HuggingFaceHandler(BaseMLEngine):
         # persist changes to handler folder
         self.engine_storage.folder_sync(model_name)
 
-    # todo move infer tasks to a seperate file
+    # todo move infer tasks to a separate file
     def predict_text_classification(self, pipeline, item, args):
         top_k = args.get("top_k", 1000)
 

--- a/mindsdb/integrations/handlers/langchain_handler/langchain_handler.py
+++ b/mindsdb/integrations/handlers/langchain_handler/langchain_handler.py
@@ -41,7 +41,7 @@ from mindsdb.integrations.handlers.openai_handler.constants import CHAT_MODELS_P
 from mindsdb.utilities import log
 from mindsdb.utilities.context_executor import ContextThreadPoolExecutor
 
-_PARSING_ERROR_PREFIXES = ["An output parsing error occured", "Could not parse LLM output"]
+_PARSING_ERROR_PREFIXES = ["An output parsing error occurred", "Could not parse LLM output"]
 
 logger = log.getLogger(__name__)
 

--- a/mindsdb/integrations/handlers/replicate_handler/replicate_handler.py
+++ b/mindsdb/integrations/handlers/replicate_handler/replicate_handler.py
@@ -33,7 +33,7 @@ class ReplicateHandler(BaseMLEngine):
                 raise Exception("Provided api_key is Incorrect. Get your api_key here: https://replicate.com/account/api-tokens")
 
             else:
-                raise Exception("Error occured.", e)
+                raise Exception("Error occurred.", e)
 
     def create(self, target: str, df: Optional[pd.DataFrame] = None, args: Optional[Dict] = None) -> None:
         """Saves model details in storage to access it later

--- a/mindsdb/integrations/handlers/yugabyte_handler/yugabyte_handler.py
+++ b/mindsdb/integrations/handlers/yugabyte_handler/yugabyte_handler.py
@@ -40,7 +40,7 @@ connection_args = OrderedDict(
     },
     schema={
         'type': ARG_TYPE.STR,
-        'description': '(OPTIONAL) comma seperated value of schema to be considered while querying',
+        'description': '(OPTIONAL) comma separated value of schema to be considered while querying',
     },
     sslmode={
         'type': ARG_TYPE.STR,


### PR DESCRIPTION
Fixed typos in handler files:
- 'seperate' → 'separate'
- 'occured' → 'occurred'