### PR TITLE
Makes user_id scoping configurable for filtering by organization

### DIFF
--- a/mindsdb/api/http/initialize.py
+++ b/mindsdb/api/http/initialize.py
@@ -349,6 +349,7 @@ def initialize_app(is_restart: bool = False):
         company_id = request.headers.get("company-id")
         user_id = request.headers.get("user-id")
         user_class = request.headers.get("user-class")
+        enforce_user_id = request.headers.get("enforce-user-id")
 
         if user_class is not None:
             try:
@@ -362,6 +363,8 @@ def initialize_app(is_restart: bool = False):
         ctx.company_id = company_id if company_id is not None else DEFAULT_COMPANY_ID
         ctx.user_id = user_id if user_id is not None else DEFAULT_USER_ID
         ctx.user_class = user_class
+        if enforce_user_id is not None:
+            ctx.enforce_user_id = enforce_user_id.lower() not in ("false", "0", "no", "")
 
     logger.debug("Done initializing app.")
     return app

--- a/mindsdb/interfaces/agents/agents_controller.py
+++ b/mindsdb/interfaces/agents/agents_controller.py
@@ -96,7 +96,7 @@ class AgentsController:
             db.Agents.company_id == ctx.company_id,
             db.Agents.deleted_at == null(),
         )
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             agent_query = agent_query.filter(db.Agents.user_id == ctx.user_id)
         return agent_query.first()
 
@@ -119,7 +119,7 @@ class AgentsController:
             db.Agents.company_id == ctx.company_id,
             db.Agents.deleted_at == null(),
         )
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             agent_query = agent_query.filter(db.Agents.user_id == ctx.user_id)
         return agent_query.first()
 
@@ -135,7 +135,7 @@ class AgentsController:
         """
 
         all_agents = db.Agents.query.filter(db.Agents.company_id == ctx.company_id, db.Agents.deleted_at == null())
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             all_agents = all_agents.filter(db.Agents.user_id == ctx.user_id)
 
         if project_name is not None:

--- a/mindsdb/interfaces/chatbot/chatbot_controller.py
+++ b/mindsdb/interfaces/chatbot/chatbot_controller.py
@@ -51,7 +51,7 @@ class ChatBotController:
             db.Tasks.object_type == self.OBJECT_TYPE,
             db.Tasks.company_id == ctx.company_id,
         ]
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             filters.append(db.Tasks.user_id == ctx.user_id)
         query = (
             db.session.query(db.ChatBots, db.Tasks)
@@ -82,7 +82,7 @@ class ChatBotController:
             )
         )
 
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.Tasks.user_id == ctx.user_id)
 
         return self._get_chatbot(query)
@@ -152,7 +152,7 @@ class ChatBotController:
             db.Tasks.object_type == self.OBJECT_TYPE,
             db.Tasks.company_id == ctx.company_id,
         ]
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             filters.append(db.Tasks.user_id == ctx.user_id)
         query = (
             db.session.query(db.ChatBots, db.Tasks)
@@ -329,7 +329,7 @@ class ChatBotController:
             db.Tasks.object_id == existing_chatbot_rec.id,
             db.Tasks.company_id == ctx.company_id,
         )
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             task_query = task_query.filter(db.Tasks.user_id == ctx.user_id)
         task = task_query.first()
 
@@ -373,7 +373,7 @@ class ChatBotController:
             db.Tasks.object_id == bot_rec.id,
             db.Tasks.company_id == ctx.company_id,
         )
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             task_query = task_query.filter(db.Tasks.user_id == ctx.user_id)
         task = task_query.first()
 
@@ -399,7 +399,7 @@ class ChatBotController:
             db.Tasks.object_type == self.OBJECT_TYPE,
             db.Tasks.company_id == ctx.company_id,
         ]
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             filters.append(db.Tasks.user_id == ctx.user_id)
         query = (
             db.session.query(db.ChatBots, db.Tasks)

--- a/mindsdb/interfaces/database/integrations.py
+++ b/mindsdb/interfaces/database/integrations.py
@@ -276,7 +276,7 @@ class IntegrationController:
 
     def get_by_id(self, integration_id, show_secrets=True):
         query = db.session.query(db.Integration).filter_by(company_id=ctx.company_id, id=integration_id)
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.Integration.user_id == ctx.user_id)
         integration_record = query.first()
         return self._get_integration_record_data(integration_record, show_secrets)
@@ -301,7 +301,7 @@ class IntegrationController:
         """
         if case_sensitive:
             query = db.session.query(db.Integration).filter_by(company_id=ctx.company_id, name=name)
-            if ctx.should_filter_by_user_id():
+            if ctx.enforce_user_id:
                 query = query.filter(db.Integration.user_id == ctx.user_id)
             integration_records = query.all()
             if len(integration_records) > 1:
@@ -313,7 +313,7 @@ class IntegrationController:
             query = db.session.query(db.Integration).filter(
                 (db.Integration.company_id == ctx.company_id) & (func.lower(db.Integration.name) == func.lower(name))
             )
-            if ctx.should_filter_by_user_id():
+            if ctx.enforce_user_id:
                 query = query.filter(db.Integration.user_id == ctx.user_id)
             integration_record = query.first()
             if integration_record is None:
@@ -323,7 +323,7 @@ class IntegrationController:
 
     def get_all(self, show_secrets=True):
         query = db.session.query(db.Integration).filter_by(company_id=ctx.company_id)
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.Integration.user_id == ctx.user_id)
         integration_records = query.all()
         integration_dict = {}

--- a/mindsdb/interfaces/database/projects.py
+++ b/mindsdb/interfaces/database/projects.py
@@ -345,7 +345,7 @@ class Project:
             deleted_at=sa.null(),
             company_id=ctx.company_id,
         )
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.Predictor.user_id == ctx.user_id)
         record = (
             query.join(db.Integration, db.Integration.id == db.Predictor.integration_id)
@@ -362,7 +362,7 @@ class Project:
             deleted_at=sa.null(),
             company_id=ctx.company_id,
         )
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.Predictor.user_id == ctx.user_id)
         if isinstance(active, bool):
             query = query.filter_by(active=active)
@@ -384,7 +384,7 @@ class Project:
             db.Agents.company_id == ctx.company_id,
             db.Agents.deleted_at == sa.null(),
         )
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.Agents.user_id == ctx.user_id)
         records = query.order_by(db.Agents.name).all()
         data = [
@@ -411,7 +411,7 @@ class Project:
 
     def get_views(self):
         query = db.session.query(db.View).filter_by(project_id=self.id, company_id=ctx.company_id)
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.View.user_id == ctx.user_id)
         records = query.order_by(db.View.name, db.View.id).all()
         data = [
@@ -435,7 +435,7 @@ class Project:
             dict | None: A dictionary with view information if found, otherwise None.
         """
         query = db.session.query(db.View).filter(db.View.project_id == self.id, db.View.company_id == ctx.company_id)
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.View.user_id == ctx.user_id)
         if strict_case:
             query = query.filter(db.View.name == name)
@@ -488,7 +488,7 @@ class Project:
         match str(table["type"]).upper():
             case "MODEL":
                 query = db.Predictor.query.filter_by(company_id=ctx.company_id, project_id=self.id, name=table_name)
-                if ctx.should_filter_by_user_id():
+                if ctx.enforce_user_id:
                     query = query.filter(db.Predictor.user_id == ctx.user_id)
                 predictor_record = query.first()
                 columns = []
@@ -517,7 +517,7 @@ class Project:
                 columns = df.columns
             case "AGENT":
                 query = db.Agents.query.filter_by(company_id=ctx.company_id, project_id=self.id, name=table_name)
-                if ctx.should_filter_by_user_id():
+                if ctx.enforce_user_id:
                     query = query.filter(db.Agents.user_id == ctx.user_id)
                 agent = query.first()
                 if agent is not None:
@@ -557,7 +557,7 @@ class ProjectController:
             (db.Project.company_id == company_id),
             (db.Project.deleted_at == sa.null()),
         ]
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             filters.append(db.Project.user_id == user_id)
         records = db.Project.query.filter(*filters).order_by(db.Project.name)
 
@@ -593,7 +593,7 @@ class ProjectController:
         company_id = ctx.company_id if ctx.company_id is not None else DEFAULT_COMPANY_ID
         user_id = ctx.user_id if ctx.user_id is not None else DEFAULT_USER_ID
         q = db.Project.query.filter_by(company_id=company_id)
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             q = q.filter(db.Project.user_id == user_id)
 
         if id is not None:

--- a/mindsdb/interfaces/database/views.py
+++ b/mindsdb/interfaces/database/views.py
@@ -22,7 +22,7 @@ class ViewController:
             db.View.company_id == ctx.company_id,
             db.View.project_id == project_id,
         )
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             view_query = view_query.filter(db.View.user_id == ctx.user_id)
         view_record = view_query.first()
         if view_record is not None:
@@ -59,7 +59,7 @@ class ViewController:
             db.View.company_id == ctx.company_id,
             db.View.project_id == project_record.id,
         )
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             q = q.filter(db.View.user_id == ctx.user_id)
         if strict_case:
             q = q.filter(db.View.name == name)
@@ -92,7 +92,7 @@ class ViewController:
             db.View.company_id == ctx.company_id,
             db.View.project_id == project_record.id,
         )
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.View.user_id == ctx.user_id)
         if strict_case:
             query = query.filter(db.View.name == name)
@@ -118,7 +118,7 @@ class ViewController:
             db.View.company_id == ctx.company_id,
             db.View.project_id.in_(list(project_names.keys())),
         )
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.View.user_id == ctx.user_id)
 
         data = []
@@ -147,7 +147,7 @@ class ViewController:
                 db.View.project_id == project_record.id,
                 db.View.company_id == ctx.company_id,
             )
-            if ctx.should_filter_by_user_id():
+            if ctx.enforce_user_id:
                 query = query.filter(db.View.user_id == ctx.user_id)
             records = query.all()
         elif name is not None:
@@ -156,7 +156,7 @@ class ViewController:
                 db.View.project_id == project_record.id,
                 db.View.company_id == ctx.company_id,
             )
-            if ctx.should_filter_by_user_id():
+            if ctx.enforce_user_id:
                 query = query.filter(db.View.user_id == ctx.user_id)
             records = query.all()
         if len(records) == 0:

--- a/mindsdb/interfaces/file/file_controller.py
+++ b/mindsdb/interfaces/file/file_controller.py
@@ -48,7 +48,7 @@ class FileController:
         if not name:
             return None
         query = db.session.query(db.File).filter_by(company_id=ctx.company_id)
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.File.user_id == ctx.user_id)
         return query.filter(func.lower(db.File.name) == name.lower()).first()
 
@@ -62,7 +62,7 @@ class FileController:
             list[str]: list of files names
         """
         query = db.session.query(db.File.name).filter_by(company_id=ctx.company_id)
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.File.user_id == ctx.user_id)
         names = [record[0] for record in query]
         if lower:
@@ -89,7 +89,7 @@ class FileController:
             list[dict]: files metadata
         """
         query = db.session.query(db.File).filter_by(company_id=ctx.company_id)
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.File.user_id == ctx.user_id)
         file_records = query.all()
         files_metadata = [

--- a/mindsdb/interfaces/jobs/jobs_controller.py
+++ b/mindsdb/interfaces/jobs/jobs_controller.py
@@ -361,7 +361,7 @@ class JobsExecutor:
             db.Jobs.active == True,  # noqa
             db.Jobs.company_id == ctx.company_id,
         ]
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             filters.append(db.Jobs.user_id == ctx.user_id)
         query = db.session.query(db.Jobs).filter(*filters).order_by(db.Jobs.next_run_at)
 

--- a/mindsdb/interfaces/model/functions.py
+++ b/mindsdb/interfaces/model/functions.py
@@ -25,7 +25,7 @@ class MultiplePredictorRecordsFound(Exception):
 def get_integration_record(name: str) -> db.Integration:
     company_id = ctx.company_id
     query = db.session.query(db.Integration).filter_by(company_id=company_id, name=name)
-    if ctx.should_filter_by_user_id():
+    if ctx.enforce_user_id:
         query = query.filter(db.Integration.user_id == ctx.user_id)
     record = query.first()
     return record
@@ -39,7 +39,7 @@ def get_project_record(name: str) -> db.Project:
         (db.Project.company_id == company_id),
         (db.Project.deleted_at == null()),
     ]
-    if ctx.should_filter_by_user_id():
+    if ctx.enforce_user_id:
         filters.append(db.Project.user_id == ctx.user_id)
 
     project_record = db.session.query(db.Project).filter(*filters).first()
@@ -50,7 +50,7 @@ def get_project_record(name: str) -> db.Project:
 def get_project_records() -> List[db.Project]:
     company_id = ctx.company_id
     filters = [(db.Project.company_id == company_id), (db.Project.deleted_at == null())]
-    if ctx.should_filter_by_user_id():
+    if ctx.enforce_user_id:
         filters.append(db.Project.user_id == ctx.user_id)
     return db.session.query(db.Project).filter(*filters).all()
 
@@ -77,7 +77,7 @@ def get_model_records(
     **kwargs,
 ):
     kwargs["company_id"] = ctx.company_id
-    if ctx.should_filter_by_user_id():
+    if ctx.enforce_user_id:
         kwargs["user_id"] = ctx.user_id
 
     if deleted_at is not None:
@@ -115,7 +115,7 @@ def get_model_record(
     **kwargs,
 ):
     kwargs["company_id"] = ctx.company_id
-    if ctx.should_filter_by_user_id():
+    if ctx.enforce_user_id:
         kwargs["user_id"] = ctx.user_id
 
     kwargs["deleted_at"] = deleted_at

--- a/mindsdb/interfaces/model/model_controller.py
+++ b/mindsdb/interfaces/model/model_controller.py
@@ -497,7 +497,7 @@ class ModelController:
             db.Predictor.company_id == ctx.company_id,
             db.Predictor.id != model_record.id,
         ]
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             filters.append(db.Predictor.user_id == ctx.user_id)
         model_records = db.Predictor.query.filter(*filters)
         for p in model_records:

--- a/mindsdb/interfaces/query_context/context_controller.py
+++ b/mindsdb/interfaces/query_context/context_controller.py
@@ -180,7 +180,7 @@ class RunningQuery:
             db.Tasks.object_id == self.record.id,
             db.Tasks.company_id == ctx.company_id,
         )
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             task_query = task_query.filter(db.Tasks.user_id == ctx.user_id)
         task = task_query.first()
 
@@ -432,7 +432,7 @@ class QueryContextController:
 
         context_name = self.gen_context_name(object_type, object_id)
         query = db.session.query(db.QueryContext).filter_by(context_name=context_name, company_id=ctx.company_id)
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.QueryContext.user_id == ctx.user_id)
         for rec in query.all():
             db.session.delete(rec)
@@ -534,7 +534,7 @@ class QueryContextController:
         context_name = self.gen_context_name(object_type, object_id)
         vars = []
         query = db.session.query(db.QueryContext).filter_by(context_name=context_name, company_id=ctx.company_id)
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.QueryContext.user_id == ctx.user_id)
         for rec in query:
             if rec.values is not None:
@@ -553,7 +553,7 @@ class QueryContextController:
             context_name=context_name,
             company_id=ctx.company_id,
         )
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.QueryContext.user_id == ctx.user_id)
         return query.first()
 
@@ -585,7 +585,7 @@ class QueryContextController:
         """
 
         query = db.Queries.query.filter(db.Queries.id == query_id, db.Queries.company_id == ctx.company_id)
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.Queries.user_id == ctx.user_id)
         rec = query.first()
 
@@ -603,7 +603,7 @@ class QueryContextController:
             db.Queries.company_id == ctx.company_id,
             db.Queries.finished_at < (dt.datetime.now() - dt.timedelta(days=1)),
         ]
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             filters.append(db.Queries.user_id == ctx.user_id)
         remove_query = db.session.query(db.Queries).filter(*filters)
         for rec in remove_query.all():
@@ -627,7 +627,7 @@ class QueryContextController:
         """
 
         query = db.session.query(db.Queries).filter(db.Queries.company_id == ctx.company_id)
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.Queries.user_id == ctx.user_id)
         return [RunningQuery(record).get_info() for record in query]
 
@@ -636,7 +636,7 @@ class QueryContextController:
         Cancels running query by id
         """
         query = db.Queries.query.filter(db.Queries.id == query_id, db.Queries.company_id == ctx.company_id)
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             query = query.filter(db.Queries.user_id == ctx.user_id)
         rec = query.first()
         if rec is None:

--- a/mindsdb/interfaces/triggers/triggers_controller.py
+++ b/mindsdb/interfaces/triggers/triggers_controller.py
@@ -98,7 +98,7 @@ class TriggersController:
             db.Tasks.object_id == trigger.id,
             db.Tasks.company_id == ctx.company_id,
         )
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             task_query = task_query.filter(db.Tasks.user_id == ctx.user_id)
         task = task_query.first()
 
@@ -119,7 +119,7 @@ class TriggersController:
             db.Tasks.object_type == self.OBJECT_TYPE,
             db.Tasks.company_id == ctx.company_id,
         ]
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             filters.append(db.Tasks.user_id == ctx.user_id)
         query = db.session.query(db.Triggers).join(db.Tasks, db.Triggers.id == db.Tasks.object_id).filter(*filters)
         return query.first()
@@ -131,7 +131,7 @@ class TriggersController:
             db.Tasks.object_type == self.OBJECT_TYPE,
             db.Tasks.company_id == ctx.company_id,
         ]
-        if ctx.should_filter_by_user_id():
+        if ctx.enforce_user_id:
             filters.append(db.Tasks.user_id == ctx.user_id)
         query = (
             db.session.query(

--- a/mindsdb/utilities/context.py
+++ b/mindsdb/utilities/context.py
@@ -38,19 +38,6 @@ class Context:
             }
         )
 
-    def should_filter_by_user_id(self) -> bool:
-        """Whether queries should be scoped by ctx.user_id.
-
-        Best practice: always scope by company_id; scope by user_id only when the caller is
-        operating in a user context. For service-to-service/company-wide operations, set
-        `ctx.enforce_user_id = False` (ideally within `ctx.without_user_id_scope()`).
-        """
-        storage = self._storage.get({})
-        enforce = storage.get("enforce_user_id", True)
-        # If user_id is not present (or explicitly set to None), treat it as "no user scoping".
-        user_id = storage.get("user_id")
-        return bool(enforce) and user_id is not None
-
     @contextmanager
     def without_user_id_scope(self):
         """Temporarily disable user_id scoping in this context."""


### PR DESCRIPTION
## Description

The pull request makes user_id scoping configurable when filtering by organization. This change replaces the previous user filtering method with an `enforce_user_id` flag, allowing more flexible data access based on organizational needs.

## Type of change

- [ ] ⚡ New feature (non-breaking change which adds functionality)

## Verification Process

To ensure the changes are working as expected:

- [ ] Test Location: Use test_shopify_handler.py and test_integration_select.py to verify functionality.
- [ ] Verification Steps:
  - Ensure changes allow flexible user_id scoping based on context
  - Test with various configurations to validate that organization filters are correctly applied

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.