### PR TITLE
Lock the PID file when creating or deleting it

### DIFF
--- a/mindsdb/utilities/fs.py
+++ b/mindsdb/utilities/fs.py
@@ -149,6 +149,7 @@ class PidFileLock:
         try:
             if sys.platform == "win32":
                 import msvcrt
+
                 # NOTE if file is locked, LK_LOCK will raise OSError after 10 seconds, LK_NBLCK immediately
                 mode = msvcrt.LK_LOCK if self._blocking else msvcrt.LK_NBLCK
                 self._fh.seek(0)


### PR DESCRIPTION
## Description

Lock PID file to prevent race-condition issues, like:
ProcessA: pid_file.exists() → False
ProcessB: pid_file.exists() → False
ProcessA: write to pid file
ProcessB: write to pid file → Error

Fixes #FQE-1878

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



