### PR TITLE
Use `uv` as a fallback if `pip` is not found when installing a handler's dependencies

### DIFF
--- a/mindsdb/integrations/utilities/install.py
+++ b/mindsdb/integrations/utilities/install.py
@@ -6,8 +6,8 @@ from typing import Text, List
 
 
 class InstallTool(Enum):
-    pip = sys.executable, "-m", "pip"
-    uv = "uv", "pip"
+    pip = (sys.executable, "-m", "pip")
+    uv = ("uv", "pip")
 
 
 def install_dependencies(dependencies: List[Text], tool: InstallTool = InstallTool.pip) -> dict:


### PR DESCRIPTION
## Description

Use `uv` as a fallback if `pip` is not found when installing a handler's dependencies.

Fixes #FQE-2032

## Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



