### PR TITLE
fix: raise ImportError when mindsdb-evaluator is not installed

### DIFF
--- a/mindsdb/api/executor/command_executor.py
+++ b/mindsdb/api/executor/command_executor.py
@@ -856,7 +856,7 @@ class ExecuteCommands:
         try:
             from mindsdb_evaluator.accuracy.general import evaluate_accuracy
         except ImportError:
-            logger.error("mindsdb-evaluator is not installed. Please install it with `pip install mindsdb-evaluator]`.")
+            raise ImportError("mindsdb-evaluator is not installed. Please install it with `pip install mindsdb-evaluator`.")
 
         try:
             sqlquery = SQLQuery(statement.data, session=self.session, database=database_name)


### PR DESCRIPTION
## Description

Please include a summary of the change and the issue it solves. 

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



