### PR TITLE
Fix scheduler worker status for failed jobs

### DIFF
--- a/mindsdb/interfaces/jobs/scheduler.py
+++ b/mindsdb/interfaces/jobs/scheduler.py
@@ -27,13 +27,15 @@ def execute_async(q_in, q_out):
         try:
             executor.execute_task_local(record_id, history_id)
         except (KeyboardInterrupt, SystemExit):
-            q_out.put(True)
+            q_out.put(False)
             raise
 
         except Exception:
+            logger.exception("Error executing scheduled task")
             db.session.rollback()
-
-        q_out.put(True)
+            q_out.put(False)
+        else:
+            q_out.put(True)
 
 
 class Scheduler:

--- a/tests/unit/interfaces/jobs/test_scheduler.py
+++ b/tests/unit/interfaces/jobs/test_scheduler.py
@@ -1,0 +1,21 @@
+import queue
+from unittest.mock import patch
+
+from mindsdb.interfaces.jobs import scheduler as scheduler_module
+
+
+def test_execute_async_marks_failure_on_exception():
+    q_in = queue.Queue()
+    q_out = queue.Queue()
+    q_in.put({"type": "task", "record_id": 1, "history_id": 1})
+    q_in.put({"type": "exit"})
+
+    with (
+        patch.object(scheduler_module, "JobsExecutor") as jobs_executor_cls,
+        patch.object(scheduler_module.db.session, "rollback") as rollback_mock,
+    ):
+        jobs_executor_cls.return_value.execute_task_local.side_effect = RuntimeError("boom")
+        scheduler_module.execute_async(q_in, q_out)
+
+    assert q_out.get_nowait() is False
+    rollback_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- stop reporting scheduler worker completion as success when `execute_task_local` raises
- emit `False` on the worker output queue for failures/interruption and `True` only on successful task execution
- add a regression unit test for `execute_async` failure signaling

## Why
`execute_async` previously pushed success to `q_out` even after exceptions, which masked task execution failures from the scheduler loop.

## Validation
- `python3 -m py_compile mindsdb/interfaces/jobs/scheduler.py tests/unit/interfaces/jobs/test_scheduler.py`
- Full pytest was not run locally because optional test dependencies are missing in this environment (`mindsdb_sql_parser`, `duckdb`).
