### PR TITLE
Fix malformed BigQuery PK metadata SQL

### DIFF
--- a/mindsdb/integrations/handlers/bigquery_handler/bigquery_handler.py
+++ b/mindsdb/integrations/handlers/bigquery_handler/bigquery_handler.py
@@ -396,7 +396,7 @@ class BigQueryHandler(MetaDatabaseHandler):
                 tc.table_name,
                 kcu.column_name,
                 kcu.ordinal_position,
-                tc.constraint_name,
+                tc.constraint_name
             FROM
                 `{self.connection_data["project_id"]}.{self.connection_data["dataset"]}.INFORMATION_SCHEMA.TABLE_CONSTRAINTS` AS tc
             JOIN

--- a/tests/unit/handlers/test_bigquery.py
+++ b/tests/unit/handlers/test_bigquery.py
@@ -200,6 +200,7 @@ class TestBigQueryHandler(unittest.TestCase):
 
         query = self.handler.native_query.call_args[0][0]
         self.assertIn("AND tc.table_name IN ('orders')", query)
+        self.assertNotIn("tc.constraint_name,", query)
 
     def test_meta_get_foreign_keys_filters(self):
         self.handler.native_query = MagicMock(return_value=Response(RESPONSE_TYPE.TABLE, data_frame=pd.DataFrame()))


### PR DESCRIPTION
## Summary
- remove the trailing comma from the `meta_get_primary_keys` SELECT list in the BigQuery handler
- extend the unit test to assert the generated query does not include a dangling comma before `FROM`

## Why
The trailing comma produces invalid SQL and breaks metadata introspection for primary keys.

## Validation
- `python3 -m py_compile mindsdb/integrations/handlers/bigquery_handler/bigquery_handler.py tests/unit/handlers/test_bigquery.py`
- `pytest -q tests/unit/handlers/test_bigquery.py -k meta_get_primary_keys_filters` *(fails in this environment due to missing optional dependency `google.api_core`)*
