### PR TITLE
Fix Postgres column stats UnboundLocalError on errors

### DIFF
--- a/tests/unit/handlers/test_postgres.py
+++ b/tests/unit/handlers/test_postgres.py
@@ -318,6 +318,15 @@ class TestPostgresHandler(BaseDatabaseHandlerTest, unittest.TestCase):
         self.assertIn('"Id"', executed_copy)
         self.assertIn('"Amount"', executed_copy)
 
+    def test_meta_get_column_statistics_returns_non_table_response(self):
+        error_response = Response(RESPONSE_TYPE.ERROR, error_message="boom")
+        self.handler.native_query = MagicMock(return_value=error_response)
+
+        result = self.handler.meta_get_column_statistics()
+
+        self.assertIs(result, error_response)
+        self.handler.native_query.assert_called_once()
+
     def test_cast_dtypes(self):
         """
         Tests the _cast_dtypes method to ensure it correctly converts PostgreSQL types to pandas types


### PR DESCRIPTION
## Summary
- return early from `meta_get_column_statistics` when `native_query` does not return a table response
- only run dataframe post-processing when a table dataframe is present
- add a regression unit test that verifies non-table responses are returned unchanged

## Why
The previous implementation always referenced `df` after the conditional transformation block, causing an `UnboundLocalError` when `native_query` returned an error/non-table response.

## Validation
- `python3 -m py_compile mindsdb/integrations/handlers/postgres_handler/postgres_handler.py tests/unit/handlers/test_postgres.py`
- `pytest -q tests/unit/handlers/test_postgres.py -k meta_get_column_statistics_returns_non_table_response` *(fails in this environment due to missing optional dependency `psycopg`)*
