### PR TITLE
Fix wrong JSON exception type in Postgres subscribe path

### DIFF
--- a/mindsdb/integrations/handlers/postgres_handler/postgres_handler.py
+++ b/mindsdb/integrations/handlers/postgres_handler/postgres_handler.py
@@ -545,7 +545,7 @@ class PostgresHandler(MetaDatabaseHandler):
         def process_event(event):
             try:
                 row = json.loads(event.payload)
-            except json.JSONDecoder:
+            except json.JSONDecodeError:
                 return
 
             # check column in input data


### PR DESCRIPTION
## Summary
- replace `json.JSONDecoder` with `json.JSONDecodeError` in Postgres notification payload parsing

## Why
`json.JSONDecoder` is a decoder class, not an exception type. Catching it does not intercept malformed JSON payloads and can surface unintended errors during subscription callbacks.

## Validation
- `python3 -m py_compile mindsdb/integrations/handlers/postgres_handler/postgres_handler.py`
