### PR TITLE
Fix Snowflake FK metadata parent/child direction

### DIFF
--- a/mindsdb/integrations/handlers/snowflake_handler/snowflake_handler.py
+++ b/mindsdb/integrations/handlers/snowflake_handler/snowflake_handler.py
@@ -712,10 +712,10 @@ class SnowflakeHandler(MetaDatabaseHandler):
                 df = df[["pk_table_name", "pk_column_name", "fk_table_name", "fk_column_name"]]
                 df = df.rename(
                     columns={
-                        "pk_table_name": "child_table_name",
-                        "pk_column_name": "child_column_name",
-                        "fk_table_name": "parent_table_name",
-                        "fk_column_name": "parent_column_name",
+                        "pk_table_name": "parent_table_name",
+                        "pk_column_name": "parent_column_name",
+                        "fk_table_name": "child_table_name",
+                        "fk_column_name": "child_column_name",
                     }
                 )
 

--- a/tests/unit/handlers/test_snowflake.py
+++ b/tests/unit/handlers/test_snowflake.py
@@ -915,6 +915,11 @@ class TestSnowflakeHandler(BaseDatabaseHandlerTest, unittest.TestCase):
 
         self.assertEqual(len(result.data_frame), 1)
         self.assertIn("child_table_name", result.data_frame.columns)
+        row = result.data_frame.iloc[0]
+        self.assertEqual(row["parent_table_name"], "ORDERS")
+        self.assertEqual(row["parent_column_name"], "CUSTOMER_ID")
+        self.assertEqual(row["child_table_name"], "CUSTOMERS")
+        self.assertEqual(row["child_column_name"], "ID")
 
     def test_meta_get_foreign_keys_handles_exception(self):
         self.handler.native_query = MagicMock(side_effect=Exception("boom"))


### PR DESCRIPTION
## Summary
- fix `meta_get_foreign_keys` column renaming so Snowflake PK columns map to `parent_*` and FK columns map to `child_*`
- extend the unit test to assert actual parent/child table+column values, not only column presence

## Why
`SHOW IMPORTED KEYS` returns primary-key metadata in `pk_*` columns and foreign-key metadata in `fk_*` columns. The previous rename inverted this relationship, producing reversed lineage in the catalog.

## Validation
- `python3 -m py_compile mindsdb/integrations/handlers/snowflake_handler/snowflake_handler.py tests/unit/handlers/test_snowflake.py`
- `pytest -q tests/unit/handlers/test_snowflake.py -k meta_get_foreign_keys_filters` *(fails in this environment due to missing optional dependency `appdirs`)*
