### PR TITLE
Fix Databricks empty SELECT response type

### DIFF
--- a/mindsdb/integrations/handlers/databricks_handler/databricks_handler.py
+++ b/mindsdb/integrations/handlers/databricks_handler/databricks_handler.py
@@ -404,7 +404,7 @@ class DatabricksHandler(MetaDatabaseHandler):
             try:
                 cursor.execute(query)
                 result = cursor.fetchall()
-                if result:
+                if cursor.description:
                     response = Response(
                         RESPONSE_TYPE.TABLE,
                         data_frame=pd.DataFrame(result, columns=[x[0] for x in cursor.description]),

--- a/tests/unit/handlers/test_databricks.py
+++ b/tests/unit/handlers/test_databricks.py
@@ -182,6 +182,15 @@ class TestTableOperations(unittest.TestCase):
         self.assertIsInstance(data, Response)
         self.assertFalse(data.error_code)
 
+    def test_native_query_empty_select_returns_table(self):
+        self.mock_cursor.set_results([], ["id", "name"])
+
+        response = self.handler.native_query("SELECT id, name FROM table WHERE 1 = 0")
+
+        self.assertEqual(response.type, RESPONSE_TYPE.TABLE)
+        self.assertEqual(list(response.data_frame.columns), ["id", "name"])
+        self.assertEqual(len(response.data_frame), 0)
+
     def test_get_tables(self):
         """
         Tests if the `get_tables` method to confirm it correctly calls `native_query` with the appropriate SQL commands.


### PR DESCRIPTION
## Summary
- update Databricks `native_query` to return `RESPONSE_TYPE.TABLE` whenever result-set metadata (`cursor.description`) exists, even when the rowset is empty
- keep `RESPONSE_TYPE.OK` for statements that do not return a result set
- add a regression test for empty SELECT behavior

## Why
Empty SELECT queries were incorrectly classified as `OK`, which hides schema information and causes downstream metadata/table handling inconsistencies.

## Validation
- `python3 -m py_compile mindsdb/integrations/handlers/databricks_handler/databricks_handler.py tests/unit/handlers/test_databricks.py`
- `pytest -q tests/unit/handlers/test_databricks.py -k empty_select_returns_table` *(fails in this environment due to missing optional dependency `appdirs`)*
