### PR TITLE
Fix Databricks get_tables non-table response handling

### DIFF
--- a/mindsdb/integrations/handlers/databricks_handler/databricks_handler.py
+++ b/mindsdb/integrations/handlers/databricks_handler/databricks_handler.py
@@ -465,6 +465,8 @@ class DatabricksHandler(MetaDatabaseHandler):
                 {all_filter}
         """
         result = self.native_query(query)
+        if result.resp_type != RESPONSE_TYPE.TABLE or result.data_frame is None:
+            return result
         df = result.data_frame
         result.data_frame = df.rename(columns={col: col.upper() for col in df.columns})
         return result

--- a/tests/unit/handlers/test_databricks.py
+++ b/tests/unit/handlers/test_databricks.py
@@ -202,6 +202,14 @@ class TestTableOperations(unittest.TestCase):
         """
         self.handler.native_query.assert_called_once_with(expected_query)
 
+    def test_get_tables_returns_non_table_response_without_transform(self):
+        expected = Response(RESPONSE_TYPE.ERROR, error_message="boom")
+        self.handler.native_query = MagicMock(return_value=expected)
+
+        result = self.handler.get_tables()
+
+        self.assertIs(result, expected)
+
     def test_get_columns(self):
         """
         Tests if the `get_columns` method correctly constructs the SQL query and if it calls `native_query` with the correct query.


### PR DESCRIPTION
## Summary
- add a guard in Databricks `get_tables()` to return early for non-table responses or missing dataframes
- only uppercase/rename columns when a table dataframe is present
- add a regression unit test ensuring error responses pass through unchanged

## Why
`get_tables()` previously assumed `result.data_frame` always existed. On error/non-table responses this triggered secondary exceptions and masked the original failure.

## Validation
- `python3 -m py_compile mindsdb/integrations/handlers/databricks_handler/databricks_handler.py tests/unit/handlers/test_databricks.py`
- `pytest -q tests/unit/handlers/test_databricks.py -k get_tables_returns_non_table_response_without_transform` *(fails in this environment due to missing optional dependency `appdirs`)*
