### PR TITLE
Fix MySQL get_columns schema scoping

### DIFF
--- a/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
+++ b/mindsdb/integrations/handlers/mysql_handler/mysql_handler.py
@@ -312,7 +312,8 @@ class MySQLHandler(MetaDatabaseHandler):
             from
                 information_schema.columns
             where
-                table_name = '{table_name}';
+                table_name = '{table_name}'
+                and table_schema = DATABASE();
         """
         result = self.native_query(q)
         result.to_columns_table_response(map_type_fn=_map_type)

--- a/tests/unit/handlers/test_mysql.py
+++ b/tests/unit/handlers/test_mysql.py
@@ -67,7 +67,8 @@ class TestMySQLHandler(BaseDatabaseHandlerTest, unittest.TestCase):
             from
                 information_schema.columns
             where
-                table_name = '{self.mock_table}';
+                table_name = '{self.mock_table}'
+                and table_schema = DATABASE();
         """
 
     def create_handler(self):
@@ -454,7 +455,8 @@ class TestMySQLHandler(BaseDatabaseHandlerTest, unittest.TestCase):
             from
                 information_schema.columns
             where
-                table_name = '{table_name}';
+                table_name = '{table_name}'
+                and table_schema = DATABASE();
         """
         self.assertEqual(call_args, expected_sql)
         self.assertEqual(response, expected_response)


### PR DESCRIPTION
## Summary
- add `table_schema = DATABASE()` filter to MySQL `get_columns` query
- update MySQL unit test expectations to include schema scoping

## Why
Without schema filtering, `get_columns` can return metadata for same-named tables from other databases, causing inconsistent or incorrect column introspection.

## Validation
- `python3 -m py_compile mindsdb/integrations/handlers/mysql_handler/mysql_handler.py tests/unit/handlers/test_mysql.py`
