### PR TITLE
Fix MSSQL check_connection exception handling

### DIFF
--- a/mindsdb/integrations/handlers/mssql_handler/mssql_handler.py
+++ b/mindsdb/integrations/handlers/mssql_handler/mssql_handler.py
@@ -327,7 +327,7 @@ class SqlServerHandler(MetaDatabaseHandler):
                 # Execute a simple query to test the connection
                 cur.execute("select 1;")
             response.success = True
-        except OperationalError as e:
+        except Exception as e:
             logger.error(f"Error connecting to Microsoft SQL Server {self.database}, {e}!")
             response.error_message = str(e)
 

--- a/tests/unit/handlers/test_mssql.py
+++ b/tests/unit/handlers/test_mssql.py
@@ -639,6 +639,13 @@ class TestMSSQLHandler(BaseDatabaseHandlerTest, unittest.TestCase):
         self.assertFalse(response.success)
         self.assertEqual(response.error_message, "Connection error")
 
+        self.handler.connect.side_effect = ValueError("Invalid connection args")
+
+        response = self.handler.check_connection()
+
+        self.assertFalse(response.success)
+        self.assertEqual(response.error_message, "Invalid connection args")
+
     def test_types_casting(self):
         """Test that types are casted correctly"""
         query_str = "SELECT * FROM test_table"


### PR DESCRIPTION
## Summary
- broaden `SqlServerHandler.check_connection()` exception handling from `OperationalError` to `Exception`
- add a regression assertion covering non-`OperationalError` failures (e.g., invalid configuration)

## Why
`check_connection()` can fail with exceptions other than `OperationalError` (especially in ODBC/validation paths). Previously those escaped and bypassed `StatusResponse` error reporting.

## Validation
- `python3 -m py_compile mindsdb/integrations/handlers/mssql_handler/mssql_handler.py tests/unit/handlers/test_mssql.py`
- `pytest -q tests/unit/handlers/test_mssql.py -k test_check_connection` *(fails in this environment due to missing optional dependency `appdirs`)*
