### PR TITLE
Fix TaskThread crash on missing task record

### DIFF
--- a/mindsdb/interfaces/tasks/task_thread.py
+++ b/mindsdb/interfaces/tasks/task_thread.py
@@ -23,6 +23,9 @@ class TaskThread(threading.Thread):
         # create context and session
 
         task_record = db.Tasks.query.get(self.task_id)
+        if task_record is None:
+            logger.error(f"Task record not found: {self.task_id}")
+            return
 
         ctx.set_default()
         ctx.company_id = task_record.company_id

--- a/tests/unit/interfaces/tasks/test_task_thread.py
+++ b/tests/unit/interfaces/tasks/test_task_thread.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch
+
+from mindsdb.interfaces.tasks.task_thread import TaskThread
+
+
+def test_run_returns_when_task_record_is_missing():
+    thread = TaskThread(task_id=123)
+
+    with (
+        patch("mindsdb.interfaces.tasks.task_thread.db.Tasks.query.get", return_value=None) as get_mock,
+        patch("mindsdb.interfaces.tasks.task_thread.ctx.set_default") as set_default_mock,
+        patch("mindsdb.interfaces.tasks.task_thread.db.session.commit") as commit_mock,
+    ):
+        thread.run()
+
+    get_mock.assert_called_once_with(123)
+    set_default_mock.assert_not_called()
+    commit_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- add a null-check in `TaskThread.run()` for missing task records
- log the missing record and return early instead of dereferencing `None`
- add a unit test for the early-return path

## Why
If a task is deleted or not found when a thread starts, `task_record` is `None` and the previous code raises an `AttributeError` while setting context fields.

## Validation
- `python3 -m py_compile mindsdb/interfaces/tasks/task_thread.py tests/unit/interfaces/tasks/test_task_thread.py`
- `pytest -q tests/unit/interfaces/tasks/test_task_thread.py` *(fails in this environment due to missing optional dependency `mind_castle`)*
