### PR TITLE
fix: correct isinstance check for redirect_url in database endpoints

### DIFF
--- a/mindsdb/api/http/namespaces/databases.py
+++ b/mindsdb/api/http/namespaces/databases.py
@@ -69,7 +69,7 @@ class DatabasesResource(Resource):
                 status = HandlerStatusResponse(success=False, error_message=str(import_error))
 
             if status.success is not True:
-                if hasattr(status, "redirect_url") and isinstance(status, str):
+                if hasattr(status, "redirect_url") and isinstance(status.redirect_url, str):
                     return {
                         "status": "redirect_required",
                         "redirect_url": status.redirect_url,
@@ -136,7 +136,7 @@ class DatabasesStatusResource(Resource):
                 shutil.rmtree(temp_dir)
 
         if not status.success:
-            if hasattr(status, "redirect_url") and isinstance(status, str):
+            if hasattr(status, "redirect_url") and isinstance(status.redirect_url, str):
                 return {
                     "status": "redirect_required",
                     "redirect_url": status.redirect_url,


### PR DESCRIPTION
## Summary

Fixes a bug in  where  is used instead of .

 is always a  instance, so  always evaluates to . This makes the redirect URL handling completely unreachable in both the  and  endpoints.

The fix changes  to  in both locations, which matches the original intent of checking whether the  attribute contains a string value before returning the redirect response.

## Test plan
- Verify that  with a non-None  now correctly triggers the redirect response path
- Existing tests should continue to pass since this code path was previously unreachable