### PR TITLE
fix: normalize backtick-wrapped qualified KB names before SQL parsing

### DIFF
--- a/mindsdb/interfaces/agents/utils/sql_toolkit.py
+++ b/mindsdb/interfaces/agents/utils/sql_toolkit.py
@@ -111,7 +111,7 @@ def normalize_kb_table_ref(sql: str) -> str:
             return f"{prefix}{quoted}"
             
         # Qualified name — split and quote each part only if necessary
-        parts = inner.split('.', 1)
+        parts = inner.split('.')
         quoted = [
             p if re.match(r'^[A-Za-z_][A-Za-z0-9_]*$', p) else f'`{p}`'
             for p in parts

--- a/tests/unit/interfaces/agents/test_sql_toolkit.py
+++ b/tests/unit/interfaces/agents/test_sql_toolkit.py
@@ -21,6 +21,15 @@ class TestNormalizeKbTableRef:
         assert '`mindsdb.my-kb`' not in result
         assert 'mindsdb.`my-kb`' in result
 
+    def test_three_part_qualified_name(self):
+        sql = "SELECT * FROM `db.schema.table`"
+        result = normalize_kb_table_ref(sql)
+        assert result == "SELECT * FROM db.schema.table"
+        
+        sql_with_hyphen = "SELECT * FROM `db.schema.my-table`"
+        result_with_hyphen = normalize_kb_table_ref(sql_with_hyphen)
+        assert result_with_hyphen == "SELECT * FROM db.schema.`my-table`"
+
     def test_plain_quoted_single_identifier_preserved(self):
         # Single identifier that needs quoting should stay quoted
         sql = "SELECT * FROM `my-kb` WHERE content = 'x'"


### PR DESCRIPTION
The LLM sometimes generates qualified KB table references wrapped in a single set of backticks, e.g. `mindsdb.my_kb`. mindsdb_sql_parser correctly treats this as one identifier with a literal dot, not as a schema.table pair, causing:

  "Can't select from <mindsdb.my_kb> in project: unknown"

The existing sql.strip("`") call only strips backticks from the edges of the full SQL string and does not address identifiers inside the query.

This PR adds normalize_kb_table_ref() which rewrites `schema.table` patterns to their correctly split form before parse_sql() is called. Single identifiers that genuinely need quoting (e.g. `my-kb`) are preserved correctly.

Fixes: #11156

Tested: tests/unit/interfaces/agents/test_sql_toolkit.py