### PR TITLE
fix: add Bearer token auth support for Confluence PAT

### DIFF
--- a/mindsdb/integrations/handlers/confluence_handler/confluence_api_client.py
+++ b/mindsdb/integrations/handlers/confluence_handler/confluence_api_client.py
@@ -4,13 +4,14 @@ import requests
 
 
 class ConfluenceAPIClient:
-    def __init__(self, url: str, username: str, password: str):
+    def __init__(self, url: str, username: str = None, password: str = None, api_token: str = None):
         self.url = url
-        self.username = username
-        self.password = password
         self.session = requests.Session()
-        self.session.auth = (self.username, self.password)
         self.session.headers.update({"Accept": "application/json"})
+        if api_token:
+            self.session.headers["Authorization"] = f"Bearer {api_token}"
+        else:
+            self.session.auth = (username, password)
 
     def get_spaces(
         self,

--- a/mindsdb/integrations/handlers/confluence_handler/confluence_handler.py
+++ b/mindsdb/integrations/handlers/confluence_handler/confluence_handler.py
@@ -66,9 +66,7 @@ class ConfluenceHandler(APIHandler):
         api_token = self.connection_data.get("api_token")
         if api_token:
             if not self.connection_data.get("api_base"):
-                raise ValueError(
-                    "Required parameter (api_base) must be provided when using api_token."
-                )
+                raise ValueError("Required parameter (api_base) must be provided when using api_token.")
         elif not all(
             key in self.connection_data and self.connection_data.get(key)
             for key in ["api_base", "username", "password"]

--- a/mindsdb/integrations/handlers/confluence_handler/confluence_handler.py
+++ b/mindsdb/integrations/handlers/confluence_handler/confluence_handler.py
@@ -63,7 +63,13 @@ class ConfluenceHandler(APIHandler):
         if self.is_connected is True:
             return self.connection
 
-        if not all(
+        api_token = self.connection_data.get("api_token")
+        if api_token:
+            if not self.connection_data.get("api_base"):
+                raise ValueError(
+                    "Required parameter (api_base) must be provided when using api_token."
+                )
+        elif not all(
             key in self.connection_data and self.connection_data.get(key)
             for key in ["api_base", "username", "password"]
         ):
@@ -75,6 +81,7 @@ class ConfluenceHandler(APIHandler):
             url=self.connection_data.get("api_base"),
             username=self.connection_data.get("username"),
             password=self.connection_data.get("password"),
+            api_token=api_token,
         )
 
         self.is_connected = True

--- a/mindsdb/integrations/handlers/confluence_handler/connection_args.py
+++ b/mindsdb/integrations/handlers/confluence_handler/connection_args.py
@@ -12,15 +12,22 @@ connection_args = OrderedDict(
     },
     username={
         "type": ARG_TYPE.STR,
-        "description": "The username for the Confluence account.",
+        "description": "The username for the Confluence account. Not required when using api_token.",
         "label": "Username",
-        "required": True
+        "required": False
     },
     password={
         "type": ARG_TYPE.STR,
         "description": "The API token for the Confluence account.",
         "label": "Password",
-        "required": True,
+        "required": False,
+        "secret": True
+    },
+    api_token={
+        "type": ARG_TYPE.STR,
+        "description": "Personal Access Token for Bearer auth. When provided, username and password are not required.",
+        "label": "API Token (PAT)",
+        "required": False,
         "secret": True
     }
 )

--- a/mindsdb/integrations/handlers/confluence_handler/connection_args.py
+++ b/mindsdb/integrations/handlers/confluence_handler/connection_args.py
@@ -8,32 +8,30 @@ connection_args = OrderedDict(
         "type": ARG_TYPE.URL,
         "description": "The base URL of the Confluence instance/server.",
         "label": "Base URL",
-        "required": True
+        "required": True,
     },
     username={
         "type": ARG_TYPE.STR,
         "description": "The username for the Confluence account. Not required when using api_token.",
         "label": "Username",
-        "required": False
+        "required": False,
     },
     password={
         "type": ARG_TYPE.STR,
         "description": "The API token for the Confluence account.",
         "label": "Password",
         "required": False,
-        "secret": True
+        "secret": True,
     },
     api_token={
         "type": ARG_TYPE.STR,
         "description": "Personal Access Token for Bearer auth. When provided, username and password are not required.",
         "label": "API Token (PAT)",
         "required": False,
-        "secret": True
-    }
+        "secret": True,
+    },
 )
 
 connection_args_example = OrderedDict(
-    api_base="https://marios.atlassian.net/",
-    username="your_username",
-    password="access_token"
+    api_base="https://marios.atlassian.net/", username="your_username", password="access_token"
 )


### PR DESCRIPTION
## Summary
Fixes #12228.

**Root cause:** `ConfluenceAPIClient` always uses HTTP Basic Auth (`session.auth = (username, password)`). Confluence Data Center with the API Token Authentication app disables basic auth and requires Personal Access Tokens (PATs) to be sent as `Authorization: Bearer <token>`.

**Fix:** Added `api_token` parameter support. When provided, the client uses Bearer auth instead of Basic Auth.

## Changes
- `confluence_api_client.py`: Extended `__init__` to accept optional `api_token`. When present, sets `Authorization: Bearer` header instead of `session.auth`.
- `confluence_handler.py`: Updated `connect()` to read `api_token` from connection data and pass it to the client. Relaxed validation when `api_token` is provided.
- `connection_args.py`: Added `api_token` parameter (optional, secret). Made `username` and `password` optional to support PAT-only auth.

## Testing
- Verified backward compatibility: without `api_token`, behavior is unchanged (Basic Auth)
- With `api_token`, Bearer auth is used and `username`/`password` are optional
- Change follows existing handler patterns for optional auth methods

Made with [Cursor](https://cursor.com)