### PR TITLE
Add bearer token auth support to Confluence handler

### DIFF
--- a/mindsdb/integrations/handlers/confluence_handler/confluence_api_client.py
+++ b/mindsdb/integrations/handlers/confluence_handler/confluence_api_client.py
@@ -1,16 +1,34 @@
-from typing import List
+from typing import List, Optional
 
 import requests
 
 
 class ConfluenceAPIClient:
-    def __init__(self, url: str, username: str, password: str):
+    def __init__(
+        self,
+        url: str,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        token: Optional[str] = None,
+        auth_method: Optional[str] = None,
+    ):
         self.url = url
         self.username = username
         self.password = password
+        self.token = token
+        self.auth_method = auth_method
         self.session = requests.Session()
-        self.session.auth = (self.username, self.password)
         self.session.headers.update({"Accept": "application/json"})
+
+        use_bearer = (auth_method == "bearer") or bool(token)
+        if use_bearer:
+            if not token:
+                raise ValueError("Token must be provided for bearer authentication.")
+            self.session.headers.update({"Authorization": f"Bearer {token}"})
+        else:
+            if not username or not password:
+                raise ValueError("Username and password must be provided for basic authentication.")
+            self.session.auth = (username, password)
 
     def get_spaces(
         self,

--- a/mindsdb/integrations/handlers/confluence_handler/confluence_handler.py
+++ b/mindsdb/integrations/handlers/confluence_handler/confluence_handler.py
@@ -58,28 +58,44 @@ class ConfluenceHandler(APIHandler):
             ValueError: If the required connection parameters are not provided.
 
         Returns:
-            atlassian.confluence.Confluence: A connection object to the Confluence API.
+            ConfluenceAPIClient: A connection object to the Confluence API.
         """
         if self.is_connected is True:
             return self.connection
 
-        if not all(
-            key in self.connection_data and self.connection_data.get(key)
-            for key in ["api_base", "username", "password"]
-        ):
-            raise ValueError(
-                "Required parameters (api_base, username, password) must be provided and should not be empty."
-            )
+        api_base = self.connection_data.get("api_base")
+        username = self.connection_data.get("username")
+        password = self.connection_data.get("password")
+        token = self.connection_data.get("token")
+        auth_method = self.connection_data.get("auth_method")
 
-        self.connection = ConfluenceAPIClient(
-            url=self.connection_data.get("api_base"),
-            username=self.connection_data.get("username"),
-            password=self.connection_data.get("password"),
-        )
+        if not api_base:
+            raise ValueError("Required parameter 'api_base' must be provided and should not be empty.")
+
+        if token or auth_method == "bearer":
+            if not token:
+                raise ValueError("Required parameter 'token' must be provided for bearer authentication.")
+
+            self.connection = ConfluenceAPIClient(
+                url=api_base,
+                token=token,
+                auth_method="bearer",
+            )
+        else:
+            if not username or not password:
+                raise ValueError(
+                    "Required parameters for basic auth (api_base, username, password) must be provided and should not be empty."
+                )
+
+            self.connection = ConfluenceAPIClient(
+                url=api_base,
+                username=username,
+                password=password,
+            )
 
         self.is_connected = True
         return self.connection
-
+        
     def check_connection(self) -> StatusResponse:
         """
         Checks the status of the connection to the Confluence API.

--- a/mindsdb/integrations/handlers/confluence_handler/connection_args.py
+++ b/mindsdb/integrations/handlers/confluence_handler/connection_args.py
@@ -1,7 +1,5 @@
 from collections import OrderedDict
-
 from mindsdb.integrations.libs.const import HANDLER_CONNECTION_ARG_TYPE as ARG_TYPE
-
 
 connection_args = OrderedDict(
     api_base={
@@ -12,21 +10,34 @@ connection_args = OrderedDict(
     },
     username={
         "type": ARG_TYPE.STR,
-        "description": "The username for the Confluence account.",
+        "description": "The username for basic authentication.",
         "label": "Username",
-        "required": True
+        "required": False
     },
     password={
         "type": ARG_TYPE.STR,
-        "description": "The API token for the Confluence account.",
+        "description": "The password or API token for basic authentication.",
         "label": "Password",
-        "required": True,
+        "required": False,
         "secret": True
+    },
+    token={
+        "type": ARG_TYPE.STR,
+        "description": "The personal access token for bearer authentication.",
+        "label": "Token",
+        "required": False,
+        "secret": True
+    },
+    auth_method={
+        "type": ARG_TYPE.STR,
+        "description": "Authentication method to use. Supported values: 'basic', 'bearer'.",
+        "label": "Auth Method",
+        "required": False
     }
 )
 
 connection_args_example = OrderedDict(
     api_base="https://marios.atlassian.net/",
-    username="your_username",
-    password="access_token"
+    token="your_personal_access_token",
+    auth_method="bearer"
 )


### PR DESCRIPTION
## Description

This adds support for Confluence PAT bearer authentication in addition to the existing username/password basic auth flow. This fixes the issue where the Confluence connector always treated credentials as basic auth, which breaks Confluence Data Center setups that require PATs to be sent as a bearer token.

Fixes #12228

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

To ensure the changes are working as expected: Check to see if the PAT/bearer auth path works correctly and if the existing basic auth behavior remains unchanged

## Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
