### PR TITLE
fix: initialize missing address attribute in HanaHandler

### DIFF
--- a/mindsdb/integrations/handlers/hana_handler/hana_handler.py
+++ b/mindsdb/integrations/handlers/hana_handler/hana_handler.py
@@ -37,6 +37,7 @@ class HanaHandler(DatabaseHandler):
         """
         super().__init__(name)
         self.connection_data = connection_data
+        self.address = self.connection_data.get('address')
         self.kwargs = kwargs
 
         self.connection = None
@@ -94,7 +95,7 @@ class HanaHandler(DatabaseHandler):
             logger.error(f'Error connecting to SAP HANA, {known_error}!')
             raise
         except Exception as unknown_error:
-            logger.error(f'Unknown error connecting to Teradata, {unknown_error}!')
+            logger.error(f'Unknown error connecting to SAP HANA, {unknown_error}!')
             raise
 
     def disconnect(self) -> None:


### PR DESCRIPTION
## Summary

- **Fixes the `AttributeError: 'HanaHandler' object has no attribute 'address'`** that occurs when SAP HANA queries fail. The `native_query` method references `self.address` in error logging, but `self.address` was never initialized in `__init__`, causing the AttributeError to mask the actual database error.
- **Fixes a copy-paste typo** in the `connect` method where the error message incorrectly referenced "Teradata" instead of "SAP HANA".

Closes #12132

## Changes

- Added `self.address = self.connection_data.get('address')` in `HanaHandler.__init__()` so that `self.address` is available when referenced in `native_query` error handlers.
- Corrected the logger message in `connect()` from "Teradata" to "SAP HANA".

## Test plan

- [ ] Verify that when a SAP HANA query fails with a `ProgrammingError`, the original database error message is correctly logged and returned (instead of `AttributeError`).
- [ ] Verify that `self.address` is populated from `connection_data['address']` upon handler initialization.
- [ ] Verify that the error message in `connect()` now correctly references "SAP HANA" instead of "Teradata".