### PR TITLE
FAISS: mixed search optimization

### DIFF
--- a/mindsdb/integrations/handlers/duckdb_faiss_handler/duckdb_faiss_table.py
+++ b/mindsdb/integrations/handlers/duckdb_faiss_handler/duckdb_faiss_table.py
@@ -72,7 +72,8 @@ class DuckDBFaissTable:
         self.faiss_index.close()
         self.connection.close()
 
-    def _empty_result(self) -> pd.DataFrame:
+    @staticmethod
+    def _empty_result() -> pd.DataFrame:
         return pd.DataFrame([], columns=["id", "content", "metadata", "distance"])
 
     def _create_kw_index(self):
@@ -174,7 +175,8 @@ class DuckDBFaissTable:
         selectivity = matched_count / total
 
         # compare forecast count of affected records for vector and metadata search and choose what will take less
-        if selectivity * total > limit / selectivity:
+        # do search even if selectivity is 0 because it might be approximate value in the future
+        if selectivity > 0 and selectivity * total > limit / selectivity:
             df = self.vector_first_search(vector_filter, meta_filters, limit, selectivity)
         else:
             df = self.metadata_first_search(vector_filter, meta_filters, limit)
@@ -281,12 +283,14 @@ class DuckDBFaissTable:
         for start in range(0, len(faiss_ids), self.META_BATCH_SIZE):
             batch_ids = faiss_ids[start : start + self.META_BATCH_SIZE]
 
-            distances, faiss_ids = self.faiss_index.search(embedding, limit, allowed_ids=batch_ids)
-            results.extend(zip(distances, faiss_ids))
+            distances, faiss_ids_found = self.faiss_index.search(embedding, limit, allowed_ids=batch_ids)
+            results.extend(zip(distances, faiss_ids_found))
 
         results.sort(key=lambda x: x[0])
 
         results = results[:limit]
+        if len(results) == 0:
+            raise RuntimeError("Something went wrong, faiss database didn't return results")
         distances, faiss_ids = zip(*results)
 
         meta_df = self._select_from_metadata(faiss_ids=faiss_ids, meta_filters=meta_filters)
@@ -417,7 +421,7 @@ class DuckDBFaissTable:
                     if len(df) > 0:
                         dfs.append(df)
                 if len(dfs) == 0:
-                    return self._empty_result()
+                    return pd.DataFrame([], columns=["faiss_id", "id", "content", "metadata"])
                 return pd.concat(dfs)
 
             if where_clause is None:

--- a/mindsdb/integrations/handlers/duckdb_faiss_handler/faiss_index.py
+++ b/mindsdb/integrations/handlers/duckdb_faiss_handler/faiss_index.py
@@ -266,7 +266,7 @@ class FaissIndex:
         self,
         query: Iterable[float],
         limit: int = 10,
-        allowed_ids: Optional[Iterable[float]] = None,
+        allowed_ids: Optional[Iterable[int]] = None,
     ):
         if self.index is None:
             return [], []
@@ -278,7 +278,11 @@ class FaissIndex:
 
         params = None
         if allowed_ids is not None:
-            ids_selector = faiss.IDSelectorArray(allowed_ids)
+            allowed_ids_array = np.asarray(list(allowed_ids), dtype=np.int64)
+            ids_selector = faiss.IDSelectorArray(
+                len(allowed_ids_array),
+                faiss.swig_ptr(allowed_ids_array),
+            )
             params = faiss.IVFSearchParameters(sel=ids_selector)
 
         ds, ids = self.index.search(queries, limit, params=params)


### PR DESCRIPTION
## Description

Input query:
```sql
Select * from vector_table
 where <vector> and <META_FILTERS> 
Limit <LIMIT>
```


**Top level logic of mixed search**

1. Measure selectivity of META_FILTERS:
Get predicted count of record after applying META_FILTERS using some of methods
Selectivity = count / total records

2. If selectivity * total_recors >  LIMIT / selectivity:
- Use Vector-first search
Else:
- Use Metadata-first search

**Calculate predicted count of record methods:**

Use simple approach, calculate count of records on every mixed query
```sql
Select count(*) from vector_table
 where <META_FILTERS> 
```
Avantages:
- It works pretty fast on duckdb 
- 100% correct value of records

Disadvantages:
- Extra query for every mixed search


**Metadata-first search**

Query list of all ids from duckdb table using META_FILTERS

Split into batches by META_BATCH. 
Per batch:
- Get batch of ids
- Use ID selector to search in FAISS only by batch of ids
- use LIMIT
- Combine results in single list alongside with distances

After all batches
- get top LIMIT vectors with min distances
- Get their ids and find records in duckdb table for them

**Vector-first search**

Input: selectivity rate

Calculate required top results from faiss: it is predicted count of records, that required to be scanned
Top_results  = LIMIT / selectivity * VECTOR_MARGIN_K 

Do in circle:
- Search Top_results vectors in faiss
- Get ids 
- query duckdb with META_FILTERS and list of ids
- If count of found records < LIMIT:
  - Increase Top_results = Top_results * VECTOR_GROWTH_MULTIPLIER to make next search iteration
  - If 
     - Top_results > total * VECTOR_MAX_RATE
     - or Top_results > VECTOR_MAX_LIMIT
     - or number of iteration >VECTOR_MAX_ITERATIONS
   - then
     - Something went wrong, maybe META_FILTERS records has greater distance than average record
     - Break vector-first search and switch to metadata-first 
 - If count of found records >= LIMIT:
 - Break and return results

Used constants
- META_BATCH = 10k
- VECTOR_MARGIN_K - 5
- VECTOR_MAX_LIMIT = 1 million 
- VECTOR_MAX_RATE = 0.25
- VECTOR_MAX_ITERATIONS = 3
- VECTOR_GROWTH_MULTIPLIER = 5


Fixes https://linear.app/mindsdb/issue/FQE-1992/faiss-improve-mixed-contentmetadata-search

## Type of change

- [x] ⚡ New feature (non-breaking change which adds functionality)


## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.




<!-- CONFIDENCE_SCORE -->
---

## Confidence Score: 1/5 - Blocking Issues

- Three critical bugs (all scored ≥8.5) are present: variable shadowing overwrites the full faiss_ids list on the first search iteration, causing incorrect or missing results in multi-query scenarios.
- Column name mismatch between `_empty_result()` ('id') and `_select_from_metadata` ('faiss_id') will cause runtime KeyErrors or silent data corruption when merging results.
- Passing `faiss.IVFSearchParameters` to a flat/IDMap index will raise a runtime exception, breaking all search operations on non-IVF indexes.
- All three issues are functional bugs that would cause crashes or incorrect behavior in normal usage paths, making this PR unsafe to merge without fixes.

<details>
<summary>Files requiring special attention</summary>

- `mindsdb/integrations/handlers/duckdb_faiss_handler/duckdb_faiss_table.py`
- `mindsdb/integrations/handlers/duckdb_faiss_handler/faiss_index.py`

</details>