### PR TITLE
fix(llm_client): handle 'model' key from OllamaConfig.model_dump() in…

### DIFF
--- a/mindsdb/interfaces/knowledge_base/llm_client.py
+++ b/mindsdb/interfaces/knowledge_base/llm_client.py
@@ -92,8 +92,35 @@ class LLMClient:
             self.client = OpenAI(**kwargs)
         elif self.provider == "ollama":
             kwargs = params.copy()
-            kwargs.pop("model_name")
+            # After get_llm_config/model_dump the model key may arrive as 'model' (OllamaConfig
+            # field name) instead of 'model_name' (the key used elsewhere in LLMClient).
+            # Normalise to 'model_name' so completion()/embeddings() can reference it uniformly.
+            model = kwargs.pop("model_name", None) or kwargs.pop("model", None)
+            if model is not None:
+                self.params["model_name"] = model
+            kwargs.pop("model", None)  # remove any residual 'model' key
             kwargs.pop("provider", None)
+            # Strip keys that OllamaConfig carries but that the OpenAI-compatible client
+            # constructor does not accept.
+            _ollama_only_keys = (
+                "temperature",
+                "top_p",
+                "top_k",
+                "timeout",
+                "format",
+                "headers",
+                "num_predict",
+                "num_ctx",
+                "num_gpu",
+                "repeat_penalty",
+                "stop",
+                "template",
+                "api_keys",
+            )
+            for key in _ollama_only_keys:
+                kwargs.pop(key, None)
+            # Ollama does not require a real API key; supply a placeholder so the
+            # OpenAI client does not raise an AuthenticationError on construction.
             if kwargs.get("api_key") is None:
                 kwargs["api_key"] = "n/a"
             self.client = OpenAI(**kwargs)

--- a/tests/unit/various/conftest.py
+++ b/tests/unit/various/conftest.py
@@ -1,0 +1,23 @@
+"""
+conftest for tests/unit/various/
+
+Injects a lightweight stub for mindsdb.integrations.utilities.handler_utils
+before test collection so that test_llm_client.py can import LLMClient without
+pulling in the full MindsDB storage/DB stack (which requires the private
+mind_castle package).
+
+setdefault is used intentionally: if the real module is already present in
+sys.modules (e.g. when the full stack is installed), the stub is NOT injected
+and the real module is used instead.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+_HANDLER_UTILS_KEY = "mindsdb.integrations.utilities.handler_utils"
+
+_stub = types.ModuleType(_HANDLER_UTILS_KEY)
+_stub.get_api_key = MagicMock(return_value=None)
+
+sys.modules.setdefault(_HANDLER_UTILS_KEY, _stub)

--- a/tests/unit/various/test_llm_client.py
+++ b/tests/unit/various/test_llm_client.py
@@ -1,0 +1,209 @@
+"""
+Unit tests for LLMClient — focusing on the Ollama provider path.
+
+Regression tests for:
+  https://github.com/mindsdb/mindsdb/issues/12339
+
+  Bug: when default_llm is set to Ollama in config.json (or the MindsDB UI),
+  the LLM() SQL function raises:
+    "The api_key client option must be set ... OPENAI_API_KEY"
+
+  Root cause: get_llm_config() returns an OllamaConfig whose model field is
+  named 'model', but LLMClient.__init__ tried to pop 'model_name' — causing a
+  KeyError that left kwargs in a broken state, which then crashed the OpenAI()
+  constructor with a missing-api-key error.
+
+  Fix: LLMClient now accepts either 'model' or 'model_name', strips OllamaConfig-
+  specific keys that the OpenAI-compatible constructor does not understand, and
+  injects a placeholder api_key so construction succeeds.
+
+The stub for mindsdb.integrations.utilities.handler_utils is injected by
+conftest.py in this directory before collection, so it is scoped to this
+test package and does not affect other test modules.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from mindsdb.interfaces.knowledge_base.llm_client import LLMClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_params_via_model_dump():
+    """
+    Simulate the dict that controller.py produces after:
+
+        cfg = get_llm_config('ollama', chat_model_params)
+        params = {k: v for k, v in cfg.model_dump(by_alias=True).items() if v is not None}
+        params['provider'] = 'ollama'
+
+    OllamaConfig declares its model field as 'model' (not 'model_name'), so
+    after model_dump the dict uses 'model' as the key.  This was the bug.
+    """
+    return {
+        "provider": "ollama",
+        "model": "llama3.2",  # <-- key produced by OllamaConfig.model_dump()
+        "base_url": "http://host.docker.internal:11434",
+        "temperature": 0.0,
+        "api_keys": {},
+    }
+
+
+def _make_params_legacy():
+    """
+    Params built without going through get_llm_config (e.g. env-var path or
+    older code) — use 'model_name'.  The fix must not break this path.
+    """
+    return {
+        "provider": "ollama",
+        "model_name": "llama3.2",  # <-- legacy key
+        "base_url": "http://host.docker.internal:11434",
+        "api_keys": {},
+    }
+
+
+def _build_client(params):
+    """
+    Instantiate LLMClient with a patched OpenAI constructor so no real network
+    call is made.  Returns (client, kwargs_passed_to_OpenAI).
+    """
+    captured = {}
+
+    class _FakeOpenAI:
+        def __init__(self_, **kwargs):
+            captured.update(kwargs)
+
+    with patch("mindsdb.interfaces.knowledge_base.llm_client.OpenAI", side_effect=_FakeOpenAI):
+        client = LLMClient(params)
+
+    return client, captured
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestLLMClientOllama(unittest.TestCase):
+    """Regression tests for issue #12339 — Ollama as default_llm."""
+
+    # ------------------------------------------------------------------
+    # Core regression: params arriving via OllamaConfig.model_dump()
+    # ------------------------------------------------------------------
+
+    def test_model_dump_key_does_not_raise(self):
+        """
+        LLMClient must not raise when params carry 'model' instead of
+        'model_name' (the output of OllamaConfig.model_dump()).
+
+        Before the fix, kwargs.pop('model_name') raised KeyError, which
+        surfaced as "The api_key client option must be set … OPENAI_API_KEY".
+        """
+        params = _make_params_via_model_dump()
+        try:
+            _build_client(params)
+        except Exception as exc:
+            self.fail(f"LLMClient raised unexpectedly with 'model' key: {exc}")
+
+    def test_model_name_normalised_from_model_key(self):
+        """
+        After construction, self.params['model_name'] must equal the value
+        that arrived under the 'model' key so that completion() and
+        embeddings() can reference it uniformly.
+        """
+        params = _make_params_via_model_dump()
+        client, _ = _build_client(params)
+        self.assertEqual(client.params["model_name"], "llama3.2")
+
+    def test_placeholder_api_key_injected_when_absent(self):
+        """
+        Ollama needs no real API key.  A non-empty placeholder must be
+        injected so the OpenAI-compatible client doesn't raise on construction.
+        """
+        params = _make_params_via_model_dump()
+        _, openai_kwargs = _build_client(params)
+        self.assertIn("api_key", openai_kwargs)
+        self.assertTrue(openai_kwargs["api_key"])
+
+    def test_base_url_forwarded_to_openai(self):
+        """base_url must reach the OpenAI-compatible client unchanged."""
+        params = _make_params_via_model_dump()
+        _, openai_kwargs = _build_client(params)
+        self.assertEqual(openai_kwargs["base_url"], "http://host.docker.internal:11434")
+
+    def test_ollama_only_keys_not_forwarded_to_openai(self):
+        """
+        OllamaConfig-specific fields (temperature, top_p, top_k, …) must be
+        stripped before calling OpenAI() — it does not accept them and would
+        raise TypeError.
+        """
+        params = {
+            **_make_params_via_model_dump(),
+            "top_p": 0.9,
+            "top_k": 40,
+            "num_ctx": 4096,
+            "repeat_penalty": 1.1,
+            "template": "my-template",
+            "headers": {"X-Custom": "val"},
+        }
+        _, openai_kwargs = _build_client(params)
+
+        disallowed = {
+            "temperature",
+            "top_p",
+            "top_k",
+            "timeout",
+            "format",
+            "headers",
+            "num_predict",
+            "num_ctx",
+            "num_gpu",
+            "repeat_penalty",
+            "stop",
+            "template",
+            "api_keys",
+            "provider",
+            "model",
+            "model_name",
+        }
+        leaked = disallowed & set(openai_kwargs.keys())
+        self.assertEqual(leaked, set(), msg=f"Keys leaked to OpenAI(): {leaked}")
+
+    def test_provider_not_forwarded_to_openai(self):
+        """'provider' must be stripped before the OpenAI() call."""
+        params = _make_params_via_model_dump()
+        _, openai_kwargs = _build_client(params)
+        self.assertNotIn("provider", openai_kwargs)
+
+    # ------------------------------------------------------------------
+    # Backward compatibility: legacy params using 'model_name'
+    # ------------------------------------------------------------------
+
+    def test_legacy_model_name_key_still_works(self):
+        """
+        Params built with 'model_name' directly (env-var path, older code)
+        must continue to work after the fix.
+        """
+        params = _make_params_legacy()
+        try:
+            client, _ = _build_client(params)
+        except Exception as exc:
+            self.fail(f"LLMClient raised with legacy 'model_name' key: {exc}")
+        self.assertEqual(client.params["model_name"], "llama3.2")
+
+    def test_explicit_api_key_preserved(self):
+        """
+        If a real api_key is provided it must be forwarded as-is, not
+        overwritten by the placeholder.
+        """
+        params = {**_make_params_via_model_dump(), "api_key": "real-secret"}
+        _, openai_kwargs = _build_client(params)
+        self.assertEqual(openai_kwargs["api_key"], "real-secret")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# fix(llm_client): handle 'model' key from OllamaConfig.model_dump() in LLM() function

## Description

Fixes #12339

When `default_llm` is set to an Ollama provider via `config.json` or the MindsDB UI, calling `LLM()` in SQL raised:

> `Unable to use LLM function, check ENV variables: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable`

**Root cause (two bugs in `LLMClient.__init__`):**

1. `get_llm_config()` returns an `OllamaConfig` whose Pydantic field is named `model`. After `model_dump()`, the dict key is `"model"` — but `LLMClient.__init__` called `kwargs.pop("model_name")`, raising `KeyError`. That exception was caught upstream and re-raised as the misleading api_key error.
2. `OllamaConfig`-specific fields (`temperature`, `top_p`, `top_k`, etc.) remained in `kwargs` and would have caused a `TypeError` when passed to `OpenAI()`.

**Fix:** Normalise `"model"`/`"model_name"` to `self.params["model_name"]` regardless of which key arrives, and strip all `OllamaConfig`-only keys before forwarding `kwargs` to the OpenAI-compatible client. Backward-compatible with params using `"model_name"` directly (env-var path).

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] 📄 This change requires a documentation update

## Verification Process

- **Test Location:** `tests/unit/various/test_llm_client.py`
- **Verification Steps:**
  1. Configure MindsDB with `default_llm` pointing to a local Ollama instance in `config.json`:
     ```json
     {
       "default_llm": {
         "provider": "ollama",
         "model_name": "llama3.2",
         "base_url": "http://host.docker.internal:11434"
       }
     }
     ```
  2. Run `LLM('some prompt')` in a SQL query — it should call Ollama instead of raising an api_key error.
  3. Run the unit tests: `pytest tests/unit/various/test_llm_client.py -v` — all 8 should pass.

## Additional Media

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist

- [x] My code follows the style guidelines (PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [ ] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.