### PR TITLE
docs: fix CREATE MODEL/PREDICTOR typo on model creation page

### DIFF
--- a/docs/mindsdb_sql/sql/create/model.mdx
+++ b/docs/mindsdb_sql/sql/create/model.mdx
@@ -8,8 +8,8 @@ sidebarTitle: Create, Train, and Deploy a Model
 The `CREATE MODEL` statement creates and trains a machine learning (ML) model.
 
 <Info>
-    Please note that the `CREATE MODEL` statement is equivalent to the `CREATE MODEL` statement.
-    We are transitioning to the `CREATE MODEL` statement, but the `CREATE MODEL` statement still works.
+    Please note that the `CREATE PREDICTOR` statement is equivalent to the `CREATE MODEL` statement.
+    We are transitioning to the `CREATE MODEL` statement, but the `CREATE PREDICTOR` statement still works.
 </Info>
 
 ## Syntax


### PR DESCRIPTION
## Summary

- The `<Info>` block on the **Create, Train, and Deploy a Model** page says `CREATE MODEL is equivalent to CREATE MODEL` -- referencing itself instead of the legacy `CREATE PREDICTOR` alias.
- This PR replaces both occurrences with the correct `CREATE PREDICTOR` wording so users understand the alias relationship.

## Changes

- `docs/mindsdb_sql/sql/create/model.mdx`: Fix the two sentences in the `<Info>` block to correctly reference `CREATE PREDICTOR`.

Fixes #12047