### PR TITLE
fix(agents): return tables from all databases in get_usable_table_names

### DIFF
--- a/mindsdb/interfaces/agents/utils/sql_toolkit.py
+++ b/mindsdb/interfaces/agents/utils/sql_toolkit.py
@@ -318,7 +318,6 @@ class MindsDBQuery:
                 if self._cache:
                     self._cache.set(cache_key, list_tables)
 
-            result_tables = []
             for row in list_tables:
                 if row.get("schema") is not None:
                     parts = [db_name, row["schema"], row["name"]]

--- a/tests/unit/interfaces/agents/test_sql_toolkit.py
+++ b/tests/unit/interfaces/agents/test_sql_toolkit.py
@@ -78,3 +78,26 @@ class TestGetUsableTableNames:
     def test_no_tables_returns_empty(self):
         query = _make_query([])
         assert query.get_usable_table_names(lazy=False) == []
+
+    def test_mixed_wildcard_and_specific_table(self):
+        """Wildcard databases should expand fully, while specific entries
+        should still be filtered down to the exact table that matches."""
+        query = _make_query(["db1.users", "db2.*"])
+
+        handlers = {
+            "db1": _make_handler(["users", "orders", "invoices"]),
+            "db2": _make_handler(["a", "b"]),
+        }
+        query.command_executor.session.integration_controller.get_data_handler.side_effect = lambda name: handlers[name]
+
+        result = query.get_usable_table_names(lazy=False)
+
+        names = {tuple(ident.parts) for ident in result}
+        assert names == {
+            ("db1", "users"),
+            ("db2", "a"),
+            ("db2", "b"),
+        }
+        # Tables present in db1 but not listed in `data.tables` must NOT leak through.
+        assert ("db1", "orders") not in names
+        assert ("db1", "invoices") not in names

--- a/tests/unit/interfaces/agents/test_sql_toolkit.py
+++ b/tests/unit/interfaces/agents/test_sql_toolkit.py
@@ -1,0 +1,80 @@
+from unittest.mock import Mock
+
+import pandas as pd
+
+from mindsdb.interfaces.agents.utils.sql_toolkit import (
+    MindsDBQuery,
+    TablesCollection,
+)
+
+
+def _make_query(tables):
+    """Build a MindsDBQuery without invoking SessionController/DB."""
+    query = MindsDBQuery.__new__(MindsDBQuery)
+    query.tables = TablesCollection(tables)
+    query.knowledge_bases = TablesCollection([])
+    query.command_executor = Mock()
+    query._cache = None
+    return query
+
+
+def _make_handler(table_names):
+    """Mock data handler whose `get_tables` returns a TableResponse-like object."""
+    handler = Mock()
+    df = pd.DataFrame({"table_name": table_names})
+    response = Mock()
+    response.data_frame = df
+    handler.get_tables.return_value = response
+    return handler
+
+
+class TestGetUsableTableNames:
+    def test_single_database_wildcard(self):
+        query = _make_query(["db1.*"])
+        handler = _make_handler(["t1", "t2"])
+        query.command_executor.session.integration_controller.get_data_handler.return_value = handler
+
+        result = query.get_usable_table_names(lazy=False)
+
+        names = [tuple(ident.parts) for ident in result]
+        assert ("db1", "t1") in names
+        assert ("db1", "t2") in names
+        assert len(names) == 2
+
+    def test_multi_database_wildcard_returns_all(self):
+        """Regression test: tables from all databases should be returned,
+        not just the last one iterated."""
+        query = _make_query(["db1.*", "db2.*"])
+
+        handlers = {
+            "db1": _make_handler(["a", "b"]),
+            "db2": _make_handler(["c", "d", "e"]),
+        }
+
+        def get_handler(name):
+            return handlers[name]
+
+        query.command_executor.session.integration_controller.get_data_handler.side_effect = get_handler
+
+        result = query.get_usable_table_names(lazy=False)
+
+        names = {tuple(ident.parts) for ident in result}
+        assert names == {
+            ("db1", "a"),
+            ("db1", "b"),
+            ("db2", "c"),
+            ("db2", "d"),
+            ("db2", "e"),
+        }
+
+    def test_lazy_returns_items_as_is(self):
+        query = _make_query(["db1.users", "db2.orders"])
+
+        result = query.get_usable_table_names(lazy=True)
+
+        names = {tuple(ident.parts) for ident in result}
+        assert names == {("db1", "users"), ("db2", "orders")}
+
+    def test_no_tables_returns_empty(self):
+        query = _make_query([])
+        assert query.get_usable_table_names(lazy=False) == []


### PR DESCRIPTION
## Description

In `MindsDBQuery.get_usable_table_names`, the `result_tables` list is reset to `[]` on every iteration of the `for db_name in self.tables.databases:` loop. As a result, when an agent is configured with tables from more than one data source (e.g. `data = {\"tables\": [\"db1.*\", \"db2.*\"]}`), only the tables from the **last** iterated database are ever returned. Tables from earlier databases are silently dropped.

This affects:

- `AgentsController.check_agent_data` (called via `get_usable_table_names(lazy=False)` during agent creation), which can spuriously fail validation.
- The agent runtime's view of which tables it has access to whenever a wildcard is used across multiple data sources.

The fix is a one-line change: move the `result_tables = []` initialization out of the per-database loop so matching tables are accumulated across all configured databases.

A unit test (`tests/unit/interfaces/agents/test_sql_toolkit.py`) is added covering:

- Single-database wildcard expansion
- Multi-database wildcard expansion (regression test for this bug)
- Lazy mode returning items as-is
- Empty tables returning an empty list

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

- Test Location: `tests/unit/interfaces/agents/test_sql_toolkit.py`
- Verification Steps:
  1. `pytest tests/unit/interfaces/agents/test_sql_toolkit.py -v`
  2. Manual: create an agent with `data = {\"tables\": [\"db1.*\", \"db2.*\"]}` and confirm tables from both databases are listed.

## Checklist

- [x] My code follows the style guidelines (PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit tests are added.