### PR TITLE
fix(knowledge_base): correct Ollama embedding URL and validate storage type

### DIFF
--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -1094,6 +1094,17 @@ class KnowledgeBaseController:
             raise ValueError(
                 f"Unable to find database named {vector_db_name}, please make sure {vector_db_name} is defined"
             )
+        # The storage backend for a knowledge base must be a vector database. If the user
+        # points `storage` at a non-vector integration (e.g. `files`, a SQL database, etc.)
+        # we previously crashed deep inside `create_table` with an opaque AttributeError.
+        # Detect that case here and raise a clear, actionable message. Fixes gh-11910.
+        if not isinstance(vector_store_handler, VectorStoreHandler):
+            handler_type = type(vector_store_handler).__name__
+            raise ValueError(
+                f"Storage '{vector_db_name}' is not a vector database "
+                f"(handler type: {handler_type}). Knowledge base storage must be a "
+                f"vector database integration such as pgvector, chromadb, or faiss."
+            )
         # create table in vectordb before creating KB
         if "default_vector_storage" in params:
             # if vector db is a default - drop previous table, if exists

--- a/mindsdb/interfaces/knowledge_base/llm_client.py
+++ b/mindsdb/interfaces/knowledge_base/llm_client.py
@@ -2,6 +2,7 @@ import os
 import time
 import asyncio
 from typing import List
+from urllib.parse import urlparse
 
 from openai import OpenAI, AzureOpenAI
 
@@ -98,6 +99,13 @@ class LLMClient:
         elif self.provider == "ollama":
             if params.get("api_key") is None:
                 params["api_key"] = "n/a"
+            # Ollama's OpenAI-compatible API is served under the `/v1` path. The OpenAI SDK
+            # appends route paths (e.g. `/embeddings`) directly to `base_url`, so a value
+            # like `http://localhost:11434` resolves to `http://localhost:11434/embeddings`
+            # which Ollama does not serve and returns 404. Provide a sensible default and
+            # transparently append `/v1` when the user-supplied URL is missing it.
+            # Fixes gh-11910.
+            params["base_url"] = self._normalize_ollama_base_url(params.get("base_url"))
             self.client = OpenAI(**params)
         elif self.provider == "bedrock":
             if "aws_region" in params:
@@ -109,6 +117,24 @@ class LLMClient:
             self.client = SnowflakeClient(**params)
         else:
             raise NotImplementedError(f'Provider "{self.provider}" is not supported')
+
+    @staticmethod
+    def _normalize_ollama_base_url(base_url: str | None) -> str:
+        """Return an Ollama base_url that points at the OpenAI-compatible `/v1` endpoint.
+
+        - When ``base_url`` is missing, default to ``http://localhost:11434/v1``.
+        - When the user-supplied URL has no ``v1`` path segment, append one.
+        - Otherwise return the URL unchanged so explicit user configuration wins.
+        """
+        default_base_url = "http://localhost:11434/v1"
+        if not base_url:
+            return default_base_url
+
+        normalized = base_url.rstrip("/")
+        path_segments = [seg for seg in urlparse(normalized).path.split("/") if seg]
+        if "v1" in path_segments:
+            return normalized
+        return f"{normalized}/v1"
 
     @run_in_batches(1000)
     @retry_with_exponential_backoff

--- a/tests/unit/interfaces/knowledge_base/test_ollama_base_url.py
+++ b/tests/unit/interfaces/knowledge_base/test_ollama_base_url.py
@@ -1,0 +1,56 @@
+"""Tests for ``LLMClient._normalize_ollama_base_url`` (gh-11910).
+
+When a knowledge base is configured with an Ollama embedding model, the
+OpenAI Python SDK appends route paths (``/embeddings``, ``/chat/completions``)
+directly onto whatever ``base_url`` the client was constructed with. Ollama
+serves its OpenAI-compatible API only under the ``/v1`` prefix, so a value
+like ``http://localhost:11434`` resolves to ``http://localhost:11434/embeddings``
+which Ollama does not expose and answers with ``404 Not Found``.
+
+These tests pin the normalization rules so future refactors cannot silently
+re-introduce the original bug.
+"""
+
+import pytest
+
+from mindsdb.interfaces.knowledge_base.llm_client import LLMClient
+
+
+OLLAMA_DEFAULT = "http://localhost:11434/v1"
+
+
+class TestNormalizeOllamaBaseUrl:
+    @pytest.mark.parametrize("missing", [None, ""])
+    def test_missing_base_url_falls_back_to_local_default(self, missing):
+        assert LLMClient._normalize_ollama_base_url(missing) == OLLAMA_DEFAULT
+
+    def test_user_url_without_v1_gets_v1_appended(self):
+        # The exact case reported in gh-11910 — first user attempt.
+        assert LLMClient._normalize_ollama_base_url("http://localhost:11434") == "http://localhost:11434/v1"
+
+    def test_trailing_slash_is_collapsed_before_appending(self):
+        assert LLMClient._normalize_ollama_base_url("http://localhost:11434/") == "http://localhost:11434/v1"
+
+    def test_explicit_v1_is_left_unchanged(self):
+        assert LLMClient._normalize_ollama_base_url("http://localhost:11434/v1") == "http://localhost:11434/v1"
+
+    def test_explicit_v1_with_trailing_slash_is_normalized(self):
+        # rstrip("/") collapses trailing slashes; presence of /v1 still detected.
+        assert LLMClient._normalize_ollama_base_url("http://localhost:11434/v1/") == "http://localhost:11434/v1"
+
+    def test_remote_host_without_v1_gets_v1_appended(self):
+        assert (
+            LLMClient._normalize_ollama_base_url("https://ollama.example.com:8080")
+            == "https://ollama.example.com:8080/v1"
+        )
+
+    def test_url_with_v1_in_subpath_is_preserved(self):
+        # Some users front Ollama with a reverse proxy under a sub-path.
+        assert (
+            LLMClient._normalize_ollama_base_url("http://gateway.local/ollama/v1") == "http://gateway.local/ollama/v1"
+        )
+
+    def test_v10_is_not_mistaken_for_v1(self):
+        # Path-segment match must be exact: "v10" must not satisfy the "v1" check,
+        # otherwise we would silently drop the append and break custom deployments.
+        assert LLMClient._normalize_ollama_base_url("http://host/v10") == "http://host/v10/v1"

--- a/tests/unit/interfaces/knowledge_base/test_storage_handler_validation.py
+++ b/tests/unit/interfaces/knowledge_base/test_storage_handler_validation.py
@@ -1,0 +1,132 @@
+"""Tests for KB storage handler validation (gh-11910).
+
+Before this fix, ``KnowledgeBaseController.add`` happily accepted any
+integration as ``storage`` and only blew up later inside
+``vector_store_handler.create_table(...)`` with an opaque
+``AttributeError: 'FileHandler' object has no attribute 'create_table'``.
+The user has no way to tell from that message that they need to point
+``storage`` at a vector database.
+
+This test pins the friendly, up-front ``ValueError`` so the bad message
+cannot regress.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mindsdb_sql_parser.ast import Identifier
+
+from mindsdb.integrations.libs.vectordatabase_handler import VectorStoreHandler
+from mindsdb.interfaces.knowledge_base.controller import KnowledgeBaseController
+
+
+class _NotAVectorStore:
+    """Stand-in for an integration handler that is not a vector database
+    (e.g. a FileHandler or a SQL handler)."""
+
+
+class _FakeVectorStore(VectorStoreHandler):
+    """Concrete subclass so isinstance(_, VectorStoreHandler) is True."""
+
+    def __init__(self):  # pragma: no cover - trivial
+        # Intentionally bypass BaseHandler.__init__ — we only need the type.
+        pass
+
+
+def _build_controller_with_storage(handler):
+    """Wire up just enough of the controller to reach the storage validation."""
+    project = SimpleNamespace(id=1, name="mindsdb")
+    database_controller = MagicMock()
+    database_controller.get_project.return_value = project
+
+    data_node = SimpleNamespace(integration_handler=handler)
+    datahub = MagicMock()
+    datahub.get.return_value = data_node
+
+    integration_controller = MagicMock()
+    integration_controller.get.return_value = {"id": 42}
+
+    session = SimpleNamespace(
+        database_controller=database_controller,
+        datahub=datahub,
+        integration_controller=integration_controller,
+        model_controller=MagicMock(),
+    )
+    return KnowledgeBaseController(session)
+
+
+def _embedding_params():
+    return {
+        "embedding_model": {
+            "provider": "openai",
+            "model_name": "text-embedding-3-small",
+            "api_key": "sk-test",
+        }
+    }
+
+
+def test_non_vector_storage_raises_clear_error_before_create_table():
+    """A non-vector handler must be rejected with an actionable message."""
+    controller = _build_controller_with_storage(_NotAVectorStore())
+
+    with (
+        patch.object(
+            KnowledgeBaseController,
+            "_check_embedding_model",
+            return_value={"dimension": 1536},
+        ),
+        patch.object(KnowledgeBaseController, "get", return_value=None),
+    ):
+        with pytest.raises(ValueError) as exc_info:
+            controller.add(
+                name="kb_bad_storage",
+                project_name="mindsdb",
+                storage=Identifier(parts=["files", "test_knowledge1"]),
+                params=_embedding_params(),
+            )
+
+    message = str(exc_info.value)
+    assert "files" in message
+    assert "vector database" in message
+    assert "pgvector" in message  # message must point user at valid alternatives
+    # The original AttributeError leak must not be what the user sees.
+    assert "create_table" not in message
+    assert "_NotAVectorStore" in message
+
+
+def test_vector_storage_passes_validation():
+    """A real VectorStoreHandler subclass is accepted (proves the guard
+    is not over-eager)."""
+    handler = _FakeVectorStore()
+    handler.create_table = MagicMock()
+    handler.drop_table = MagicMock()
+    handler.add_full_text_index = MagicMock()
+    controller = _build_controller_with_storage(handler)
+
+    with (
+        patch.object(
+            KnowledgeBaseController,
+            "_check_embedding_model",
+            return_value={"dimension": 1536},
+        ),
+        patch.object(KnowledgeBaseController, "_check_vector_table", return_value=None),
+        patch.object(KnowledgeBaseController, "get", return_value=None),
+        patch("mindsdb.interfaces.knowledge_base.controller.db.session"),
+    ):
+        # We don't care about the return value here; we only care that the
+        # storage-type guard does not reject a real vector handler. Any
+        # downstream failure should NOT be the ValueError we are protecting
+        # against in the negative test above.
+        try:
+            controller.add(
+                name="kb_good_storage",
+                project_name="mindsdb",
+                storage=Identifier(parts=["pgvector_db", "kb_table"]),
+                params=_embedding_params(),
+            )
+        except ValueError as e:
+            assert "is not a vector database" not in str(e)
+
+    handler.create_table.assert_called_once_with("kb_table")


### PR DESCRIPTION
## Description

Fixes #11910 — two related bugs surface when creating a knowledge base configured with an Ollama embedding model.

### Bug 1: 404 on Ollama embeddings without explicit `/v1`

The OpenAI SDK appends route paths (`/embeddings`, `/chat/completions`) directly onto whatever `base_url` the client was constructed with. Ollama exposes its OpenAI-compatible API **only** under `/v1`, so a configured value of:

```
embedding_model = {
    "provider": "ollama",
    "model_name": "nomic-embed-text",
    "base_url": "http://localhost:11434"
}
```

resolves to `POST http://localhost:11434/embeddings` — a route Ollama does not serve, returning `404 Not Found` (which then propagates as the opaque message `Problem with embedding model config: 'str' object has no attribute 'get'` on older versions).

**Fix:** in `LLMClient.__init__`'s ollama branch, normalize `base_url` via a new `_normalize_ollama_base_url` helper:
- Missing `base_url` → default to `http://localhost:11434/v1`.
- User URL without a `v1` path segment → transparently append `/v1`.
- User URL that already contains `v1` → left unchanged (explicit user config wins).

The path-segment check uses `urlparse` so that `http://host/v10` is **not** mistaken for `v1`. This mirrors the provider-specific-default approach in #12405 (reranker fix for the related issue gh-11952), but additionally heals the very-common user case from the bug report where the URL was supplied without the `/v1` suffix.

### Bug 2: `AttributeError` when storage points at a non-vector integration

Configuring `storage = files.test_knowledge1` (or any other non-vector handler) previously crashed deep inside the controller with:

```
AttributeError: 'FileHandler' object has no attribute 'create_table'
```

The user has no way to tell from that message that knowledge-base storage must be a vector database.

**Fix:** validate up front that the resolved `vector_store_handler` is an instance of `VectorStoreHandler` (the base class extended by every in-repo vector backend — pgvector, chromadb, duckdb_faiss). If not, raise a clear, actionable `ValueError` that names the offending integration, the handler type, and points at valid alternatives.

The default-storage code path (`storage=None`) only ever provisions `pgvector` or `duckdb_faiss`, both of which extend `VectorStoreHandler`, so this validation cannot false-positive on the auto-storage flow.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification Process

- **Test Location:** `tests/unit/interfaces/knowledge_base/test_ollama_base_url.py`, `tests/unit/interfaces/knowledge_base/test_storage_handler_validation.py`
- **Verification Steps:**
  1. `python -m pytest tests/unit/interfaces/knowledge_base/ -v` — 15 tests pass (8 new for the ollama URL normalization rules including the v10/v1 false-positive guard, 2 new for the storage handler type validation, plus the 5 pre-existing default-storage tests still green).
  2. End-to-end: with the issue's repro `CREATE KNOWLEDGE_BASE` statement (Ollama running locally with `nomic-embed-text` pulled), the embedding probe now succeeds against `http://localhost:11434` (auto-corrected to `/v1`) and the `files.*` storage misuse now fails fast with: `Storage 'files' is not a vector database (handler type: FileHandler). Knowledge base storage must be a vector database integration such as pgvector, chromadb, or faiss.`

## Checklist

- [x] My code follows the style guidelines (PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [x] Relevant unit and integration tests are updated or added.