### PR TITLE
docs(s3): document region_name connection parameter

### DIFF
--- a/docs/integrations/data-integrations/amazon-s3.mdx
+++ b/docs/integrations/data-integrations/amazon-s3.mdx
@@ -24,6 +24,7 @@ WITH
     parameters = {
       "aws_access_key_id": "AQAXEQK89OX07YS34OP",
       "aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      "region_name": "us-east-1",
       "bucket": "my-bucket"
     };
 ```
@@ -40,6 +41,7 @@ Required connection parameters include the following:
 Optional connection parameters include the following:
 
 * `aws_session_token`: The AWS session token that identifies the user or IAM role. This becomes necessary when using temporary security credentials.
+* `region_name`: The AWS region of the bucket (for example, `us-east-1`). When omitted, MindsDB falls back to the bucket's location, which may add an extra metadata round trip and can fail for endpoints that require an explicit region.
 * `bucket`: The name of the Amazon S3 bucket. If not provided, all available buckets can be queried, however, this can affect performance, especially when listing all of the available objects.
 
 ## Usage


### PR DESCRIPTION
## Summary

- Adds the missing `region_name` parameter to the Amazon S3 integration page (Required/Optional connection parameters list and the `CREATE DATABASE` example).
- The parameter is already documented in `docs/integrations/data-integrations/all-data-integrations.mdx` and honored by the handler, but is absent from the standalone Amazon S3 page.
- Without it, users hitting endpoints that require an explicit region (or who don't want the implicit `GetBucketLocation` round trip) have to discover it from issue trackers.

Refs: #12286

## Testing

- Doc-only change. Verified the rendered MDX renders alongside the existing parameter list. No code paths touched.