### PR TITLE
Avoid mutating LLM prompt dataframes

### DIFF
--- a/mindsdb/integrations/libs/llm/utils.py
+++ b/mindsdb/integrations/libs/llm/utils.py
@@ -62,7 +62,7 @@ def get_completed_prompts(base_template: str, df: pd.DataFrame, strict=True) -> 
         if strict:
             raise AssertionError("No placeholders found in the prompt, please provide a valid prompt template.")
         prompts = [base_template] * len(df)
-        return prompts, np.ndarray(0)
+        return prompts, np.array([], dtype=int)
 
     first_span = matches[0].start()
     last_span = matches[-1].end()
@@ -80,15 +80,15 @@ def get_completed_prompts(base_template: str, df: pd.DataFrame, strict=True) -> 
 
     empty_prompt_ids = np.where(df[columns].isna().all(axis=1).values)[0]
 
-    df["__mdb_prompt"] = ""
+    completed_prompts = pd.Series("", index=df.index)
     for i in range(len(template)):
         atom = template[i]
         if i < len(columns):
             col = df[columns[i]].replace(to_replace=[None], value="")  # add empty quote if data is missing
-            df["__mdb_prompt"] = df["__mdb_prompt"].apply(lambda x: x + atom) + col.astype("string")
+            completed_prompts = completed_prompts.apply(lambda x: x + atom) + col.astype("string")
         else:
-            df["__mdb_prompt"] = df["__mdb_prompt"].apply(lambda x: x + atom)
-    prompts = list(df["__mdb_prompt"])
+            completed_prompts = completed_prompts.apply(lambda x: x + atom)
+    prompts = list(completed_prompts)
 
     return prompts, empty_prompt_ids
 

--- a/tests/unit/various/test_llm_utils.py
+++ b/tests/unit/various/test_llm_utils.py
@@ -33,3 +33,18 @@ class TestLLM(unittest.TestCase):
         df = pd.DataFrame({"text": user_inputs})
         with self.assertRaises(Exception):
             get_completed_prompts(base_template, df)
+
+    def test_get_completed_prompts_does_not_mutate_dataframe(self):
+        df = pd.DataFrame(
+            {
+                "text": ["What is MindsDB?"],
+                "__mdb_prompt": ["user data"],
+            }
+        )
+
+        prompts, empties = get_completed_prompts("Answer: {{text}}", df)
+
+        assert prompts == ["Answer: What is MindsDB?"]
+        assert empties.shape == (0,)
+        assert df["__mdb_prompt"].tolist() == ["user data"]
+        assert df.columns.tolist() == ["text", "__mdb_prompt"]


### PR DESCRIPTION
## Summary
- build LLM prompt template completions without writing an internal `__mdb_prompt` column into the caller DataFrame
- return a typed empty integer array for no-placeholder non-strict prompt templates
- add a regression test that preserves a user-provided `__mdb_prompt` column

## Why
`get_completed_prompts` is used by LLM/model handlers to render prompt templates. The helper previously mutated its input DataFrame by adding `__mdb_prompt`, which could leak internal state into downstream code or overwrite a real user column with the same name.

## Validation
- `.test-venv/bin/python -m pytest tests/unit/various/test_llm_utils.py -q` -> `2 passed in 13.09s`
- `/tmp/mindsdb-ruff-venv/bin/ruff check mindsdb/integrations/libs/llm/utils.py tests/unit/various/test_llm_utils.py` -> `All checks passed!`