### PR TITLE
fix(self-host): share api's network namespace so nginx proxies over loopback (ENG-457)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,11 +12,15 @@ services:
       - cowork-data:/home/cowork/.cowork
     # ENG-459: do NOT publish 26866 to the host. Publishing it exposed the raw,
     # unauthenticated API directly, bypassing nginx. `expose` keeps the port
-    # reachable only on the compose network — nginx (web) still proxies to it as
-    # `api:26866`. NOTE: the nginx /v1/ path is itself still unauthenticated
-    # until app-layer auth (COWORK_REQUIRE_AUTH / bearer-token-auth) lands.
+    # reachable only on the compose network. NOTE: the nginx /v1/ path is
+    # itself still unauthenticated until app-layer auth
+    # (COWORK_REQUIRE_AUTH / bearer-token-auth) lands.
     expose:
       - "26866"
+    # ENG-457: `web` now shares this container's network namespace (see
+    # below), so the host's published port lands here instead of on `web`.
+    ports:
+      - "3000:80"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "python", "-c",
@@ -30,8 +34,13 @@ services:
     build:
       context: .
       dockerfile: docker/web.Dockerfile
-    ports:
-      - "3000:80"
+    # ENG-457: share api's network namespace so nginx's proxy to cowork-server
+    # is a genuine loopback hop (127.0.0.1), not a separate-container bridge
+    # hop. cowork-server's `_require_local` guard on /settings/reveal-key and
+    # /raw only allows loopback callers — on the default bridge network the
+    # proxied request would arrive as this container's bridge IP and get
+    # 403'd, breaking onboarding's calls to those endpoints.
+    network_mode: "service:api"
     depends_on:
       api:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     # ENG-457: share api's network namespace so nginx's proxy to cowork-server
     # is a genuine loopback hop (127.0.0.1), not a separate-container bridge
     # hop. cowork-server's `_require_local` guard on /settings/reveal-key and
-    # /raw only allows loopback callers — on the default bridge network the
+    # /raw only allows loopback callers. On the default bridge network the
     # proxied request would arrive as this container's bridge IP and get
     # 403'd, breaking onboarding's calls to those endpoints.
     network_mode: "service:api"

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -4,7 +4,10 @@ server {
     index index.html;
 
     location /v1/ {
-        proxy_pass http://api:26866;
+        # ENG-457: web shares api's network namespace (docker-compose.yml),
+        # so this is a genuine loopback hop -- required for cowork-server's
+        # loopback-only guard on /settings/reveal-key and /raw.
+        proxy_pass http://127.0.0.1:26866;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -5,8 +5,8 @@ server {
 
     location /v1/ {
         # ENG-457: web shares api's network namespace (docker-compose.yml),
-        # so this is a genuine loopback hop -- required for cowork-server's
-        # loopback-only guard on /settings/reveal-key and /raw.
+        # so this is a genuine loopback hop, which cowork-server's
+        # loopback-only guard on /settings/reveal-key and /raw requires.
         proxy_pass http://127.0.0.1:26866;
         proxy_http_version 1.1;
         proxy_set_header Host $host;


### PR DESCRIPTION
## Summary

Companion fix for [ENG-457](https://linear.app/mindsdb/issue/ENG-457): makes the self-host docker-compose stack compatible with cowork-server's loopback-only guard on secret-returning settings endpoints (mindsdb/cowork-server#143, unmerged).

That guard (`_require_local`) 403s any caller of `GET /settings/reveal-key/{name}` and `GET`/`POST /settings/raw` whose peer isn't `127.0.0.1`/`::1`. In this compose stack, `web` (nginx) and `api` (cowork-server) are separate containers on the default bridge network, so nginx's proxied request would arrive at cowork-server as the `web` container's bridge IP, not loopback. That would 403 onboarding's calls to `/settings/raw` (see the reviewer comment on #143).

## Fix

`web` now runs with `network_mode: "service:api"`, sharing api's network namespace, and nginx proxies to `127.0.0.1:26866` directly instead of the `api` service-name DNS hop. The published host port (`3000:80`) moves to the `api` service definition, since port bindings have to live on the container that owns the network stack.

## Verification

I couldn't do a full `docker compose up --build` here, since submodules aren't initialized in this workspace and it'd need the actual `api`/`web` builds. Instead I verified the underlying mechanism directly: stood up a throwaway nginx + `http.server` pair with the identical topology (`network_mode: service:api`, nginx `proxy_pass http://127.0.0.1:8000`) and confirmed the proxied request's peer address is `127.0.0.1` on the receiving side, which is exactly what `_require_local` checks for. I also ran `docker compose config` against the real file to confirm it resolves cleanly: the port binding correctly attaches to `api`, and `web` carries no separate network block.

## Note

This doesn't add security to the self-host stack by itself: nginx still has no auth in front of it (`COWORK_REQUIRE_AUTH` is opt-in). It only makes sure the upcoming loopback guard doesn't regress onboarding once #143 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)