### PR TITLE
docs: add README translations (Chinese, Spanish, Portuguese, Hindi)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,147 @@
+<a name="readme-top"></a>
+
+<div align="center">
+
+# MindsHub Cowork
+
+**El espacio de trabajo unificado donde los agentes de código abierto hacen el trabajo por ti.**
+
+_Delega lo que sea. Vuelve hecho._
+
+[![Release](https://img.shields.io/github/v/release/mindsdb/minds?logo=github&label=release)](https://github.com/mindsdb/minds/releases)
+[![Stars](https://img.shields.io/github/stars/mindsdb/minds?logo=github)](https://github.com/mindsdb/minds/stargazers)
+[![License: MIT](https://img.shields.io/github/license/mindsdb/minds)](#-licencia)
+[![Python 3.10–3.13](https://img.shields.io/badge/python-3.10%20–%203.13-brightgreen.svg)](https://www.python.org/downloads/)
+
+[Sitio web](https://mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) ·
+[Documentación](https://docs.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) ·
+[App web](https://console.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) ·
+[Precios](https://mindshub.ai/pricing?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) ·
+[Discord](https://mindshub.ai/discord)
+
+<p align="center">
+  <sub>Otros idiomas: <a href="README.md">English</a> · <a href="README.zh.md">中文</a> · <a href="README.pt.md">Português</a> · <a href="README.hi.md">हिन्दी</a></sub>
+</p>
+
+</div>
+
+<p align="center">
+  <img alt="MindsHub Cowork — el espacio de trabajo unificado" width="100%" src="https://github.com/user-attachments/assets/769e6463-0a9d-45ae-83d1-ef9e234775d3" />
+</p>
+
+**MindsHub Cowork** es el espacio de trabajo unificado donde delegas tareas completas —investigación, análisis, informes, operaciones programadas— y recibes resultados terminados y listos para compartir. Conecta tus datos, dirige cada paso al modelo adecuado, ejecuta agentes de código abierto y convierte su resultado en artefactos que puedes publicar. Es de código abierto y funciona en cualquier lugar: tu máquina, tu VPC o la app alojada.
+
+Este repositorio es el **superproyecto de la plataforma**: reúne la app de escritorio/web, el backend del agente y el motor de datos para que puedas construir y ejecutar toda la pila desde el código fuente.
+
+## Primeros pasos
+
+Elige lo que mejor te convenga:
+
+- **Web — nada que instalar.** Abre **[console.mindshub.ai](https://console.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)** e inicia sesión.
+- **macOS.** [Descarga la app de escritorio](https://downloads.mindsdb.com/mindshub-cowork/mac/mindshub-cowork-latest.pkg) (`.pkg`).
+- **Windows.** [Descarga la app de escritorio](https://downloads.mindsdb.com/mindshub-cowork/windows/mindshub-cowork-latest.exe) (`.exe`).
+- **Ejecútalo como código abierto.** [Compílalo desde el código fuente](#compílalo-desde-el-código-fuente) — ver más abajo.
+
+Gratis para empezar. Pro añade todos los modelos de vanguardia y artefactos privados — ver [precios](https://mindshub.ai/pricing?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme).
+
+## Qué puedes hacer
+
+Para cualquier trabajador del conocimiento —creadores, estrategas y operadores—:
+
+- **Automatiza** trabajo repetitivo de varios pasos que implica leer y escribir: informes, monitoreo, flujos de trabajo recurrentes y operaciones programadas.
+- **Crea** herramientas y artefactos internos de IA —apps, dashboards, presentaciones, documentos, análisis— sin necesidad de ingeniería, y publícalos en una URL en vivo para compartir con tu equipo.
+
+## Qué incluye
+
+- **Datos conectados.** Un vault seguro conecta sistemas como BigQuery, Postgres, Gmail, Drive, HubSpot, Notion y Linear. Las credenciales quedan delimitadas por conexión —los agentes nunca ven las claves en bruto.
+- **Model Router.** Cambia entre modelos de vanguardia (Claude, GPT, Gemini) y modelos abiertos (DeepSeek, Qwen, Kimi) sin configurar una clave para cada proveedor.
+- **Agentes abiertos.** Ejecuta harnesses de código abierto intercambiables —Anton (por defecto) y Hermes— seleccionables desde un menú desplegable.
+- **Artefactos.** Convierte la salida del agente en documentos, dashboards, apps y código, y publícalo en una URL en vivo.
+- **Memoria, habilidades y programación.** Memoria entre sesiones, una biblioteca de habilidades reutilizable y tareas que se ejecutan según un horario.
+
+## Compílalo desde el código fuente
+
+**1. Clona el repositorio**
+
+```bash
+git clone --recurse-submodules https://github.com/mindsdb/minds.git
+cd minds
+```
+
+**2. Instala las dependencias**
+
+```bash
+make setup
+```
+
+**3. Ejecuta**
+
+| Modo | Comando |
+|---|---|
+| App de escritorio (Electron) con hot reload | `make dev` o `make watch` |
+| App web en el navegador con hot reload | `make dev-web` |
+| Build de producción | `make build` |
+| Empaquetar para macOS | `make dist-mac` |
+| Empaquetar para Windows | `make dist-win` |
+| Compilar la `.app` de macOS desde código local sin confirmar | `make pack-local` |
+| Borrar todas las instalaciones y datos locales (empezar de cero) | `make flush` |
+
+> **Empezar de cero:** `make flush` elimina el runtime local (la herramienta uv `cowork-server` y los `backend/*/.venv`) y borra el estado de la app en `~/.anton` (claves de proveedores) y `~/.cowork` (base de datos, hermes, proyectos). Úsalo para probar el flujo de instalación desde cero o para recuperarte de una instalación rota. Pide confirmación —pasa `FORCE=1` para omitirla. El siguiente `make setup` o el próximo arranque de la app reinstala todo. ⚠️ Esto elimina tus conversaciones y claves guardadas.
+
+### Trabajar en ramas de funcionalidades (submódulos)
+
+Este repositorio es un superproyecto que fija (pin) cada módulo (`frontend`, `backend/core_api`, `backend/core_agent`, `backend/data-vault`) a un commit. Para trabajar en ramas de los módulos sin ensuciar el `git status` ni pelear por los pins:
+
+**1. Elige tus ramas** en un `dev.env` (ignorado por git, cópialo de la plantilla):
+
+```bash
+cp dev.env.example dev.env      # luego define REF=feat/mi-cosa (o por módulo API_REF=…)
+```
+
+**2. `make` sigue esa configuración** —un solo ajuste, para ambas formas de ejecutar:
+
+| Comando | Qué hace |
+|---|---|
+| `make use` | hace checkout de las ramas de `dev.env` en todos los submódulos |
+| `make dev` / `make watch` | ejecuta la app Electron con hot reload contra el código local |
+| `make dev-web` | ejecuta la SPA web con hot reload contra el código local |
+| `make server` + `make app` | (re)instala el servidor de escritorio desde la rama configurada y lo lanza |
+| `make server-local` + `make app-local` | instala el servidor de escritorio desde **código local sin confirmar** y lo lanza |
+| `make pack-local` | compila la `.app` de macOS desde código local sin confirmar (sin necesidad de push) |
+| `make refs` | muestra qué referencias usará la próxima ejecución |
+| `make baseline` | restablece los submódulos a los commits fijados |
+| `make pin` | registra los commits actuales de los submódulos como los pins del superproyecto (un commit deliberado) |
+
+Los submódulos están configurados con `ignore = all`, así que tu trabajo en ramas nunca aparece como cambios del superproyecto —el `git status` del repositorio padre se mantiene limpio. Los pins solo se mueven con `make pin`. Consulta [`CLAUDE.md`](CLAUDE.md) para el flujo completo.
+
+## Despliega en cualquier lugar
+
+Cowork está diseñado para un despliegue flexible —infraestructura **en la nube, VPC, on-prem, air-gapped e híbrida**— para que mantengas el control total sobre tu infraestructura, modelos, permisos y datos.
+
+## Ayuda y soporte
+
+- **Haz una pregunta** — únete a la [comunidad de Discord](https://mindshub.ai/discord).
+- **Reporta un bug** — abre un [issue en GitHub](https://github.com/mindsdb/minds/issues) con los pasos para reproducirlo.
+- **Lee la documentación** — guías, configuración y la API en [docs.mindshub.ai](https://docs.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme).
+- **SLAs empresariales o despliegues a medida** — [contacta al equipo](https://mindshub.ai/contact?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme).
+
+## 🤝 Contribuir
+
+Cowork es de código abierto y las contribuciones son bienvenidas —código, integraciones, documentación, reportes de bugs e ideas de funcionalidades. Lee la [documentación](https://docs.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) para configurarte, explora los [issues abiertos](https://github.com/mindsdb/minds/issues) y saluda en [Discord](https://mindshub.ai/discord).
+
+## 🔒 Seguridad
+
+¿Encontraste una vulnerabilidad de seguridad? Por favor **no** abras un issue público. Repórtala de forma privada a través de nuestra [política de seguridad](https://github.com/mindsdb/minds/security).
+
+## 📚 Recursos
+
+- [Documentación](https://docs.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)
+- [Blog](https://mindshub.ai/blog?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)
+- [Guías de marca y kit de prensa](https://mindshub.ai/press-kit?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)
+- [Comunidad de Discord](https://mindshub.ai/discord)
+
+## 📄 Licencia
+
+Este repositorio se publica bajo la [Licencia MIT](LICENSE). Los componentes incluidos se rigen por sus propias licencias —consulta el repositorio de cada submódulo para más detalles.
+
+<p align="right">(<a href="#readme-top">volver arriba</a>)</p>

--- a/README.hi.md
+++ b/README.hi.md
@@ -1,0 +1,147 @@
+<a name="readme-top"></a>
+
+<div align="center">
+
+# MindsHub Cowork
+
+**वह एकीकृत वर्कस्पेस जहाँ ओपन-सोर्स एजेंट आपके लिए काम पूरा करते हैं।**
+
+_कोई भी काम सौंप दें। वह पूरा होकर वापस आता है।_
+
+[![Release](https://img.shields.io/github/v/release/mindsdb/minds?logo=github&label=release)](https://github.com/mindsdb/minds/releases)
+[![Stars](https://img.shields.io/github/stars/mindsdb/minds?logo=github)](https://github.com/mindsdb/minds/stargazers)
+[![License: MIT](https://img.shields.io/github/license/mindsdb/minds)](#-लाइसेंस)
+[![Python 3.10–3.13](https://img.shields.io/badge/python-3.10%20–%203.13-brightgreen.svg)](https://www.python.org/downloads/)
+
+[वेबसाइट](https://mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) ·
+[दस्तावेज़](https://docs.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) ·
+[वेब ऐप](https://console.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) ·
+[मूल्य निर्धारण](https://mindshub.ai/pricing?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) ·
+[Discord](https://mindshub.ai/discord)
+
+<p align="center">
+  <sub>अन्य भाषाएँ: <a href="README.md">English</a> · <a href="README.zh.md">中文</a> · <a href="README.es.md">Español</a> · <a href="README.pt.md">Português</a></sub>
+</p>
+
+</div>
+
+<p align="center">
+  <img alt="MindsHub Cowork — एकीकृत वर्कस्पेस" width="100%" src="https://github.com/user-attachments/assets/769e6463-0a9d-45ae-83d1-ef9e234775d3" />
+</p>
+
+**MindsHub Cowork** वह एकीकृत वर्कस्पेस है जहाँ आप पूरे कार्य सौंप सकते हैं — रिसर्च, विश्लेषण, रिपोर्टिंग, शेड्यूल्ड ऑपरेशंस — और तैयार, शेयर करने-लायक नतीजे पाते हैं। अपना डेटा कनेक्ट करें, हर स्टेप को सही मॉडल पर रूट करें, ओपन-सोर्स एजेंट चलाएँ, और उनके आउटपुट को प्रकाशित (publish) करने-योग्य आर्टिफैक्ट्स में बदलें। यह ओपन सोर्स है और कहीं भी चलता है — आपकी मशीन पर, आपके VPC में, या होस्टेड ऐप में।
+
+यह रिपॉज़िटरी **प्लेटफ़ॉर्म सुपरप्रोजेक्ट** है: यह डेस्कटॉप/वेब ऐप, एजेंट बैकएंड, और डेटा इंजन को एक साथ जोड़ता है, ताकि आप पूरा स्टैक सोर्स से बना और चला सकें।
+
+## शुरुआत करें
+
+जो आपके लिए सही हो, चुनें:
+
+- **वेब — कुछ भी इंस्टॉल करने की ज़रूरत नहीं।** **[console.mindshub.ai](https://console.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)** खोलें और साइन इन करें।
+- **macOS.** [डेस्कटॉप ऐप डाउनलोड करें](https://downloads.mindsdb.com/mindshub-cowork/mac/mindshub-cowork-latest.pkg) (`.pkg`)।
+- **Windows.** [डेस्कटॉप ऐप डाउनलोड करें](https://downloads.mindsdb.com/mindshub-cowork/windows/mindshub-cowork-latest.exe) (`.exe`)।
+- **इसे ओपन सोर्स के रूप में चलाएँ।** [सोर्स से बिल्ड करें](#सोर्स-से-बिल्ड-करें) — नीचे देखें।
+
+शुरू करना फ्री है। Pro में सभी फ्रंटियर मॉडल्स और प्राइवेट आर्टिफैक्ट्स जुड़ते हैं — [मूल्य निर्धारण](https://mindshub.ai/pricing?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) देखें।
+
+## आप क्या कर सकते हैं
+
+हर नॉलेज वर्कर के लिए — क्रिएटर्स, स्ट्रैटेजिस्ट्स, और ऑपरेटर्स:
+
+- **ऑटोमेट करें** पढ़ने-लिखने से जुड़े दोहराव वाले, मल्टी-स्टेप काम: रिपोर्ट्स, मॉनिटरिंग, बार-बार होने वाले वर्कफ़्लो, और शेड्यूल्ड ऑपरेशंस।
+- **बनाएँ** इंटरनल AI टूल्स और आर्टिफैक्ट्स — ऐप्स, डैशबोर्ड्स, डेक्स, डॉक्युमेंट्स, एनालिसिस — इंजीनियरिंग के बिना, और अपनी टीम के साथ शेयर करने के लिए एक लाइव URL पर पब्लिश करें।
+
+## इसमें क्या शामिल है
+
+- **कनेक्टेड डेटा।** एक सुरक्षित वॉल्ट BigQuery, Postgres, Gmail, Drive, HubSpot, Notion, और Linear जैसे सिस्टम्स को जोड़ता है। क्रेडेंशियल्स हर कनेक्शन के हिसाब से सीमित रहते हैं — एजेंट्स कभी भी असली की (raw key) नहीं देखते।
+- **मॉडल राउटर (Model Router)।** फ्रंटियर मॉडल्स (Claude, GPT, Gemini) और ओपन मॉडल्स (DeepSeek, Qwen, Kimi) के बीच बिना हर प्रोवाइडर के लिए अलग की सेट किए स्विच करें।
+- **ओपन एजेंट्स।** इंटरचेंजेबल ओपन-सोर्स हार्नेस चलाएँ — Anton (डिफ़ॉल्ट) और Hermes — जिन्हें ड्रॉपडाउन से बदला जा सकता है।
+- **आर्टिफैक्ट्स।** एजेंट के आउटपुट को डॉक्युमेंट्स, डैशबोर्ड्स, ऐप्स और कोड में बदलें, और लाइव URL पर पब्लिश करें।
+- **मेमोरी, स्किल्स और शेड्यूलिंग।** सेशन्स के बीच याद रखने वाली मेमोरी, दोबारा इस्तेमाल होने वाली स्किल लाइब्रेरी, और शेड्यूल पर चलने वाले टास्क।
+
+## सोर्स से बिल्ड करें
+
+**1. रिपॉज़िटरी क्लोन करें**
+
+```bash
+git clone --recurse-submodules https://github.com/mindsdb/minds.git
+cd minds
+```
+
+**2. डिपेंडेंसीज़ इंस्टॉल करें**
+
+```bash
+make setup
+```
+
+**3. चलाएँ**
+
+| मोड | कमांड |
+|---|---|
+| हॉट रीलोड के साथ डेस्कटॉप ऐप (Electron) | `make dev` या `make watch` |
+| हॉट रीलोड के साथ ब्राउज़र में वेब ऐप | `make dev-web` |
+| प्रोडक्शन बिल्ड | `make build` |
+| macOS के लिए पैकेज करें | `make dist-mac` |
+| Windows के लिए पैकेज करें | `make dist-win` |
+| लोकल अनकमिटेड सोर्स से macOS `.app` बनाएँ | `make pack-local` |
+| सभी लोकल इंस्टॉल्स + डेटा मिटाएँ (शुरुआत से) | `make flush` |
+
+> **शुरुआत से:** `make flush` लोकल रनटाइम (`cowork-server` uv टूल और `backend/*/.venv`) हटा देता है और `~/.anton` (प्रोवाइडर कीज़) व `~/.cowork` (डेटाबेस, hermes, प्रोजेक्ट्स) में ऐप स्टेट डिलीट कर देता है। इसका उपयोग शुरुआत से इंस्टॉल फ़्लो टेस्ट करने या टूटे हुए इंस्टॉल से रिकवर करने के लिए करें। यह पुष्टि माँगता है — पुष्टि स्किप करने के लिए `FORCE=1` पास करें। अगला `make setup` या ऐप लॉन्च सब कुछ फिर से इंस्टॉल कर देता है। ⚠️ इससे आपकी बातचीत (conversations) और सेव्ड कीज़ डिलीट हो जाती हैं।
+
+### फ़ीचर ब्रांच पर काम करना (सबमॉड्यूल्स)
+
+यह रिपॉज़िटरी एक सुपरप्रोजेक्ट है जो हर मॉड्यूल (`frontend`, `backend/core_api`, `backend/core_agent`, `backend/data-vault`) को एक कमिट पर पिन करता है। `git status` को गंदा किए बिना या पिन्स को लेकर उलझे बिना मॉड्यूल ब्रांच पर काम करने के लिए:
+
+**1. अपनी ब्रांच चुनें** एक (gitignored) `dev.env` में (टेम्प्लेट से कॉपी करें):
+
+```bash
+cp dev.env.example dev.env      # फिर सेट करें REF=feat/my-thing (या हर मॉड्यूल के लिए API_REF=…)
+```
+
+**2. `make` इसे फ़ॉलो करता है** — एक ही सेटिंग, दोनों रन-पाथ के लिए:
+
+| कमांड | यह क्या करता है |
+|---|---|
+| `make use` | सभी सबमॉड्यूल्स में `dev.env` की ब्रांच चेकआउट करता है |
+| `make dev` / `make watch` | लोकल सोर्स के खिलाफ़ हॉट रीलोड के साथ Electron ऐप चलाता है |
+| `make dev-web` | लोकल सोर्स के खिलाफ़ हॉट रीलोड के साथ वेब SPA चलाता है |
+| `make server` + `make app` | कॉन्फ़िगर की गई ब्रांच से डेस्कटॉप सर्वर (फिर से) इंस्टॉल करता है, फिर लॉन्च करता है |
+| `make server-local` + `make app-local` | **लोकल अनकमिटेड सोर्स** से डेस्कटॉप सर्वर इंस्टॉल करता है, फिर लॉन्च करता है |
+| `make pack-local` | लोकल अनकमिटेड सोर्स से macOS `.app` बनाता है (push की ज़रूरत नहीं) |
+| `make refs` | दिखाता है कि अगला रन किन रेफ़्स का उपयोग करेगा |
+| `make baseline` | सबमॉड्यूल्स को पिन किए गए कमिट्स पर रीसेट करता है |
+| `make pin` | मौजूदा सबमॉड्यूल कमिट्स को सुपरप्रोजेक्ट के पिन्स के रूप में रिकॉर्ड करता है (एक जानबूझकर किया गया कमिट) |
+
+सबमॉड्यूल्स `ignore = all` के साथ कॉन्फ़िगर किए गए हैं, इसलिए आपका ब्रांच वाला काम कभी भी सुपरप्रोजेक्ट में बदलाव के रूप में नहीं दिखता — पेरेंट रिपॉज़िटरी का `git status` हमेशा साफ़ रहता है। पिन्स **केवल** `make pin` से बदलते हैं। पूरा वर्कफ़्लो [`CLAUDE.md`](CLAUDE.md) में देखें।
+
+## कहीं भी डिप्लॉय करें
+
+Cowork फ्लेक्सिबल डिप्लॉयमेंट के लिए बनाया गया है — **क्लाउड, VPC, ऑन-प्रेम, एयर-गैप्ड, और हाइब्रिड** इंफ़्रास्ट्रक्चर — ताकि आपका अपने इंफ़्रास्ट्रक्चर, मॉडल्स, परमिशन्स, और डेटा पर पूरा नियंत्रण बना रहे।
+
+## मदद और सहायता
+
+- **सवाल पूछें** — [Discord कम्युनिटी](https://mindshub.ai/discord) से जुड़ें।
+- **बग रिपोर्ट करें** — रीप्रोडक्शन स्टेप्स के साथ एक [GitHub issue](https://github.com/mindsdb/minds/issues) खोलें।
+- **दस्तावेज़ पढ़ें** — गाइड्स, सेटअप, और API [docs.mindshub.ai](https://docs.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) पर।
+- **एंटरप्राइज़ SLA या कस्टम डिप्लॉयमेंट** — [टीम से संपर्क करें](https://mindshub.ai/contact?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)।
+
+## 🤝 योगदान करें
+
+Cowork ओपन सोर्स है और योगदान का स्वागत है — कोड, इंटीग्रेशन्स, दस्तावेज़, बग रिपोर्ट्स, और फ़ीचर आइडियाज़। सेटअप के लिए [दस्तावेज़](https://docs.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) पढ़ें, [ओपन इश्यूज़](https://github.com/mindsdb/minds/issues) ब्राउज़ करें, और [Discord](https://mindshub.ai/discord) पर हाय कहें।
+
+## 🔒 सुरक्षा
+
+कोई सुरक्षा खामी (vulnerability) मिली? कृपया कोई पब्लिक issue **न** खोलें। हमारी [सुरक्षा नीति](https://github.com/mindsdb/minds/security) के ज़रिए इसे प्राइवेट तौर पर रिपोर्ट करें।
+
+## 📚 संसाधन
+
+- [दस्तावेज़](https://docs.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)
+- [ब्लॉग](https://mindshub.ai/blog?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)
+- [ब्रांड गाइडलाइंस और प्रेस किट](https://mindshub.ai/press-kit?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)
+- [Discord कम्युनिटी](https://mindshub.ai/discord)
+
+## 📄 लाइसेंस
+
+यह रिपॉज़िटरी [MIT लाइसेंस](LICENSE) के तहत जारी की गई है। बंडल किए गए कॉम्पोनेंट्स अपने-अपने लाइसेंस से गवर्न होते हैं — विवरण के लिए हर सबमॉड्यूल की रिपॉज़िटरी देखें।
+
+<p align="right">(<a href="#readme-top">ऊपर वापस जाएँ</a>)</p>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ _Delegate anything. It comes back done._
 [Pricing](https://mindshub.ai/pricing?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) ·
 [Discord](https://mindshub.ai/discord)
 
+<p align="center">
+  <sub>Read this in: <a href="README.zh.md">中文</a> · <a href="README.es.md">Español</a> · <a href="README.pt.md">Português</a> · <a href="README.hi.md">हिन्दी</a></sub>
+</p>
+
 </div>
 
 <p align="center">

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,0 +1,147 @@
+<a name="readme-top"></a>
+
+<div align="center">
+
+# MindsHub Cowork
+
+**O espaço de trabalho unificado onde agentes de código aberto fazem o trabalho por você.**
+
+_Delegue qualquer coisa. Ela volta pronta._
+
+[![Release](https://img.shields.io/github/v/release/mindsdb/minds?logo=github&label=release)](https://github.com/mindsdb/minds/releases)
+[![Stars](https://img.shields.io/github/stars/mindsdb/minds?logo=github)](https://github.com/mindsdb/minds/stargazers)
+[![License: MIT](https://img.shields.io/github/license/mindsdb/minds)](#-licença)
+[![Python 3.10–3.13](https://img.shields.io/badge/python-3.10%20–%203.13-brightgreen.svg)](https://www.python.org/downloads/)
+
+[Site](https://mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) ·
+[Documentação](https://docs.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) ·
+[App web](https://console.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) ·
+[Preços](https://mindshub.ai/pricing?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) ·
+[Discord](https://mindshub.ai/discord)
+
+<p align="center">
+  <sub>Outros idiomas: <a href="README.md">English</a> · <a href="README.zh.md">中文</a> · <a href="README.es.md">Español</a> · <a href="README.hi.md">हिन्दी</a></sub>
+</p>
+
+</div>
+
+<p align="center">
+  <img alt="MindsHub Cowork — o espaço de trabalho unificado" width="100%" src="https://github.com/user-attachments/assets/769e6463-0a9d-45ae-83d1-ef9e234775d3" />
+</p>
+
+O **MindsHub Cowork** é o espaço de trabalho unificado onde você delega tarefas inteiras —pesquisa, análise, relatórios, operações agendadas— e recebe resultados finalizados e prontos para compartilhar. Conecte seus dados, direcione cada etapa para o modelo certo, execute agentes de código aberto e transforme a saída deles em artefatos que você pode publicar. É open source e funciona em qualquer lugar —sua máquina, sua VPC, ou o app hospedado.
+
+Este repositório é o **superprojeto da plataforma**: ele reúne o app de desktop/web, o backend do agente e o motor de dados para que você possa compilar e executar toda a stack a partir do código-fonte.
+
+## Comece agora
+
+Escolha o que fizer mais sentido:
+
+- **Web — nada para instalar.** Abra **[console.mindshub.ai](https://console.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)** e faça login.
+- **macOS.** [Baixe o app de desktop](https://downloads.mindsdb.com/mindshub-cowork/mac/mindshub-cowork-latest.pkg) (`.pkg`).
+- **Windows.** [Baixe o app de desktop](https://downloads.mindsdb.com/mindshub-cowork/windows/mindshub-cowork-latest.exe) (`.exe`).
+- **Execute como open source.** [Compile a partir do código-fonte](#compile-a-partir-do-código-fonte) — veja abaixo.
+
+Grátis para começar. O plano Pro adiciona todos os modelos de ponta e artefatos privados — veja os [preços](https://mindshub.ai/pricing?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme).
+
+## O que você pode fazer
+
+Para todo trabalhador do conhecimento —criadores, estrategistas e operadores:
+
+- **Automatize** trabalho repetitivo e multietapas que envolve leitura e escrita: relatórios, monitoramento, fluxos recorrentes e operações agendadas.
+- **Construa** ferramentas e artefatos internos de IA —apps, dashboards, apresentações, documentos, análises— sem precisar de engenharia, e publique em uma URL ativa para compartilhar com sua equipe.
+
+## O que tem por dentro
+
+- **Dados conectados.** Um vault seguro conecta sistemas como BigQuery, Postgres, Gmail, Drive, HubSpot, Notion e Linear. As credenciais ficam restritas por conexão —os agentes nunca veem as chaves brutas.
+- **Model Router.** Alterne entre modelos de ponta (Claude, GPT, Gemini) e modelos abertos (DeepSeek, Qwen, Kimi) sem configurar uma chave para cada provedor.
+- **Agentes abertos.** Execute harnesses de código aberto intercambiáveis —Anton (padrão) e Hermes— selecionáveis em um menu.
+- **Artefatos.** Transforme a saída do agente em documentos, dashboards, apps e código, e publique em uma URL ativa.
+- **Memória, habilidades e agendamento.** Memória entre sessões, uma biblioteca de habilidades reutilizável e tarefas que rodam em horários programados.
+
+## Compile a partir do código-fonte
+
+**1. Clone o repositório**
+
+```bash
+git clone --recurse-submodules https://github.com/mindsdb/minds.git
+cd minds
+```
+
+**2. Instale as dependências**
+
+```bash
+make setup
+```
+
+**3. Execute**
+
+| Modo | Comando |
+|---|---|
+| App de desktop (Electron) com hot reload | `make dev` ou `make watch` |
+| App web no navegador com hot reload | `make dev-web` |
+| Build de produção | `make build` |
+| Empacotar para macOS | `make dist-mac` |
+| Empacotar para Windows | `make dist-win` |
+| Compilar o `.app` do macOS a partir do código local não commitado | `make pack-local` |
+| Apagar todas as instalações e dados locais (começar do zero) | `make flush` |
+
+> **Começar do zero:** `make flush` remove o runtime local (a ferramenta uv `cowork-server` e os `backend/*/.venv`) e apaga o estado do app em `~/.anton` (chaves de provedores) e `~/.cowork` (banco de dados, hermes, projetos). Use para testar o fluxo de instalação do zero ou recuperar uma instalação corrompida. Pede confirmação —passe `FORCE=1` para pular. O próximo `make setup` ou início do app reinstala tudo. ⚠️ Isso apaga suas conversas e chaves salvas.
+
+### Trabalhando em branches de features (submódulos)
+
+Este repositório é um superprojeto que fixa (pin) cada módulo (`frontend`, `backend/core_api`, `backend/core_agent`, `backend/data-vault`) em um commit. Para trabalhar em branches dos módulos sem poluir o `git status` ou disputar os pins:
+
+**1. Escolha suas branches** em um `dev.env` (ignorado pelo git, copie do modelo):
+
+```bash
+cp dev.env.example dev.env      # depois defina REF=feat/minha-coisa (ou por módulo API_REF=…)
+```
+
+**2. O `make` segue essa configuração** —um único controle, para os dois modos de execução:
+
+| Comando | O que faz |
+|---|---|
+| `make use` | faz checkout das branches do `dev.env` em todos os submódulos |
+| `make dev` / `make watch` | executa o app Electron com hot reload a partir do código local |
+| `make dev-web` | executa a SPA web com hot reload a partir do código local |
+| `make server` + `make app` | (re)instala o servidor de desktop a partir da branch configurada e inicia |
+| `make server-local` + `make app-local` | instala o servidor de desktop a partir do **código local não commitado** e inicia |
+| `make pack-local` | compila o `.app` do macOS a partir do código local não commitado (sem precisar de push) |
+| `make refs` | mostra quais referências a próxima execução vai usar |
+| `make baseline` | reseta os submódulos para os commits fixados |
+| `make pin` | registra os commits atuais dos submódulos como os pins do superprojeto (um commit deliberado) |
+
+Os submódulos são configurados com `ignore = all`, então seu trabalho em branches nunca aparece como alterações do superprojeto —o `git status` do repositório pai permanece limpo. Os pins só mudam via `make pin`. Veja o fluxo completo em [`CLAUDE.md`](CLAUDE.md).
+
+## Implante em qualquer lugar
+
+O Cowork é feito para implantação flexível —infraestrutura em **nuvem, VPC, on-premises, air-gapped e híbrida**— para que você mantenha controle total sobre sua infraestrutura, modelos, permissões e dados.
+
+## Ajuda e suporte
+
+- **Faça uma pergunta** — entre na [comunidade do Discord](https://mindshub.ai/discord).
+- **Reporte um bug** — abra uma [issue no GitHub](https://github.com/mindsdb/minds/issues) com os passos para reproduzir.
+- **Leia a documentação** — guias, configuração e a API em [docs.mindshub.ai](https://docs.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme).
+- **SLAs empresariais ou implantações personalizadas** — [entre em contato com o time](https://mindshub.ai/contact?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme).
+
+## 🤝 Contribua
+
+O Cowork é open source e contribuições são bem-vindas —código, integrações, documentação, relatos de bugs e ideias de funcionalidades. Leia a [documentação](https://docs.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) para se preparar, veja as [issues abertas](https://github.com/mindsdb/minds/issues) e dê um alô no [Discord](https://mindshub.ai/discord).
+
+## 🔒 Segurança
+
+Encontrou uma vulnerabilidade de segurança? Por favor, **não** abra uma issue pública. Reporte de forma privada através da nossa [política de segurança](https://github.com/mindsdb/minds/security).
+
+## 📚 Recursos
+
+- [Documentação](https://docs.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)
+- [Blog](https://mindshub.ai/blog?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)
+- [Diretrizes de marca e press kit](https://mindshub.ai/press-kit?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)
+- [Comunidade do Discord](https://mindshub.ai/discord)
+
+## 📄 Licença
+
+Este repositório é distribuído sob a [Licença MIT](LICENSE). Os componentes empacotados são regidos por suas próprias licenças —consulte o repositório de cada submódulo para mais detalhes.
+
+<p align="right">(<a href="#readme-top">voltar ao topo</a>)</p>

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,147 @@
+<a name="readme-top"></a>
+
+<div align="center">
+
+# MindsHub Cowork
+
+**开源智能体为你完成工作的统一工作空间。**
+
+_委托任何任务,完成后直接送达。_
+
+[![Release](https://img.shields.io/github/v/release/mindsdb/minds?logo=github&label=release)](https://github.com/mindsdb/minds/releases)
+[![Stars](https://img.shields.io/github/stars/mindsdb/minds?logo=github)](https://github.com/mindsdb/minds/stargazers)
+[![License: MIT](https://img.shields.io/github/license/mindsdb/minds)](#-许可证)
+[![Python 3.10–3.13](https://img.shields.io/badge/python-3.10%20–%203.13-brightgreen.svg)](https://www.python.org/downloads/)
+
+[官网](https://mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) ·
+[文档](https://docs.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) ·
+[网页应用](https://console.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) ·
+[定价](https://mindshub.ai/pricing?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme) ·
+[Discord](https://mindshub.ai/discord)
+
+<p align="center">
+  <sub>其他语言: <a href="README.md">English</a> · <a href="README.es.md">Español</a> · <a href="README.pt.md">Português</a> · <a href="README.hi.md">हिन्दी</a></sub>
+</p>
+
+</div>
+
+<p align="center">
+  <img alt="MindsHub Cowork — 统一工作空间" width="100%" src="https://github.com/user-attachments/assets/769e6463-0a9d-45ae-83d1-ef9e234775d3" />
+</p>
+
+**MindsHub Cowork** 是一个统一工作空间,你可以在这里委托完整的任务——调研、分析、报告、定时运维——并获得可直接分享的成品结果。连接你的数据,将每一步路由到合适的模型,运行开源智能体,并将其产出转化为可发布的成果物(Artifacts)。它是开源的,可以运行在任何地方——你的电脑、你的 VPC,或托管应用中。
+
+本仓库是**平台超级项目(superproject)**:它整合了桌面/网页应用、智能体后端和数据引擎,让你可以从源码构建并运行整套技术栈。
+
+## 快速开始
+
+选择最适合你的方式:
+
+- **网页版 —— 无需安装。** 打开 **[console.mindshub.ai](https://console.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)** 并登录。
+- **macOS。** [下载桌面应用](https://downloads.mindsdb.com/mindshub-cowork/mac/mindshub-cowork-latest.pkg)(`.pkg`)。
+- **Windows。** [下载桌面应用](https://downloads.mindsdb.com/mindshub-cowork/windows/mindshub-cowork-latest.exe)(`.exe`)。
+- **以开源方式运行。** [从源码构建](#从源码构建)——见下文。
+
+免费即可开始使用。Pro 版本解锁全部前沿模型与私有成果物——详见[定价](https://mindshub.ai/pricing?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)。
+
+## 你能做什么
+
+面向每一位知识工作者——创作者、策略制定者与运营者:
+
+- **自动化**涉及读写的重复性多步骤工作:报告、监控、周期性工作流以及定时运维任务。
+- **构建**内部 AI 工具与成果物——应用、仪表盘、演示文稿、文档、分析报告——无需工程开发,并发布到可分享给团队的在线链接。
+
+## 内含功能
+
+- **数据连接。** 安全的密钥库(vault)可连接 BigQuery、Postgres、Gmail、Drive、HubSpot、Notion、Linear 等系统。凭证按连接单独限定范围——智能体永远看不到原始密钥。
+- **模型路由(Model Router)。** 在前沿模型(Claude、GPT、Gemini)与开源模型(DeepSeek、Qwen、Kimi)之间自由切换,无需为每个提供方单独配置密钥。
+- **开源智能体。** 运行可互换的开源执行引擎(harness)——Anton(默认)与 Hermes——通过下拉菜单即可切换。
+- **成果物(Artifacts)。** 将智能体的产出转化为文档、仪表盘、应用与代码,并发布到在线链接。
+- **记忆、技能与定时任务。** 跨会话记忆、可复用的技能库,以及按计划运行的任务。
+
+## 从源码构建
+
+**1. 克隆仓库**
+
+```bash
+git clone --recurse-submodules https://github.com/mindsdb/minds.git
+cd minds
+```
+
+**2. 安装依赖**
+
+```bash
+make setup
+```
+
+**3. 运行**
+
+| 模式 | 命令 |
+|---|---|
+| 桌面应用(Electron),支持热重载 | `make dev` 或 `make watch` |
+| 浏览器网页应用,支持热重载 | `make dev-web` |
+| 生产构建 | `make build` |
+| 打包 macOS 版本 | `make dist-mac` |
+| 打包 Windows 版本 | `make dist-win` |
+| 从本地未提交的源码构建 macOS `.app` | `make pack-local` |
+| 清除所有本地安装与数据(从零开始) | `make flush` |
+
+> **从零开始:** `make flush` 会移除本地运行环境(`cowork-server` uv 工具及 `backend/*/.venv`),并删除 `~/.anton`(提供方密钥)与 `~/.cowork`(数据库、hermes、项目)中的应用状态。用它来测试从零安装流程,或从损坏的安装中恢复。执行前会要求确认——传入 `FORCE=1` 可跳过确认。之后运行 `make setup` 或启动应用即可重新安装全部内容。⚠️ 此操作会删除你的对话记录和已保存的密钥。
+
+### 在功能分支上开发(子模块)
+
+本仓库是一个超级项目,将每个模块(`frontend`、`backend/core_api`、`backend/core_agent`、`backend/data-vault`)固定(pin)到某个提交。要在模块分支上开发而不污染 `git status` 或与固定版本产生冲突:
+
+**1. 在(已加入 `.gitignore` 的)`dev.env` 中选择你的分支**(从模板复制):
+
+```bash
+cp dev.env.example dev.env      # 然后设置 REF=feat/my-thing(或按模块设置 API_REF=…)
+```
+
+**2. `make` 会自动读取该配置** —— 一个开关,适用于两种运行方式:
+
+| 命令 | 作用 |
+|---|---|
+| `make use` | 按 `dev.env` 中的配置检出所有子模块的分支 |
+| `make dev` / `make watch` | 以本地源码热重载方式运行 Electron 应用 |
+| `make dev-web` | 以本地源码热重载方式运行网页版 SPA |
+| `make server` + `make app` | 从配置的分支(重新)安装桌面服务端,然后启动 |
+| `make server-local` + `make app-local` | 从**本地未提交的源码**安装桌面服务端,然后启动 |
+| `make pack-local` | 从本地未提交的源码构建 macOS `.app`(无需推送) |
+| `make refs` | 显示下一次运行将使用的分支引用 |
+| `make baseline` | 将子模块重置为固定的提交版本 |
+| `make pin` | 将当前子模块提交记录为超级项目的固定版本(一次明确的提交) |
+
+子模块配置了 `ignore = all`,因此你在分支上的工作永远不会显示为超级项目的更改——父仓库的 `git status` 始终保持干净。固定版本**只能**通过 `make pin` 变更。完整流程见 [`CLAUDE.md`](CLAUDE.md)。
+
+## 随处部署
+
+Cowork 的设计支持灵活部署——**云端、VPC、本地部署、离线隔离环境以及混合基础设施**——让你完全掌控自己的基础设施、模型、权限与数据。
+
+## 帮助与支持
+
+- **提出问题** —— 加入 [Discord 社区](https://mindshub.ai/discord)。
+- **报告 Bug** —— 提交 [GitHub issue](https://github.com/mindsdb/minds/issues),并附上复现步骤。
+- **查阅文档** —— 使用指南、部署说明与 API,见 [docs.mindshub.ai](https://docs.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)。
+- **企业级 SLA 或定制化部署** —— [联系我们](https://mindshub.ai/contact?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)。
+
+## 🤝 参与贡献
+
+Cowork 是开源项目,欢迎任何形式的贡献——代码、集成、文档、Bug 报告与功能建议。阅读[文档](https://docs.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)完成环境搭建,浏览[已有 issue](https://github.com/mindsdb/minds/issues),也欢迎到 [Discord](https://mindshub.ai/discord) 打个招呼。
+
+## 🔒 安全
+
+发现安全漏洞?请**不要**创建公开 issue。请通过我们的[安全策略](https://github.com/mindsdb/minds/security)私下提交报告。
+
+## 📚 资源
+
+- [文档](https://docs.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)
+- [博客](https://mindshub.ai/blog?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)
+- [品牌指南与媒体资料包](https://mindshub.ai/press-kit?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)
+- [Discord 社区](https://mindshub.ai/discord)
+
+## 📄 许可证
+
+本仓库基于 [MIT 许可证](LICENSE) 发布。所捆绑的组件遵循各自的许可证——详情请参阅各子模块仓库。
+
+<p align="right">(<a href="#readme-top">返回顶部</a>)</p>


### PR DESCRIPTION
## Summary
- Adds full README translations: `README.zh.md` (Chinese), `README.es.md` (Spanish), `README.pt.md` (Portuguese), `README.hi.md` (Hindi).
- Each translated file cross-links back to English and to the other translations, with a translated "back to top" anchor.
- Adds a subtle language-switch line under the nav links in the main `README.md`.
- Commands, code blocks, and URLs (with `utm` params) are left untranslated; only prose, headings, and table labels are localized.

## Test plan
- [ ] Preview each README file on GitHub to confirm rendering (badges, tables, links, anchors).
- [ ] Click through the language-switch links in each file to confirm they resolve correctly.